### PR TITLE
Return string for status rather than JobStatus

### DIFF
--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -59,7 +59,7 @@ class IBMQJob(BaseJob):
 
         try:
             job_status = job.status() # It won't block. It will query the backend API.
-            if job_status is JobStatus.RUNNING:
+            if job_status is 'RUNNING':
                 print('The job is still running')
 
         except JobError as ex:
@@ -229,7 +229,7 @@ class IBMQJob(BaseJob):
         """Query the API to update the status.
 
         Returns:
-            qiskit.providers.JobStatus: The status of the job, once updated.
+            str: The status of the job, once updated.
 
         Raises:
             JobError: if there was an exception in the future being executed
@@ -277,8 +277,8 @@ class IBMQJob(BaseJob):
         else:
             raise JobError('Unrecognized answer from server: \n{}'
                            .format(pprint.pformat(api_job)))
-
-        return self._status
+        
+        return self._status.name
 
     def error_message(self):
         """Return the error message returned from the API server response."""

--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -277,7 +277,7 @@ class IBMQJob(BaseJob):
         else:
             raise JobError('Unrecognized answer from server: \n{}'
                            .format(pprint.pformat(api_job)))
-        
+
         return self._status.name
 
     def error_message(self):

--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -59,7 +59,7 @@ class IBMQJob(BaseJob):
 
         try:
             job_status = job.status() # It won't block. It will query the backend API.
-            if job_status is 'RUNNING':
+            if job_status == 'RUNNING':
                 print('The job is still running')
 
         except JobError as ex:

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -80,7 +80,7 @@ class TestIBMQJob(JobTestCase):
         qobj = compile(self._qc, backend)
         shots = qobj.config.shots
         job = backend.run(qobj)
-        while not job.status() is 'DONE':
+        while not job.status() == 'DONE':
             time.sleep(4)
 
         result = job.result()
@@ -116,17 +116,17 @@ class TestIBMQJob(JobTestCase):
         timeout = 30
         start_time = time.time()
         while not found_async_jobs:
-            check = sum([job.status() is 'RUNNING' for job in job_array])
+            check = sum([job.status() == 'RUNNING' for job in job_array])
             if check >= 2:
                 self.log.info('found %d simultaneous jobs', check)
                 break
-            if all([job.status() is 'DONE' for job in job_array]):
+            if all([job.status() == 'DONE' for job in job_array]):
                 # done too soon? don't generate error
                 self.log.warning('all jobs completed before simultaneous jobs '
                                  'could be detected')
                 break
             for job in job_array:
-                self.log.info('%s %s %s %s', job.status(), job.status() is 'RUNNING',
+                self.log.info('%s %s %s %s', job.status(), job.status() == 'RUNNING',
                               check, job.job_id())
             self.log.info('-  %s', str(time.time()-start_time))
             if time.time() - start_time > timeout:
@@ -137,7 +137,7 @@ class TestIBMQJob(JobTestCase):
         result_array = [job.result() for job in job_array]
         self.log.info('got back all job results')
         # Ensure all jobs have finished.
-        self.assertTrue(all([job.status() is 'DONE' for job in job_array]))
+        self.assertTrue(all([job.status() == 'DONE' for job in job_array]))
         self.assertTrue(all([result.success for result in result_array]))
 
         # Ensure job ids are unique.
@@ -165,11 +165,11 @@ class TestIBMQJob(JobTestCase):
         job_array = [backend.run(qobj) for _ in range(num_jobs)]
         time.sleep(3)  # give time for jobs to start (better way?)
         job_status = [job.status() for job in job_array]
-        num_init = sum([status is 'INITIALIZING' for status in job_status])
-        num_queued = sum([status is 'QUEUED' for status in job_status])
-        num_running = sum([status is 'RUNNING' for status in job_status])
-        num_done = sum([status is 'DONE' for status in job_status])
-        num_error = sum([status is 'ERROR' for status in job_status])
+        num_init = sum([status == 'INITIALIZING' for status in job_status])
+        num_queued = sum([status == 'QUEUED' for status in job_status])
+        num_running = sum([status == 'RUNNING' for status in job_status])
+        num_done = sum([status == 'DONE' for status in job_status])
+        num_error = sum([status == 'ERROR' for status in job_status])
         self.log.info('number of currently initializing jobs: %d/%d',
                       num_init, num_jobs)
         self.log.info('number of currently queued jobs: %d/%d',
@@ -186,7 +186,7 @@ class TestIBMQJob(JobTestCase):
         result_array = [job.result() for job in job_array]
 
         # Ensure all jobs have finished.
-        self.assertTrue(all([job.status() is 'DONE' for job in job_array]))
+        self.assertTrue(all([job.status() == 'DONE' for job in job_array]))
         self.assertTrue(all([result.success for result in result_array]))
 
         # Ensure job ids are unique.
@@ -207,7 +207,7 @@ class TestIBMQJob(JobTestCase):
         self.wait_for_initialization(job, timeout=5)
         can_cancel = job.cancel()
         self.assertTrue(can_cancel)
-        self.assertTrue(job.status() is 'CANCELLED')
+        self.assertTrue(job.status() == 'CANCELLED')
 
     @requires_qe_access
     def test_job_id(self, qe_token, qe_url):
@@ -314,7 +314,7 @@ class TestIBMQJob(JobTestCase):
             job_list = backend.jobs(limit=5, skip=0, status='DONE')
 
         for job in job_list:
-            self.assertTrue(job.status() is 'DONE')
+            self.assertTrue(job.status() == 'DONE')
 
     @requires_qe_access
     def test_get_jobs_filter_counts(self, qe_token, qe_url):

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -17,7 +17,7 @@ import numpy
 from scipy.stats import chi2_contingency
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers import JobError, JobStatus
+from qiskit.providers import JobError
 from qiskit.providers.ibmq import IBMQ, least_busy
 from qiskit.providers.ibmq.exceptions import IBMQBackendError
 from qiskit.providers.ibmq.ibmqjob import IBMQJob
@@ -80,7 +80,7 @@ class TestIBMQJob(JobTestCase):
         qobj = compile(self._qc, backend)
         shots = qobj.config.shots
         job = backend.run(qobj)
-        while not job.status() is JobStatus.DONE:
+        while not job.status() is 'DONE':
             time.sleep(4)
 
         result = job.result()
@@ -116,17 +116,17 @@ class TestIBMQJob(JobTestCase):
         timeout = 30
         start_time = time.time()
         while not found_async_jobs:
-            check = sum([job.status() is JobStatus.RUNNING for job in job_array])
+            check = sum([job.status() is 'RUNNING' for job in job_array])
             if check >= 2:
                 self.log.info('found %d simultaneous jobs', check)
                 break
-            if all([job.status() is JobStatus.DONE for job in job_array]):
+            if all([job.status() is 'DONE' for job in job_array]):
                 # done too soon? don't generate error
                 self.log.warning('all jobs completed before simultaneous jobs '
                                  'could be detected')
                 break
             for job in job_array:
-                self.log.info('%s %s %s %s', job.status(), job.status() is JobStatus.RUNNING,
+                self.log.info('%s %s %s %s', job.status(), job.status() is 'RUNNING',
                               check, job.job_id())
             self.log.info('-  %s', str(time.time()-start_time))
             if time.time() - start_time > timeout:
@@ -137,7 +137,7 @@ class TestIBMQJob(JobTestCase):
         result_array = [job.result() for job in job_array]
         self.log.info('got back all job results')
         # Ensure all jobs have finished.
-        self.assertTrue(all([job.status() is JobStatus.DONE for job in job_array]))
+        self.assertTrue(all([job.status() is 'DONE' for job in job_array]))
         self.assertTrue(all([result.success for result in result_array]))
 
         # Ensure job ids are unique.
@@ -165,11 +165,11 @@ class TestIBMQJob(JobTestCase):
         job_array = [backend.run(qobj) for _ in range(num_jobs)]
         time.sleep(3)  # give time for jobs to start (better way?)
         job_status = [job.status() for job in job_array]
-        num_init = sum([status is JobStatus.INITIALIZING for status in job_status])
-        num_queued = sum([status is JobStatus.QUEUED for status in job_status])
-        num_running = sum([status is JobStatus.RUNNING for status in job_status])
-        num_done = sum([status is JobStatus.DONE for status in job_status])
-        num_error = sum([status is JobStatus.ERROR for status in job_status])
+        num_init = sum([status is 'INITIALIZING' for status in job_status])
+        num_queued = sum([status is 'QUEUED' for status in job_status])
+        num_running = sum([status is 'RUNNING' for status in job_status])
+        num_done = sum([status is 'DONE' for status in job_status])
+        num_error = sum([status is 'ERROR' for status in job_status])
         self.log.info('number of currently initializing jobs: %d/%d',
                       num_init, num_jobs)
         self.log.info('number of currently queued jobs: %d/%d',
@@ -186,7 +186,7 @@ class TestIBMQJob(JobTestCase):
         result_array = [job.result() for job in job_array]
 
         # Ensure all jobs have finished.
-        self.assertTrue(all([job.status() is JobStatus.DONE for job in job_array]))
+        self.assertTrue(all([job.status() is 'DONE' for job in job_array]))
         self.assertTrue(all([result.success for result in result_array]))
 
         # Ensure job ids are unique.
@@ -207,7 +207,7 @@ class TestIBMQJob(JobTestCase):
         self.wait_for_initialization(job, timeout=5)
         can_cancel = job.cancel()
         self.assertTrue(can_cancel)
-        self.assertTrue(job.status() is JobStatus.CANCELLED)
+        self.assertTrue(job.status() is 'CANCELLED')
 
     @requires_qe_access
     def test_job_id(self, qe_token, qe_url):
@@ -311,10 +311,10 @@ class TestIBMQJob(JobTestCase):
             warnings.filterwarnings('ignore',
                                     category=DeprecationWarning,
                                     module='qiskit.providers.ibmq.ibmqbackend')
-            job_list = backend.jobs(limit=5, skip=0, status=JobStatus.DONE)
+            job_list = backend.jobs(limit=5, skip=0, status='DONE')
 
         for job in job_list:
-            self.assertTrue(job.status() is JobStatus.DONE)
+            self.assertTrue(job.status() is 'DONE')
 
     @requires_qe_access
     def test_get_jobs_filter_counts(self, qe_token, qe_url):

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -16,7 +16,6 @@ from qiskit.test.mock import new_fake_qobj, FakeRueschlikon
 from qiskit.providers import JobError, JobTimeoutError
 from qiskit.providers.ibmq.api import ApiError
 from qiskit.providers.ibmq.ibmqjob import API_FINAL_STATES, IBMQJob
-from qiskit.providers.jobstatus import JobStatus
 from ..jobtestcase import JobTestCase
 
 
@@ -85,76 +84,76 @@ class TestIBMQJobStates(JobTestCase):
         job = self.run_with_api(ValidatingAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.VALIDATING)
+        self.assertEqual(job.status(), 'VALIDATING')
 
     def test_error_while_creating_job(self):
         job = self.run_with_api(ErrorWhileCreatingAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.ERROR)
+        self.assertEqual(job.status(), 'ERROR')
 
     def test_error_while_validating_job(self):
         job = self.run_with_api(ErrorWhileValidatingAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.VALIDATING)
+        self.assertEqual(job.status(), 'VALIDATING')
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.ERROR)
+        self.assertEqual(job.status(), 'ERROR')
 
     def test_status_flow_for_non_queued_job(self):
         job = self.run_with_api(NonQueuedAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertEqual(job.status(), 'DONE')
 
     def test_status_flow_for_queued_job(self):
         job = self.run_with_api(QueuedAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.QUEUED)
+        self.assertEqual(job.status(), 'QUEUED')
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertEqual(job.status(), 'DONE')
 
     def test_status_flow_for_cancellable_job(self):
         job = self.run_with_api(CancellableAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
         can_cancel = job.cancel()
         self.assertTrue(can_cancel)
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.CANCELLED)
+        self.assertEqual(job.status(), 'CANCELLED')
 
     def test_status_flow_for_non_cancellable_job(self):
         job = self.run_with_api(NonCancellableAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
         can_cancel = job.cancel()
         self.assertFalse(can_cancel)
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
     def test_status_flow_for_errored_cancellation(self):
         job = self.run_with_api(ErroredCancellationAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
         can_cancel = job.cancel()
         self.assertFalse(can_cancel)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
     def test_status_flow_for_unable_to_run_valid_qobj(self):
         """Contrary to other tests, this one is expected to fail even for a
@@ -182,21 +181,21 @@ class TestIBMQJobStates(JobTestCase):
             job.status()
 
         # Now the API gets fixed and doesn't throw anymore.
-        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertEqual(job.status(), 'DONE')
 
     def test_status_flow_for_unable_to_run_invalid_qobj(self):
         job = self.run_with_api(RejectingJobAPI())
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.ERROR)
+        self.assertEqual(job.status(), 'ERROR')
 
     def test_error_while_running_job(self):
         job = self.run_with_api(ErrorWhileRunningAPI())
 
         self.wait_for_initialization(job)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        self.assertEqual(job.status(), 'RUNNING')
 
         self._current_api.progress()
-        self.assertEqual(job.status(), JobStatus.ERROR)
+        self.assertEqual(job.status(), 'ERROR')
         self.assertEqual(job.error_message(), 'Error running job')
 
     def test_cancelled_result(self):
@@ -207,7 +206,7 @@ class TestIBMQJobStates(JobTestCase):
         self._current_api.progress()
         with self.assertRaises(JobError):
             _ = job.result()
-            self.assertEqual(job.status(), JobStatus.CANCELLED)
+            self.assertEqual(job.status(), 'CANCELLED')
 
     def test_errored_result(self):
         job = self.run_with_api(ThrowingGetJobAPI())
@@ -221,7 +220,7 @@ class TestIBMQJobStates(JobTestCase):
         self.wait_for_initialization(job)
         self._current_api.progress()
         self.assertEqual(job.result().success, True)
-        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertEqual(job.status(), 'DONE')
 
     def test_block_on_result_waiting_until_completed(self):
         from concurrent import futures
@@ -232,7 +231,7 @@ class TestIBMQJobStates(JobTestCase):
 
         result = job.result()
         self.assertEqual(result.success, True)
-        self.assertEqual(job.status(), JobStatus.DONE)
+        self.assertEqual(job.status(), 'DONE')
 
     def test_block_on_result_waiting_until_cancelled(self):
         from concurrent.futures import ThreadPoolExecutor
@@ -244,7 +243,7 @@ class TestIBMQJobStates(JobTestCase):
         with self.assertRaises(JobError):
             job.result()
 
-        self.assertEqual(job.status(), JobStatus.CANCELLED)
+        self.assertEqual(job.status(), 'CANCELLED')
 
     def test_block_on_result_waiting_until_exception(self):
         from concurrent.futures import ThreadPoolExecutor
@@ -267,7 +266,7 @@ class TestIBMQJobStates(JobTestCase):
         job = self.run_with_api(CancellableAPI())
         can_cancel = job.cancel()
         self.assertFalse(can_cancel)
-        self.assertEqual(job.status(), JobStatus.INITIALIZING)
+        self.assertEqual(job.status(), 'INITIALIZING')
 
     def test_only_final_states_cause_detailed_request(self):
         from unittest import mock

--- a/test/jobtestcase.py
+++ b/test/jobtestcase.py
@@ -10,7 +10,6 @@
 
 import time
 
-from qiskit.providers import JobStatus
 from qiskit.test import QiskitTestCase
 
 
@@ -21,7 +20,7 @@ class JobTestCase(QiskitTestCase):
         """Waits until job progresses from `INITIALIZING` to other status."""
         waited = 0
         wait = 0.1
-        while job.status() is 'INITIALIZING':
+        while job.status() == 'INITIALIZING':
             time.sleep(wait)
             waited += wait
             if waited > timeout:

--- a/test/jobtestcase.py
+++ b/test/jobtestcase.py
@@ -21,7 +21,7 @@ class JobTestCase(QiskitTestCase):
         """Waits until job progresses from `INITIALIZING` to other status."""
         waited = 0
         wait = 0.1
-        while job.status() is JobStatus.INITIALIZING:
+        while job.status() is 'INITIALIZING':
             time.sleep(wait)
             waited += wait
             if waited > timeout:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The main reasons as to why this is desired are here: https://github.com/Qiskit/qiskit-terra/issues/1903#issuecomment-470855012

I will also add that when getting a Job from a backend and filtering by status, the status is a string, not `JobStatus` instance, which is also in line with the change presented here.

### Details and comments

I also do not see why `queue_position` and `error_message` should not be incorporated into the status message itself.  As an user I obviously want to know this information, and having to make two separate calls to get it doesn't make sense, but that can easily be added if so desired.


