### PR TITLE
Remove marshmallow dependency

### DIFF
--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -10,11 +10,10 @@
 import logging
 from collections import OrderedDict
 
-from marshmallow import ValidationError
-
 from qiskit.providers import BaseProvider
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers.providerutils import filter_backends
+from qiskit.validation.exceptions import ModelValidationError
 
 from .api import IBMQConnector
 from .ibmqbackend import IBMQBackend
@@ -101,7 +100,7 @@ class IBMQSingleProvider(BaseProvider):
                     provider=self._ibm_provider,
                     credentials=self.credentials,
                     api=self._api)
-            except ValidationError as ex:
+            except ModelValidationError as ex:
                 logger.warning(
                     'Remote backend "%s" could not be instantiated due to an '
                     'invalid config: %s',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 qiskit-terra>=0.7,<0.8
-marshmallow>=2.17.0,<3
 requests>=2.19
 requests-ntlm>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ from setuptools import setup
 
 requirements = [
     "qiskit-terra>=0.7,<0.8",
-    "marshmallow>=2.17.0,<3",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",
 ]

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -105,8 +105,10 @@ class TestIBMQAccounts(QiskitTestCase):
         """Test saving the same credentials twice."""
         with custom_qiskitrc(), mock_ibmq_provider():
             IBMQ.save_account('QISKITRC_TOKEN')
-            IBMQ.save_account('QISKITRC_TOKEN')
+            with self.assertWarns(UserWarning) as context_manager:
+                IBMQ.save_account('QISKITRC_TOKEN')
 
+            self.assertIn('Set overwrite', str(context_manager.warning))
             # Compare the session accounts with the ones stored in file.
             stored_accounts = read_credentials_from_qiskitrc()
             self.assertEqual(len(stored_accounts), 1)


### PR DESCRIPTION
Fixes #17 , now that https://github.com/Qiskit/qiskit-terra/pull/1695 has been merged

Remove the dependency on `marshmallow`, as we can use the new
`ModelValidationError` exception directly from `qiskit`.
Additionally, catch a warning that was being issued during the tests
from the credentials system.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


