### PR TITLE
Fix json serializer for NoiseModel class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
 """""
 
 - Fixed incorrect parsing of some API hub URLs (#77).
+- Fixed noise model handling for remote simulators (#84).
 
 
 `0.1.1`_ - 2019-05-01

--- a/qiskit/providers/ibmq/utils.py
+++ b/qiskit/providers/ibmq/utils.py
@@ -33,9 +33,11 @@ def update_qobj_config(qobj, backend_options=None, noise_model=None):
     # Append backend options to configuration.
     if backend_options:
         for key, val in backend_options.items():
+            if key == 'noise_model':
+                val = val.as_dict(serializable=True)
             config[key] = val
 
-    # Append noise model to configuration.
+    # Append noise model to configuration. Overwrites backend option
     if noise_model:
         config['noise_model'] = noise_model.as_dict(serializable=True)
 

--- a/qiskit/providers/ibmq/utils.py
+++ b/qiskit/providers/ibmq/utils.py
@@ -16,6 +16,7 @@
 
 from qiskit.qobj import QobjHeader
 
+
 def _serialize_noise_model(config):
     """Traverse the dictionary looking for noise_model keys and apply
        a transformation so it can be serialized.
@@ -39,6 +40,7 @@ def _serialize_noise_model(config):
                     pass
 
     return config
+
 
 def update_qobj_config(qobj, backend_options=None, noise_model=None):
     """Update a Qobj configuration from options and noise model.

--- a/qiskit/providers/ibmq/utils.py
+++ b/qiskit/providers/ibmq/utils.py
@@ -25,7 +25,7 @@ def _serialize_noise_model(config):
            config (dict): The dictionary to traverse
 
        Returns:
-           config (dict): The transformed dictionary
+           dict: The transformed dictionary
     """
     for k, v in config.items():
         if isinstance(config[k], dict):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Traverse the config dictionary looking for NoiseModel objects so we can transform them in order to serialize them to json.


### Details and comments
We need to call `NoiseModel::as_dict(serializable=True)` in all the `NoiseModel` objects stored in the config file, so they can be serialized.

