### PR TITLE
Fix Qobj instantiation in IBMQJob

### DIFF
--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -183,7 +183,7 @@ class IBMQJob(BaseJob):
             # Populate self._qobj_payload by retrieving the results.
             self._wait_for_job()
 
-        return Qobj(**self._qobj_payload)
+        return Qobj.from_dict(self._qobj_payload)
 
     def properties(self):
         """Return the backend properties for this job.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix the generation of a `Qobj`, using `from_dict` instead of kwargs in order to adapt to latest Terra changes.


### Details and comments


