### PR TITLE
Fixing split errors in URLs which contain "//api"

### DIFF
--- a/qiskit/providers/ibmq/api/ibmqconnector.py
+++ b/qiskit/providers/ibmq/api/ibmqconnector.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+import re
 
 from qiskit.providers.ibmq.api.websocket import WebsocketClient
 from .apijobstatus import ApiJobStatus
@@ -76,12 +77,13 @@ class IBMQConnector:
 
     This class exposes a Python API for making requests to the IBMQ platform.
     """
+
     def __init__(self, token=None, config=None, verify=True):
         """ If verify is set to false, ignore SSL certificate errors """
         self.config = config
 
         if self.config and ('url' in self.config):
-            url_parsed = self.config['url'].split('/api')
+            url_parsed = re.compile(r'(?<!\/)\/api').split(self.config['url'])
             if len(url_parsed) == 2:
                 hub = group = project = None
                 project_parse = url_parsed[1].split('/Projects/')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR improves the `split()` function used in https://github.com/Qiskit/qiskit-ibmq-provider/blob/master/qiskit/providers/ibmq/api/ibmqconnector.py#L84

The current split `self.config['url'].split('/api')` produces unintended effects when using a URL like `https://api.qiskit.org/api`, slicing the non-desired part of the string. The change introduced prevents to split the string when finding `//api` to split only when matching `/api` occurrences with a single slash. 


### Details and comments


