### PR TITLE
Use BackendConfiguration subclasses for backends

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,20 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 ^^^^^^^^^^^^^
 
+`0.1.1`_
+^^^^^^^^
+
+Changed
+"""""""
+
+- The backend configurations now return instances of specialized
+  ``BackendConfiguration`` classes (ie. ``QasmBackendConfiguration``). (#74).
+
+Fixed
+"""""
+
+- Fixed signature mismatch during ``job.cancel()``. (#73)
+
 
 `0.1`_
 ^^^^^^
@@ -32,7 +46,7 @@ Added
 - Added ``backend.defauls()`` for retrieving the pulse defaults for a
   backend through a new endpoint (#33).
 - Added ``job.properties()`` for retrieving the backend properties for
-  a job through a new endpint (#35).
+  a job through a new endpoint (#35).
 
 Changed
 """""""
@@ -46,7 +60,6 @@ Changed
   job to fail. (#48)
 - ``backend.jobs()`` no longer emits a warning for pre-qobj jobs. (#59)
 
-
 Removed
 """""""
 
@@ -54,7 +67,8 @@ Removed
 
 
 
-.. _UNRELEASED: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.1...HEAD
-.. _0.1rc3: https://github.com/Qiskit/qiskit-ibmq-provider/compare/104d524...0.1
+.. _UNRELEASED: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.1.1...HEAD
+.. _0.1.1: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.1...0.1.1
+.. _0.1: https://github.com/Qiskit/qiskit-ibmq-provider/compare/104d524...0.1
 
 .. _Keep a Changelog: http://keepachangelog.com/en/1.0.0/

--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -11,7 +11,8 @@ import logging
 from collections import OrderedDict
 
 from qiskit.providers import BaseProvider
-from qiskit.providers.models import BackendConfiguration
+from qiskit.providers.models import (QasmBackendConfiguration,
+                                     PulseBackendConfiguration)
 from qiskit.providers.providerutils import filter_backends
 from qiskit.validation.exceptions import ModelValidationError
 
@@ -97,7 +98,10 @@ class IBMQSingleProvider(BaseProvider):
         configs_list = self._api.available_backends()
         for raw_config in configs_list:
             try:
-                config = BackendConfiguration.from_dict(raw_config)
+                if raw_config.get('open_pulse', False):
+                    config = PulseBackendConfiguration.from_dict(raw_config)
+                else:
+                    config = QasmBackendConfiguration.from_dict(raw_config)
                 backend_cls = IBMQSimulator if config.simulator else IBMQBackend
                 ret[config.backend_name] = backend_cls(
                     configuration=config,


### PR DESCRIPTION
Fixes #70

Update the `IBMQSingleProvider` so it uses the specialized
`BackendConfiguration` subclasses instead of the parent class.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


