### PR TITLE
Make use of noise model serialization

### DIFF
--- a/qiskit/providers/ibmq/utils.py
+++ b/qiskit/providers/ibmq/utils.py
@@ -7,31 +7,7 @@
 
 """Utilities related to the IBMQ Provider."""
 
-import json
-
-from numpy import ndarray
-
 from qiskit.qobj import QobjHeader
-
-
-class AerJSONEncoder(json.JSONEncoder):
-    """JSON encoder for NumPy arrays and complex numbers.
-
-    This functions as the standard JSON Encoder but adds support
-    for encoding:
-        complex numbers z as lists [z.real, z.imag]
-        ndarrays as nested lists.
-    """
-
-    # pylint: disable=method-hidden,arguments-differ
-    def default(self, obj):
-        if isinstance(obj, ndarray):
-            return obj.tolist()
-        if isinstance(obj, complex):
-            return [obj.real, obj.imag]
-        if hasattr(obj, "as_dict"):
-            return obj.as_dict()
-        return super().default(obj)
 
 
 def update_qobj_config(qobj, backend_options=None, noise_model=None):
@@ -54,8 +30,7 @@ def update_qobj_config(qobj, backend_options=None, noise_model=None):
 
     # Append noise model to configuration.
     if noise_model:
-        config['noise_model'] = json.loads(json.dumps(noise_model,
-                                                      cls=AerJSONEncoder))
+        config['noise_model'] = noise_model.as_dict(serializable=True)
 
     # Update the Qobj configuration.
     qobj.config = QobjHeader.from_dict(config)


### PR DESCRIPTION
Fixes #66

Make use of the optional `serializable` parameter for noise models,
delegating the serialization on Aer itself instead of manually
converting to simple types in this codebase.


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


