### PR TITLE
Remove the extra parsing for auth URL

### DIFF
--- a/qiskit/providers/ibmq/api_v2/rest/auth.py
+++ b/qiskit/providers/ibmq/api_v2/rest/auth.py
@@ -42,12 +42,4 @@ class Auth(RestAdapterBase):
         url = self.get_url('user_info')
         response = self.session.get(url).json()
 
-        # Revise the URL.
-        try:
-            api_url = response['urls']['http']
-            if not api_url.endswith('/api'):
-                response['urls']['http'] = '{}/api'.format(api_url)
-        except KeyError:
-            pass
-
         return response


### PR DESCRIPTION
Remove the extra parsing for the URL returned by the authentication
service, in preparation for version 2 release.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


