### PR TITLE
Add ibmq monitors from terra to ibmq provider package

### DIFF
--- a/qiskit/providers/ibmq/monitors/__init__.py
+++ b/qiskit/providers/ibmq/monitors/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A module for monitoring jobs, backends, etc.
+"""
+
+from .job_monitor import job_monitor
+from .backend_overview import backend_monitor, backend_overview

--- a/qiskit/providers/ibmq/monitors/backend_overview.py
+++ b/qiskit/providers/ibmq/monitors/backend_overview.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" A module for viewing the details of all available devices.
+"""
+
+import math
+from qiskit.exceptions import QiskitError
+
+try:
+    from qiskit.providers.ibmq import IBMQ, IBMQBackend
+except ImportError:
+    pass
+
+
+def get_unique_backends():
+    """Gets the unique backends that are available.
+
+    Returns:
+        list: Unique available backends.
+
+    Raises:
+        QiskitError: No backends available.
+    """
+    backends = IBMQ.backends()
+    unique_hardware_backends = []
+    unique_names = []
+    for back in backends:
+        if back.name() not in unique_names and not back.configuration().simulator:
+            unique_hardware_backends.append(back)
+            unique_names.append(back.name())
+    if not unique_hardware_backends:
+        raise QiskitError('No backends available.')
+    return unique_hardware_backends
+
+
+def backend_monitor(backend):
+    """Monitor a single IBMQ backend.
+
+    Args:
+        backend (IBMQBackend): Backend to monitor.
+    Raises:
+        QiskitError: Input is not a IBMQ backend.
+    """
+    if not isinstance(backend, IBMQBackend):
+        raise QiskitError('Input variable is not of type IBMQBackend.')
+    config = backend.configuration().to_dict()
+    status = backend.status().to_dict()
+    config_dict = {**status, **config}
+    if not config['simulator']:
+        props = backend.properties().to_dict()
+
+    print(backend.name())
+    print('='*len(backend.name()))
+    print('Configuration')
+    print('-'*13)
+    offset = '    '
+
+    upper_list = ['n_qubits', 'operational',
+                  'status_msg', 'pending_jobs',
+                  'basis_gates', 'local', 'simulator']
+
+    lower_list = list(set(config_dict.keys()).difference(upper_list))
+    # Remove gates because they are in a different tab
+    lower_list.remove('gates')
+    for item in upper_list+lower_list:
+        print(offset+item+':', config_dict[item])
+
+    # Stop here if simulator
+    if config['simulator']:
+        return
+
+    print()
+    qubit_header = 'Qubits [Name / Freq / T1 / T2 / U1 err / U2 err / U3 err / Readout err]'
+    print(qubit_header)
+    print('-'*len(qubit_header))
+
+    sep = ' / '
+    for qub in range(len(props['qubits'])):
+        name = 'Q%s' % qub
+        qubit_data = props['qubits'][qub]
+        gate_data = props['gates'][3*qub:3*qub+3]
+        t1_info = qubit_data[0]
+        t2_info = qubit_data[1]
+        freq_info = qubit_data[2]
+        readout_info = qubit_data[3]
+
+        freq = str(round(freq_info['value'], 5))+' '+freq_info['unit']
+        T1 = str(round(t1_info['value'],  # pylint: disable=invalid-name
+                       5))+' ' + t1_info['unit']
+        T2 = str(round(t2_info['value'],  # pylint: disable=invalid-name
+                       5))+' ' + t2_info['unit']
+        # pylint: disable=invalid-name
+        U1 = str(round(gate_data[0]['parameters'][0]['value'], 5))
+        # pylint: disable=invalid-name
+        U2 = str(round(gate_data[1]['parameters'][0]['value'], 5))
+        # pylint: disable=invalid-name
+        U3 = str(round(gate_data[2]['parameters'][0]['value'], 5))
+
+        readout_error = str(round(readout_info['value'], 5))
+
+        qstr = sep.join([name, freq, T1, T2, U1, U2, U3, readout_error])
+        print(offset+qstr)
+
+    print()
+    multi_qubit_gates = props['gates'][3*config['n_qubits']:]
+    multi_header = 'Multi-Qubit Gates [Name / Type / Gate Error]'
+    print(multi_header)
+    print('-'*len(multi_header))
+
+    for gate in multi_qubit_gates:
+        name = gate['name']
+        ttype = gate['gate']
+        error = str(round(gate['parameters'][0]['value'], 5))
+        mstr = sep.join([name, ttype, error])
+        print(offset+mstr)
+
+
+def backend_overview():
+    """Gives overview information on all the IBMQ
+    backends that are available.
+    """
+    unique_hardware_backends = get_unique_backends()
+    _backends = []
+    # Sort backends by operational or not
+    for idx, back in enumerate(unique_hardware_backends):
+        if back.status().operational:
+            _backends = [back] + _backends
+        else:
+            _backends = _backends + [back]
+
+    stati = [back.status() for back in _backends]
+    idx = list(range(len(_backends)))
+    pending = [s.pending_jobs for s in stati]
+    _, least_idx = zip(*sorted(zip(pending, idx)))
+
+    # Make sure least pending is operational
+    for ind in least_idx:
+        if stati[ind].operational:
+            least_pending_idx = ind
+            break
+
+    num_rows = math.ceil(len(_backends)/3)
+
+    count = 0
+    num_backends = len(_backends)
+    for _ in range(num_rows):
+        max_len = 0
+        str_list = ['']*8
+        for idx in range(3):
+            offset = ' ' * 10 if idx else ''
+            config = _backends[count].configuration().to_dict()
+            props = _backends[count].properties().to_dict()
+            n_qubits = config['n_qubits']
+            str_list[0] += (' '*(max_len-len(str_list[0]))+offset)
+            str_list[0] += _backends[count].name()
+
+            str_list[1] += (' '*(max_len-len(str_list[1]))+offset)
+            str_list[1] += '-'*len(_backends[count].name())
+
+            str_list[2] += (' '*(max_len-len(str_list[2]))+offset)
+            str_list[2] += 'Num. Qubits:  %s' % config['n_qubits']
+
+            str_list[3] += (' '*(max_len-len(str_list[3]))+offset)
+            str_list[3] += 'Pending Jobs: %s' % stati[count].pending_jobs
+
+            str_list[4] += (' '*(max_len-len(str_list[4]))+offset)
+            str_list[4] += 'Least busy:   %s' % (count == least_pending_idx)
+
+            str_list[5] += (' '*(max_len-len(str_list[5]))+offset)
+            str_list[5] += 'Operational:  %s' % stati[count].operational
+
+            str_list[6] += (' '*(max_len-len(str_list[6]))+offset)
+            str_list[6] += 'Avg. T1:      %s' % round(sum([q[0]['value']
+                                                           for q in props['qubits']])/n_qubits, 1)
+            str_list[7] += (' '*(max_len-len(str_list[7]))+offset)
+            str_list[7] += 'Avg. T2:      %s' % round(sum([q[1]['value']
+                                                           for q in props['qubits']])/n_qubits, 1)
+            count += 1
+            if count == num_backends:
+                break
+            max_len = max([len(s) for s in str_list])
+
+        print("\n".join(str_list))
+        print('\n'*2)

--- a/qiskit/providers/ibmq/monitors/job_monitor.py
+++ b/qiskit/providers/ibmq/monitors/job_monitor.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""A module for monitoring various qiskit functionality"""
+
+import sys
+import time
+import threading
+from qiskit.exceptions import QiskitError
+
+_NOTEBOOK_ENV = False
+if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+    _NOTEBOOK_ENV = True
+    from IPython.display import display    # pylint: disable=import-error
+
+
+def _text_checker(job, interval, _interval_set=False, quiet=False, output=sys.stdout):
+    """A text-based job status checker
+
+    Args:
+        job (BaseJob): The job to check.
+        interval (int): The interval at which to check.
+        _interval_set (bool): Was interval time set by user?
+        quiet (bool): If True, do not print status messages.
+        output (file): The file like object to write status messages to.
+        By default this is sys.stdout.
+
+    """
+    status = job.status()
+    msg = status.value
+    prev_msg = msg
+    msg_len = len(msg)
+
+    if not quiet:
+        print('\r%s: %s' % ('Job Status', msg), end='', file=output)
+    while status.name not in ['DONE', 'CANCELLED', 'ERROR']:
+        time.sleep(interval)
+        status = job.status()
+        msg = status.value
+
+        if status.name == 'QUEUED':
+            msg += ' (%s)' % job.queue_position()
+            if not _interval_set:
+                interval = max(job.queue_position(), 2)
+        else:
+            if not _interval_set:
+                interval = 2
+
+        # Adjust length of message so there are no artifacts
+        if len(msg) < msg_len:
+            msg += ' ' * (msg_len - len(msg))
+        elif len(msg) > msg_len:
+            msg_len = len(msg)
+
+        if msg != prev_msg and not quiet:
+            print('\r%s: %s' % ('Job Status', msg), end='', file=output)
+            prev_msg = msg
+    if not quiet:
+        print('', file=output)
+
+
+def job_monitor(job, interval=None, monitor_async=False, quiet=False, output=sys.stdout):
+    """Monitor the status of a IBMQJob instance.
+
+    Args:
+        job (BaseJob): Job to monitor.
+        interval (int): Time interval between status queries.
+        monitor_async (bool): Monitor asynchronously (in Jupyter only).
+        quiet (bool): If True, do not print status messages.
+        output (file): The file like object to write status messages to.
+        By default this is sys.stdout.
+
+    Raises:
+        QiskitError: When trying to run async outside of Jupyter
+        ImportError: ipywidgets not available for notebook.
+    """
+    if interval is None:
+        _interval_set = False
+        interval = 2
+    else:
+        _interval_set = True
+    if _NOTEBOOK_ENV:
+        if monitor_async:
+            try:
+                import ipywidgets as widgets  # pylint: disable=import-error
+            except ImportError:
+                raise ImportError('These functions  need ipywidgets. '
+                                  'Run "pip install ipywidgets" before.')
+            from qiskit.tools.jupyter.jupyter_magics import _html_checker
+
+            style = "font-size:16px;"
+            header = "<p style='{style}'>Job Status: %s </p>".format(
+                style=style)
+            status = widgets.HTML(value=header % job.status().value)
+            display(status)
+
+            thread = threading.Thread(target=_html_checker, args=(job, interval,
+                                                                  status, header))
+            thread.start()
+        else:
+            _text_checker(job, interval, _interval_set,
+                          quiet=quiet, output=output)
+
+    else:
+        if monitor_async:
+            raise QiskitError(
+                'monitor_async only available in Jupyter notebooks.')
+        _text_checker(job, interval, _interval_set, quiet=quiet, output=output)

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
               'qiskit.providers.ibmq.api_v2.rest',
               'qiskit.providers.ibmq.circuits',
               'qiskit.providers.ibmq.credentials',
-              'qiskit.providers.ibmq.job'],
+              'qiskit.providers.ibmq.job',
+              'qiskit.providers.ibmq.monitors'],
     install_requires=requirements,
     include_package_data=True,
     python_requires=">=3.5"

--- a/test/ibmq/monitor/__init__.py
+++ b/test/ibmq/monitor/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for backend monitor-related functionality."""

--- a/test/ibmq/monitor/test_backend_monitor.py
+++ b/test/ibmq/monitor/test_backend_monitor.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the wrapper functionality."""
+
+import unittest
+from unittest.mock import patch
+from io import StringIO
+
+from qiskit.providers.ibmq.monitors import backend_overview, backend_monitor
+from qiskit.test import QiskitTestCase, requires_qe_access
+from qiskit.util import _has_connection
+
+from qiskit.providers.ibmq import IBMQ
+# Check if internet connection exists
+HAS_NET_CONNECTION = _has_connection('qiskit.org', 443)
+
+
+class TestBackendOverview(QiskitTestCase):
+    """Tools test case."""
+
+    @unittest.skipIf(not HAS_NET_CONNECTION, "requries internet connection.")
+    @requires_qe_access
+    def test_backend_overview(self, qe_token, qe_url):
+        """Test backend_overview"""
+        IBMQ.enable_account(qe_token, qe_url)
+
+        with patch('sys.stdout', new=StringIO()) as fake_stout:
+            backend_overview()
+        stdout = fake_stout.getvalue()
+        self.assertIn('Operational:', stdout)
+        self.assertIn('Avg. T1:', stdout)
+        self.assertIn('Num. Qubits:', stdout)
+
+    @unittest.skipIf(not HAS_NET_CONNECTION, "requries internet connection.")
+    @requires_qe_access
+    def test_backend_monitor(self, qe_token, qe_url):
+        """Test backend_monitor"""
+        IBMQ.enable_account(qe_token, qe_url)
+        for back in IBMQ.backends():
+            if not back.configuration().simulator:
+                backend = back
+                break
+        with patch('sys.stdout', new=StringIO()) as fake_stout:
+            backend_monitor(backend)
+
+        stdout = fake_stout.getvalue()
+        self.assertIn('Configuration', stdout)
+        self.assertIn('Qubits [Name / Freq / T1 / T2 / U1 err / U2 err / U3 err / Readout err]',
+                      stdout)
+        self.assertIn('Multi-Qubit Gates [Name / Type / Gate Error]', stdout)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/ibmq/monitor/test_job_monitor.py
+++ b/test/ibmq/monitor/test_job_monitor.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the wrapper functionality."""
+
+import unittest
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit import BasicAer
+from qiskit import execute
+from qiskit.providers.ibmq.monitors import job_monitor
+from qiskit.test import QiskitTestCase
+
+
+class TestJobMonitor(QiskitTestCase):
+    """Tools test case."""
+    def test_job_monitor(self):
+        """Test job_monitor"""
+        qreg = QuantumRegister(2)
+        creg = ClassicalRegister(2)
+        qc = QuantumCircuit(qreg, creg)
+        qc.h(qreg[0])
+        qc.cx(qreg[0], qreg[1])
+        qc.measure(qreg, creg)
+        backend = BasicAer.get_backend('qasm_simulator')
+        job_sim = execute([qc]*10, backend)
+        job_monitor(job_sim)
+        self.assertEqual(job_sim.status().name, 'DONE')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The qiskit.tools.monitors modules included in qiskit terra are 100%
dependent on the ibmq provider. They provide an interace to interact and
wait on IBMQ jobs and backends which is very useful for end users.
However, it's completely specific to the IBMQ provider, so this should
live in the provider so it's only installed if IBMQ is available and
gets updated when the the provider does.

### Details and comments
