### PR TITLE
Remove usages of compile() in test_ibmq_client_v2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -329,7 +329,7 @@ callbacks=cb_,_cb
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,future.builtins,qiskit.tools.compiler
+redefining-builtins-modules=six.moves,future.builtins
 
 
 [CLASSES]

--- a/test/ibmq/test_ibmq_client_v2.py
+++ b/test/ibmq/test_ibmq_client_v2.py
@@ -18,11 +18,11 @@ import re
 from unittest import SkipTest, skip
 
 from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit.compiler import assemble, transpile
 from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.ibmq.api_v2 import IBMQClient
 from qiskit.providers.ibmq.api_v2.exceptions import ApiError
 from qiskit.test import QiskitTestCase, requires_qe_access
-from qiskit.tools.compiler import compile
 
 
 class TestIBMQClient(QiskitTestCase):
@@ -65,7 +65,8 @@ class TestIBMQClient(QiskitTestCase):
         # Create a Qobj.
         backend_name = 'ibmq_qasm_simulator'
         backend = IBMQ.get_backend(backend_name)
-        qobj = compile(self.qc1, backend=backend, seed=self.seed, shots=1)
+        circuit = transpile(self.qc1, backend, seed_transpiler=self.seed)
+        qobj = assemble(circuit, backend, shots=1)
 
         # Run the job through the IBMQClient directly.
         api = backend._api
@@ -123,8 +124,8 @@ class TestIBMQClient(QiskitTestCase):
 
         backend_name = 'ibmq_qasm_simulator'
         backend = IBMQ.get_backend(backend_name)
-        qobj = compile([self.qc1, self.qc2],
-                       backend=backend, seed=self.seed, shots=1)
+        circuit = transpile(self.qc1, backend, seed_transpiler=self.seed)
+        qobj = assemble(circuit, backend, shots=1)
 
         api = backend._api
         job = api.run_job(qobj.as_dict(), backend_name)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the same spirit as #86 , remove the last remainders of deprecated `compile()` in the tests in a recently added file, along with removing the pylint `redefining-builtins-modules` exclusion.

### Details and comments


