### PR TITLE
Add IBMQClient._user_hubs

### DIFF
--- a/qiskit/providers/ibmq/api_v2/ibmqclient.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqclient.py
@@ -97,6 +97,35 @@ class IBMQClient:
         response = self.client_auth.user_info()
         return response['urls']
 
+    def _user_hubs(self):
+        """Retrieve the hubs available to the user.
+
+        The first entry in the list will be the default one, as indicated by
+        the API (by having `isDefault` in all hub, group, project fields).
+
+        Returns:
+            list[dict]: a list of dicts with the hubs, which contains the keys
+                `hub`, `group`, `project`.
+        """
+        response = self.client_api.hubs()
+
+        hubs = []
+        for hub in response:
+            hub_name = hub['name']
+            for group_name, group in hub['groups'].items():
+                for project_name, project in group['projects'].items():
+                    entry = {'hub': hub_name,
+                             'group': group_name,
+                             'project': project_name}
+
+                    # If
+                    if project.get('isDefault'):
+                        hubs.insert(0, entry)
+                    else:
+                        hubs.append(entry)
+
+        return hubs
+
     # Backend-related public functions.
 
     def list_backends(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #90

Add `IBMQClient._user_hubs()`, in order to use the endpoint that provides hub/group/project information and parse accordingly. The function is not used directly during this PR, but instead prepares for retrieving that information dynamically for upcoming PRs.

### Details and comments


