### PR TITLE
Fix for backend_status authorization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Fixed
 """""
 
 - Fixed Qcircuit status checks according to latest API changes. (#95)
+- Fixed an authentication issue with the ``backend_status`` endpoint when
+  using the new api. (#101).
 
 Changed
 """""""

--- a/qiskit/providers/ibmq/api/ibmqconnector.py
+++ b/qiskit/providers/ibmq/api/ibmqconnector.py
@@ -313,8 +313,7 @@ class IBMQConnector:
         if not backend_type:
             raise BadBackendError(backend)
 
-        status = self.req.get('/Backends/' + backend_type + '/queue/status',
-                              with_token=False)
+        status = self.req.get('/Backends/' + backend_type + '/queue/status')
         ret = {}
 
         # Adjust fields according to the specs (BackendStatus).


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix for passing the token to the `backend_status` call, as the new api required authentication for that endpoint whereas the classic API did not.

### Details and comments


