### PR TITLE
Drop old jobs silently from backend.jobs()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Changed
 - Ensured that retrieved jobs come from their appropriate backend (#23)
 - Job ``error_message()`` function now summarizes the problems that made the
   job to fail. (#48)
+- ``backend.jobs()`` no longer emits a warning for pre-qobj jobs. (#59)
 
 
 Removed

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -103,7 +103,12 @@ class IBMQBackend(BaseBackend):
         return None
 
     def jobs(self, limit=50, skip=0, status=None, db_filter=None):
-        """Attempt to get the jobs submitted to the backend.
+        """Return the jobs submitted to this backend.
+
+        Return the jobs submitted to this backend, with optional filtering and
+        pagination. Note that jobs submitted with earlier versions of Qiskit
+        (in particular, those that predate the Qobj format) are not included
+        in the returned list.
 
         Args:
             limit (int): number of jobs to retrieve
@@ -167,10 +172,9 @@ class IBMQBackend(BaseBackend):
         job_info_list = self._api.get_status_jobs(limit=limit, skip=skip,
                                                   filter=api_filter)
         job_list = []
-        old_format_jobs = []
         for job_info in job_info_list:
             if job_info.get('kind', None) != 'q-object':
-                old_format_jobs.append(job_info.get('id'))
+                # Discard pre-qobj jobs.
                 break
 
             job = IBMQJob(self, job_info.get('id'), self._api,
@@ -178,15 +182,10 @@ class IBMQBackend(BaseBackend):
                           api_status=job_info.get('status'))
             job_list.append(job)
 
-        if old_format_jobs:
-            job_ids = '\n - '.join(old_format_jobs)
-            warnings.warn('Some jobs are in a no-longer supported format. '
-                          'Please send the job using Qiskit 0.8+. Old jobs:'
-                          '\n - {}'.format(job_ids), DeprecationWarning)
         return job_list
 
     def retrieve_job(self, job_id):
-        """Attempt to get the specified job by job_id
+        """Return a job submitted to this backend.
 
         Args:
             job_id (str): the job id of the job to retrieve


### PR DESCRIPTION
Fix #57 

Remove the explicit warning emitted during `IBMQBackend.jobs()` when
pre-qobj jobs were encountered in the list, replacing it with a note
in the docstring instead.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


