### PR TITLE
Remove pre-qobj constructs

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -5,10 +5,8 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""IbmQ module
+"""Module for interfacing with an IBMQ Backend."""
 
-This module is used for connecting to the Quantum Experience.
-"""
 import logging
 import warnings
 
@@ -25,8 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class IBMQBackend(BaseBackend):
-    """Backend class interfacing with the Quantum Experience remotely.
-    """
+    """Backend class interfacing with an IBMQ backend."""
 
     def __init__(self, configuration, provider, credentials, api):
         """Initialize remote backend for IBM Quantum Experience.
@@ -50,13 +47,12 @@ class IBMQBackend(BaseBackend):
         """Run qobj asynchronously.
 
         Args:
-            qobj (dict): description of job
+            qobj (Qobj): description of job
 
         Returns:
             IBMQJob: an instance derived from BaseJob
         """
-        job = IBMQJob(self, None, self._api,
-                      not self.configuration().simulator, qobj=qobj)
+        job = IBMQJob(self, None, self._api, qobj=qobj)
         job.submit()
         return job
 
@@ -165,8 +161,7 @@ class IBMQBackend(BaseBackend):
                 old_format_jobs.append(job_info.get('id'))
                 break
 
-            is_device = not bool(self.configuration().simulator)
-            job = IBMQJob(self, job_info.get('id'), self._api, is_device,
+            job = IBMQJob(self, job_info.get('id'), self._api,
                           creation_date=job_info.get('creationDate'),
                           api_status=job_info.get('status'))
             job_list.append(job)
@@ -220,8 +215,7 @@ class IBMQBackend(BaseBackend):
             raise IBMQBackendError('Failed to get job "{}": {}'
                                    .format(job_id, str(ex)))
 
-        is_device = not bool(self.configuration().simulator)
-        job = IBMQJob(self, job_info.get('id'), self._api, is_device,
+        job = IBMQJob(self, job_info.get('id'), self._api,
                       creation_date=job_info.get('creationDate'),
                       api_status=job_info.get('status'))
         return job

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -19,7 +19,7 @@ from qiskit.providers.models import BackendStatus, BackendProperties
 
 from .api import ApiError
 from .exceptions import IBMQBackendError, IBMQBackendValueError
-from .ibmqjob import IBMQJob, IBMQJobPreQobj
+from .ibmqjob import IBMQJob
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +55,8 @@ class IBMQBackend(BaseBackend):
         Returns:
             IBMQJob: an instance derived from BaseJob
         """
-        job_class = _job_class_from_backend_support(self)
-        job = job_class(self, None, self._api,
-                        not self.configuration().simulator, qobj=qobj)
+        job = IBMQJob(self, None, self._api,
+                      not self.configuration().simulator, qobj=qobj)
         job.submit()
         return job
 
@@ -162,21 +161,21 @@ class IBMQBackend(BaseBackend):
         job_list = []
         old_format_jobs = []
         for job_info in job_info_list:
-            job_class = _job_class_from_job_response(job_info)
-            if job_class is IBMQJobPreQobj:
+            if job_info.get('kind', None) != 'q-object':
                 old_format_jobs.append(job_info.get('id'))
+                break
 
             is_device = not bool(self.configuration().simulator)
-            job = job_class(self, job_info.get('id'), self._api, is_device,
-                            creation_date=job_info.get('creationDate'),
-                            api_status=job_info.get('status'))
+            job = IBMQJob(self, job_info.get('id'), self._api, is_device,
+                          creation_date=job_info.get('creationDate'),
+                          api_status=job_info.get('status'))
             job_list.append(job)
 
         if old_format_jobs:
             job_ids = '\n - '.join(old_format_jobs)
-            warnings.warn('Some jobs ({}) are in a no-longer supported format. These jobs will '
-                          'stop working after Qiskit 0.7. Save the results or send the job with '
-                          'Qiskit 0.7+. Old jobs:\n - {}'.format(len(old_format_jobs), job_ids),
+            warnings.warn('Some jobs ({}) are in a no-longer supported format. '
+                          'Please send the job using Qiskit 0.8+. Old jobs:'
+                          '\n - {}'.format(len(old_format_jobs), job_ids),
                           DeprecationWarning)
         return job_list
 
@@ -206,19 +205,20 @@ class IBMQBackend(BaseBackend):
                 raise IBMQBackendError('Failed to get job "{}": {}'
                                        .format(job_id, job_info['error']))
         except ApiError as ex:
-            raise IBMQBackendError('Failed to get job "{}":{}'
+            raise IBMQBackendError('Failed to get job "{}": {}'
                                    .format(job_id, str(ex)))
-        job_class = _job_class_from_job_response(job_info)
-        if job_class is IBMQJobPreQobj:
+
+        if job_info.get('kind', None) != 'q-object':
             warnings.warn('The result of job {} is in a no longer supported format. '
-                          'These jobs will stop working after Qiskit 0.7. Save the results '
-                          'or send the job with Qiskit 0.7+'.format(job_id),
+                          'Please send the job using Qiskit 0.8+.'.format(job_id),
                           DeprecationWarning)
+            raise IBMQBackendError('Failed to get job "{}": {}'
+                                   .format(job_id, 'job in pre-qobj format'))
 
         is_device = not bool(self.configuration().simulator)
-        job = job_class(self, job_info.get('id'), self._api, is_device,
-                        creation_date=job_info.get('creationDate'),
-                        api_status=job_info.get('status'))
+        job = IBMQJob(self, job_info.get('id'), self._api, is_device,
+                      creation_date=job_info.get('creationDate'),
+                      api_status=job_info.get('status'))
         return job
 
     def __repr__(self):
@@ -228,13 +228,3 @@ class IBMQBackend(BaseBackend):
                                                    self.project)
         return "<{}('{}') from IBMQ({})>".format(
             self.__class__.__name__, self.name(), credentials_info)
-
-
-def _job_class_from_job_response(job_response):
-    is_qobj = job_response.get('kind', None) == 'q-object'
-    return IBMQJob if is_qobj else IBMQJobPreQobj
-
-
-def _job_class_from_backend_support(backend):
-    support_qobj = getattr(backend.configuration(), 'allow_q_object', False)
-    return IBMQJob if support_qobj else IBMQJobPreQobj

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -168,10 +168,9 @@ class IBMQBackend(BaseBackend):
 
         if old_format_jobs:
             job_ids = '\n - '.join(old_format_jobs)
-            warnings.warn('Some jobs ({}) are in a no-longer supported format. '
+            warnings.warn('Some jobs are in a no-longer supported format. '
                           'Please send the job using Qiskit 0.8+. Old jobs:'
-                          '\n - {}'.format(len(old_format_jobs), job_ids),
-                          DeprecationWarning)
+                          '\n - {}'.format(job_ids), DeprecationWarning)
         return job_list
 
     def retrieve_job(self, job_id):

--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -339,7 +339,7 @@ class IBMQJob(BaseJob):
         backend_name = self.backend().name()
 
         try:
-            submit_info = self._api.run_job(self._qobj_payload, backend=backend_name)
+            submit_info = self._api.run_job(self._qobj_payload, backend_name=backend_name)
         # pylint: disable=broad-except
         except Exception as err:
             # Undefined error during submission:

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -299,8 +299,7 @@ class TestIBMQJobStates(JobTestCase):
         """Creates a new ``IBMQJob`` running with the provided API object."""
         backend = FakeRueschlikon()
         self._current_api = api
-        self._current_qjob = IBMQJob(backend, None, api, False,
-                                     qobj=new_fake_qobj())
+        self._current_qjob = IBMQJob(backend, None, api, qobj=new_fake_qobj())
         self._current_qjob.submit()
         return self._current_qjob
 
@@ -315,7 +314,7 @@ def _auto_progress_api(api, interval=0.2):
             api.progress()
 
 
-class BaseFakeAPI():
+class BaseFakeAPI:
     """Base class for faking the IBM-Q API."""
 
     class NoMoreStatesError(Exception):
@@ -525,14 +524,3 @@ class ErroredCancellationAPI(BaseFakeAPI):
 
     def cancel_job(self, job_id, *_args, **_kwargs):
         return {'status': 'Error', 'error': 'test-error-while-cancelling'}
-
-
-# TODO: Remove once qobj results come by default from all the simulator
-# backends.
-class QObjResultAPI(BaseFakeAPI):
-    """Class for emulating a successfully-completed non-queued API."""
-
-    _job_status = [
-        {'status': 'RUNNING'},
-
-    ]

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -15,9 +15,58 @@ from contextlib import suppress
 from qiskit.test.mock import new_fake_qobj, FakeRueschlikon
 from qiskit.providers import JobError, JobTimeoutError
 from qiskit.providers.ibmq.api import ApiError
-from qiskit.providers.ibmq.ibmqjob import API_FINAL_STATES, IBMQJobPreQobj
+from qiskit.providers.ibmq.ibmqjob import API_FINAL_STATES, IBMQJob
 from qiskit.providers.jobstatus import JobStatus
 from ..jobtestcase import JobTestCase
+
+
+VALID_QOBJ_RESPONSE = {
+    'status': 'COMPLETED',
+    'qObjectResult': {
+        'backend_name': 'ibmqx2',
+        'backend_version': '1.1.1',
+        'job_id': 'XC1323XG2',
+        'qobj_id': 'Experiment1',
+        'success': True,
+        'status': 'COMPLETED',
+        'results': [
+            {
+                'header': {
+                    'name': 'Bell state',
+                    'memory_slots': 2,
+                    'creg_sizes': [['c', 2]],
+                    'clbit_labels': [['c', 0], ['c', 1]],
+                    'qubit_labels': [['q', 0], ['q', 1]]
+                },
+                'shots': 1024,
+                'status': 'DONE',
+                'success': True,
+                'data': {
+                    'counts': {
+                        '0x0': 480, '0x3': 490, '0x1': 20, '0x2': 34
+                    }
+                }
+            },
+            {
+                'header': {
+                    'name': 'Bell state XY',
+                    'memory_slots': 2,
+                    'creg_sizes': [['c', 2]],
+                    'clbit_labels': [['c', 0], ['c', 1]],
+                    'qubit_labels': [['q', 0], ['q', 1]]
+                },
+                'shots': 1024,
+                'status': 'DONE',
+                'success': True,
+                'data': {
+                    'counts': {
+                        '0x0': 29, '0x3': 15, '0x1': 510, '0x2': 480
+                    }
+                }
+            }
+        ]
+    }
+}
 
 
 class TestIBMQJobStates(JobTestCase):
@@ -220,7 +269,7 @@ class TestIBMQJobStates(JobTestCase):
         self.assertFalse(can_cancel)
         self.assertEqual(job.status(), JobStatus.INITIALIZING)
 
-    def test_only_final_states_cause_datailed_request(self):
+    def test_only_final_states_cause_detailed_request(self):
         from unittest import mock
 
         # The state ERROR_CREATING_JOB is only handled when running the job,
@@ -246,13 +295,12 @@ class TestIBMQJobStates(JobTestCase):
                     else:
                         self.assertFalse(self._current_api.get_job.called)
 
-    def run_with_api(self, api, job_class=IBMQJobPreQobj):
-        """Creates a new ``IBMQJobPreQobj`` instance running with the provided API
-        object.
-        """
+    def run_with_api(self, api):
+        """Creates a new ``IBMQJob`` running with the provided API object."""
         backend = FakeRueschlikon()
         self._current_api = api
-        self._current_qjob = job_class(backend, None, api, False, qobj=new_fake_qobj())
+        self._current_qjob = IBMQJob(backend, None, api, False,
+                                     qobj=new_fake_qobj())
         self._current_qjob.submit()
         return self._current_qjob
 
@@ -345,7 +393,7 @@ class NonQueuedAPI(BaseFakeAPI):
 
     _job_status = [
         {'status': 'RUNNING'},
-        {'status': 'COMPLETED', 'qasms': []}
+        VALID_QOBJ_RESPONSE
     ]
 
 
@@ -486,51 +534,5 @@ class QObjResultAPI(BaseFakeAPI):
 
     _job_status = [
         {'status': 'RUNNING'},
-        {
-            'status': 'COMPLETED',
-            'qObjectResult': {
-                'backend_name': 'ibmqx2',
-                'backend_version': '1.1.1',
-                'job_id': 'XC1323XG2',
-                'qobj_id': 'Experiment1',
-                'success': True,
-                'status': 'COMPLETED',
-                'results': [
-                    {
-                        'header': {
-                            'name': 'Bell state',
-                            'memory_slots': 2,
-                            'creg_sizes': [['c', 2]],
-                            'clbit_labels': [['c', 0], ['c', 1]],
-                            'qubit_labels': [['q', 0], ['q', 1]]
-                        },
-                        'shots': 1024,
-                        'status': 'DONE',
-                        'success': True,
-                        'data': {
-                            'counts': {
-                                '0x0': 480, '0x3': 490, '0x1': 20, '0x2': 34
-                            }
-                        }
-                    },
-                    {
-                        'header': {
-                            'name': 'Bell state XY',
-                            'memory_slots': 2,
-                            'creg_sizes': [['c', 2]],
-                            'clbit_labels': [['c', 0], ['c', 1]],
-                            'qubit_labels': [['q', 0], ['q', 1]]
-                        },
-                        'shots': 1024,
-                        'status': 'DONE',
-                        'success': True,
-                        'data': {
-                            'counts': {
-                                '0x0': 29, '0x3': 15, '0x1': 510, '0x2': 480
-                            }
-                        }
-                    }
-                ]
-            }
-        }
+
     ]


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Fixes #15, Fixes #21

### Summary

Remove pre-qobj elements and helpers:
* remove `IBMQJobPreQobj`
* remove `IBMQJob._job_data`
* clean `IBMQJob.__init__()` parameters
* update `IBMQBackend.retrieve_job()` and `jobs()`, being more strict and disallowing old pre-qobj jobs
* update `IBMQConnector.run_job()` signature and code
* update tests and related code accordingly.



### Details and comments


