### PR TITLE
Fix signature mismatch when cancelling a job

### DIFF
--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -10,6 +10,7 @@
 This module is used for creating asynchronous job objects for the
 IBM Q Experience.
 """
+
 import asyncio
 import datetime
 import logging
@@ -234,18 +235,14 @@ class IBMQJob(BaseJob):
         """Attempt to cancel a job.
 
         Returns:
-            bool: True if job can be cancelled, else False. Currently this is
-            only possible on commercial systems.
+            bool: True if job can be cancelled, else False. Note this operation
+            might not be possible depending on the environment.
 
         Raises:
             JobError: if there was some unexpected failure in the server.
         """
-        hub = self._api.config.get('hub', None)
-        group = self._api.config.get('group', None)
-        project = self._api.config.get('project', None)
-
         try:
-            response = self._api.cancel_job(self._job_id, hub, group, project)
+            response = self._api.cancel_job(self._job_id)
             self._cancelled = 'error' not in response
             return self._cancelled
         except ApiError as error:


### PR DESCRIPTION
Fixes #71 - thanks @mstypulk for catching it!

Fix calling `api.cancel_job()` with invalid parameters from
`IBMQJob.cancel()`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


