### PR TITLE
Fix usage of qiskit.tools.compiler.execute in test

### DIFF
--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -11,7 +11,8 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers.ibmq import IBMQ, least_busy
 from qiskit.result import Result
 from qiskit.test import QiskitTestCase, requires_qe_access
-from qiskit.tools.compiler import compile, execute
+from qiskit.tools.compiler import compile
+from qiskit.execute import execute
 from qiskit.transpiler import transpile
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix an usage of `qiskit.tools.compiler.execute` directly in the tests, which has been relocated during recent terra changes, and was preventing the tests to be run.

### Details and comments


