### PR TITLE
Move "requires_qe_access" into the package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Changed
 """""""
 
 - Updated detection of classic vs. new api based on version endpoint. (#95)
+- The ``requires_qe_access`` decorator, previously in terra, is now included
+  in this package. (#128)
 
 Added
 """""

--- a/qiskit/providers/ibmq/api_v2/ibmqclient.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqclient.py
@@ -72,7 +72,7 @@ class IBMQClient:
             self.client_auth.login(self.api_token)
         except RequestsApiError as ex:
             response = ex.original_exception.response
-            if response.status_code == 401:
+            if response and response.status_code == 401:
                 try:
                     error_code = response.json()['error']['name']
                     if error_code == 'ACCEPT_LICENSE_REQUIRED':

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -146,4 +146,4 @@ def _get_credentials():
         # Use the first available credentials.
         return list(discovered_credentials.values())[0]
 
-    raise Exception('Could not locate valid credentials.')
+    raise Exception('Could not locate valid credentials.') from None

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -14,8 +14,13 @@
 
 """Decorators for using with IBMQProvider unit tests."""
 
+import os
 from functools import wraps
 from unittest import SkipTest
+
+from qiskit.test.testing_options import get_test_options
+from qiskit.providers.ibmq.credentials import (Credentials,
+                                               discover_credentials)
 
 
 def requires_new_api_auth(func):
@@ -73,3 +78,72 @@ def requires_classic_api(func):
         return func(self, *args, **kwargs)
 
     return _wrapper
+
+
+def requires_qe_access(func):
+    """Decorator that signals that the test uses the online API.
+
+    It involves:
+        * determines if the test should be skipped by checking environment
+            variables.
+        * if the `USE_ALTERNATE_ENV_CREDENTIALS` environment variable is
+          set, it reads the credentials from an alternative set of environment
+          variables.
+        * if the test is not skipped, it reads `qe_token` and `qe_url` from
+            `Qconfig.py`, environment variables or qiskitrc.
+        * if the test is not skipped, it appends `qe_token` and `qe_url` as
+            arguments to the test function.
+
+    Args:
+        func (callable): test function to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+    @wraps(func)
+    def _wrapper(self, *args, **kwargs):
+        if get_test_options()['skip_online']:
+            raise SkipTest('Skipping online tests')
+
+        credentials = _get_credentials()
+        self.using_ibmq_credentials = credentials.is_ibmq()
+        kwargs.update({'qe_token': credentials.token,
+                       'qe_url': credentials.url})
+
+        return func(self, *args, **kwargs)
+
+    return _wrapper
+
+
+def _get_credentials():
+    """Finds the credentials for a specific test and options.
+
+    Returns:
+        Credentials: set of credentials
+
+    Raises:
+        Exception: when the credential could not be set and they are needed
+            for that set of options
+    """
+    if os.getenv('USE_ALTERNATE_ENV_CREDENTIALS', ''):
+        # Special case: instead of using the standard credentials mechanism,
+        # load them from different environment variables. This assumes they
+        # will always be in place, as is used by the Travis setup.
+        return Credentials(os.getenv('IBMQ_TOKEN'), os.getenv('IBMQ_URL'))
+
+    # Attempt to read the standard credentials.
+    discovered_credentials = discover_credentials()
+
+    if discovered_credentials:
+        # Decide which credentials to use for testing.
+        if len(discovered_credentials) > 1:
+            try:
+                # Attempt to use QE credentials.
+                return discovered_credentials[(None, None, None)]
+            except KeyError:
+                pass
+
+        # Use the first available credentials.
+        return list(discovered_credentials.values())[0]
+
+    raise Exception('Could not locate valid credentials.')

--- a/test/ibmq/test_circuits.py
+++ b/test/ibmq/test_circuits.py
@@ -19,10 +19,11 @@ import os
 from qiskit.providers.ibmq.circuits.exceptions import CircuitAvailabilityError
 
 from qiskit.result import Result
-from qiskit.test import QiskitTestCase, requires_qe_access
+from qiskit.test import QiskitTestCase
 
 from qiskit.providers.ibmq import IBMQ
 
+from ..decorators import requires_qe_access
 
 class TestCircuits(QiskitTestCase):
     """Tests IBM Q Circuits."""

--- a/test/ibmq/test_circuits.py
+++ b/test/ibmq/test_circuits.py
@@ -25,6 +25,7 @@ from qiskit.providers.ibmq import IBMQ
 
 from ..decorators import requires_qe_access
 
+
 class TestCircuits(QiskitTestCase):
     """Tests IBM Q Circuits."""
 

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -15,8 +15,9 @@
 """Backends Filtering Test."""
 
 from qiskit.providers.ibmq import IBMQ, least_busy
-from qiskit.test import QiskitTestCase, requires_qe_access
+from qiskit.test import QiskitTestCase
 
+from ..decorators import requires_qe_access
 
 class TestBackendFilters(QiskitTestCase):
     """Qiskit Backend Filtering Tests."""

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -19,6 +19,7 @@ from qiskit.test import QiskitTestCase
 
 from ..decorators import requires_qe_access
 
+
 class TestBackendFilters(QiskitTestCase):
     """Qiskit Backend Filtering Tests."""
 

--- a/test/ibmq/test_ibmq_backends.py
+++ b/test/ibmq/test_ibmq_backends.py
@@ -20,8 +20,10 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.ibmq import IBMQ
 from qiskit.qobj import QobjHeader
-from qiskit.test import QiskitTestCase, requires_qe_access, slow_test
+from qiskit.test import QiskitTestCase, slow_test
 from qiskit.compiler import assemble, transpile
+
+from ..decorators import requires_qe_access
 
 
 class TestIBMQBackends(QiskitTestCase):

--- a/test/ibmq/test_ibmq_client_v2.py
+++ b/test/ibmq/test_ibmq_client_v2.py
@@ -22,9 +22,9 @@ from qiskit.compiler import assemble, transpile
 from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.ibmq.api_v2 import IBMQClient
 from qiskit.providers.ibmq.api_v2.exceptions import ApiError
-from qiskit.test import QiskitTestCase, requires_qe_access
+from qiskit.test import QiskitTestCase
 
-from ..decorators import requires_new_api_auth
+from ..decorators import requires_new_api_auth, requires_qe_access
 
 
 class TestIBMQClient(QiskitTestCase):
@@ -86,7 +86,6 @@ class TestIBMQClient(QiskitTestCase):
         backend = IBMQ.get_backend(backend_name)
         circuit = transpile(self.qc1, backend, seed_transpiler=self.seed)
         qobj = assemble(circuit, backend, shots=1)
-        print('complied')
 
         # Run the job through the IBMQClient directly using object storage.
         api = backend._api

--- a/test/ibmq/test_ibmq_connector.py
+++ b/test/ibmq/test_ibmq_connector.py
@@ -20,8 +20,8 @@ from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import assemble, transpile
 from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.ibmq.api import (ApiError, BadBackendError, IBMQConnector)
-from qiskit.test import QiskitTestCase, requires_qe_access
-from ..decorators import requires_classic_api
+from qiskit.test import QiskitTestCase
+from ..decorators import requires_classic_api, requires_qe_access
 
 
 class TestIBMQConnector(QiskitTestCase):

--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -17,9 +17,11 @@
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers.ibmq import IBMQ, least_busy
 from qiskit.result import Result
-from qiskit.test import QiskitTestCase, requires_qe_access
+from qiskit.test import QiskitTestCase
 from qiskit.execute import execute
 from qiskit.compiler import assemble, transpile
+
+from ..decorators import requires_qe_access
 
 
 class TestIBMQIntegration(QiskitTestCase):

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -28,9 +28,11 @@ from qiskit.providers import JobError, JobStatus
 from qiskit.providers.ibmq import IBMQ, least_busy
 from qiskit.providers.ibmq.exceptions import IBMQBackendError
 from qiskit.providers.ibmq.job.ibmqjob import IBMQJob
-from qiskit.test import requires_qe_access, slow_test
+from qiskit.test import slow_test
 from qiskit.compiler import assemble, transpile
+
 from ..jobtestcase import JobTestCase
+from ..decorators import requires_qe_access
 
 
 class TestIBMQJob(JobTestCase):

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -25,6 +25,7 @@ from qiskit.providers import JobError, JobTimeoutError
 from qiskit.providers.ibmq.api import ApiError
 from qiskit.providers.ibmq.job.ibmqjob import IBMQJob
 from qiskit.providers.jobstatus import JobStatus
+
 from ..jobtestcase import JobTestCase
 
 

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -16,8 +16,10 @@
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers.ibmq import IBMQ
-from qiskit.test import QiskitTestCase, requires_qe_access
+from qiskit.test import QiskitTestCase
 from qiskit.compiler import assemble, transpile
+
+from ..decorators import requires_qe_access
 
 
 class TestIbmqQasmSimulator(QiskitTestCase):

--- a/test/ibmq/test_ibmq_qobj.py
+++ b/test/ibmq/test_ibmq_qobj.py
@@ -20,8 +20,10 @@ from qiskit import (BasicAer, ClassicalRegister, QuantumCircuit,
                     QuantumRegister)
 from qiskit.providers.ibmq import IBMQ
 from qiskit.qasm import pi
-from qiskit.test import QiskitTestCase, requires_qe_access, slow_test
+from qiskit.test import QiskitTestCase, slow_test
 from qiskit.compiler import transpile
+
+from ..decorators import requires_qe_access
 
 
 class TestIBMQQobj(QiskitTestCase):

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -31,6 +31,7 @@ from qiskit.providers.ibmq.ibmqprovider import QE_URL
 from qiskit.providers.ibmq.ibmqsingleprovider import IBMQSingleProvider
 from qiskit.test import QiskitTestCase
 
+
 IBMQ_TEMPLATE = 'https://localhost/api/Hubs/{}/Groups/{}/Projects/{}'
 
 PROXIES = {

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -17,9 +17,9 @@
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import assemble, transpile
 from qiskit.providers.ibmq import IBMQ, least_busy
-from qiskit.test import QiskitTestCase, requires_qe_access, slow_test
+from qiskit.test import QiskitTestCase, slow_test
 
-from ...decorators import requires_new_api_auth
+from ...decorators import requires_new_api_auth, requires_qe_access
 
 
 class TestWebsocketIntegration(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Due to the changes proposed in https://github.com/Qiskit/qiskit-terra/pull/2448, the `requires_qe_access` decorator might end up being deprecated or with its functionaly removed. In this PR, the decorator and some auxiliary function is moved to provider-land.


### Details and comments


