### PR TITLE
Make the websocket mocked server during the tests more dynamic

### DIFF
--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -27,7 +27,8 @@ from qiskit.test import QiskitTestCase
 
 from .websocket_server import (
     TOKEN_JOB_COMPLETED, TOKEN_JOB_TRANSITION, TOKEN_WRONG_FORMAT,
-    TOKEN_TIMEOUT, websocket_handler)
+    TOKEN_TIMEOUT, TEST_IP_ADDRESS, TEST_WSS_PORT, TEST_WS_PORT,
+    websocket_handler)
 
 
 class TestWebsocketClient(QiskitTestCase):
@@ -35,7 +36,7 @@ class TestWebsocketClient(QiskitTestCase):
 
     def test_invalid_url(self):
         """Test connecting to an invalid URL."""
-        client = WebsocketClient('wss://127.0.0.1:9876', None)
+        client = WebsocketClient('wss://{}:{}'.format(TEST_IP_ADDRESS, TEST_WSS_PORT), None)
 
         with self.assertRaises(WebsocketError):
             asyncio.get_event_loop().run_until_complete(
@@ -44,13 +45,12 @@ class TestWebsocketClient(QiskitTestCase):
 
 class TestWebsocketClientMock(QiskitTestCase):
     """Tests for the the websocket client against a mock server."""
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
         # Launch the mock server.
-        start_server = websockets.serve(websocket_handler, '127.0.0.1', 8765)
+        start_server = websockets.serve(websocket_handler, TEST_IP_ADDRESS, int(TEST_WS_PORT))
         cls.server = asyncio.get_event_loop().run_until_complete(start_server)
 
     @classmethod
@@ -69,7 +69,8 @@ class TestWebsocketClientMock(QiskitTestCase):
 
     def test_job_final_status(self):
         """Test retrieving a job already in final status."""
-        client = WebsocketClient('ws://127.0.0.1:8765', TOKEN_JOB_COMPLETED)
+        client = WebsocketClient('ws://{}:{}'.format(
+            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_JOB_COMPLETED)
         response = asyncio.get_event_loop().run_until_complete(
             client.get_job_status('job_id'))
         self.assertIsInstance(response, dict)
@@ -78,7 +79,8 @@ class TestWebsocketClientMock(QiskitTestCase):
 
     def test_job_transition(self):
         """Test retrieving a job that transitions to final status."""
-        client = WebsocketClient('ws://127.0.0.1:8765', TOKEN_JOB_TRANSITION)
+        client = WebsocketClient('ws://{}:{}'.format(
+            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_JOB_TRANSITION)
         response = asyncio.get_event_loop().run_until_complete(
             client.get_job_status('job_id'))
         self.assertIsInstance(response, dict)
@@ -87,14 +89,16 @@ class TestWebsocketClientMock(QiskitTestCase):
 
     def test_timeout(self):
         """Test timeout during retrieving a job status."""
-        client = WebsocketClient('ws://127.0.0.1:8765', TOKEN_TIMEOUT)
+        client = WebsocketClient('ws://{}:{}'.format(
+            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_TIMEOUT)
         with self.assertRaises(WebsocketTimeoutError):
             _ = asyncio.get_event_loop().run_until_complete(
                 client.get_job_status('job_id', timeout=2))
 
     def test_invalid_response(self):
         """Test unparseable response from the server."""
-        client = WebsocketClient('ws://127.0.0.1:8765', TOKEN_WRONG_FORMAT)
+        client = WebsocketClient('ws://{}:{}'.format(
+            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_WRONG_FORMAT)
         with self.assertRaises(WebsocketIBMQProtocolError):
             _ = asyncio.get_event_loop().run_until_complete(
                 client.get_job_status('job_id'))

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -30,8 +30,8 @@ from .websocket_server import (
     TOKEN_TIMEOUT, websocket_handler)
 
 TEST_IP_ADDRESS = '127.0.0.1'
-TEST_WSS_PORT = '9876'
-TEST_WS_PORT = '8765'
+INVALID_PORT = 9876
+VALID_PORT = 8765
 
 
 class TestWebsocketClient(QiskitTestCase):
@@ -39,7 +39,7 @@ class TestWebsocketClient(QiskitTestCase):
 
     def test_invalid_url(self):
         """Test connecting to an invalid URL."""
-        client = WebsocketClient('wss://{}:{}'.format(TEST_IP_ADDRESS, TEST_WSS_PORT), None)
+        client = WebsocketClient('wss://{}:{}'.format(TEST_IP_ADDRESS, INVALID_PORT), None)
 
         with self.assertRaises(WebsocketError):
             asyncio.get_event_loop().run_until_complete(
@@ -53,7 +53,7 @@ class TestWebsocketClientMock(QiskitTestCase):
         super().setUpClass()
 
         # Launch the mock server.
-        start_server = websockets.serve(websocket_handler, TEST_IP_ADDRESS, int(TEST_WS_PORT))
+        start_server = websockets.serve(websocket_handler, TEST_IP_ADDRESS, int(VALID_PORT))
         cls.server = asyncio.get_event_loop().run_until_complete(start_server)
 
     @classmethod
@@ -73,7 +73,7 @@ class TestWebsocketClientMock(QiskitTestCase):
     def test_job_final_status(self):
         """Test retrieving a job already in final status."""
         client = WebsocketClient('ws://{}:{}'.format(
-            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_JOB_COMPLETED)
+            TEST_IP_ADDRESS, VALID_PORT), TOKEN_JOB_COMPLETED)
         response = asyncio.get_event_loop().run_until_complete(
             client.get_job_status('job_id'))
         self.assertIsInstance(response, dict)
@@ -83,7 +83,7 @@ class TestWebsocketClientMock(QiskitTestCase):
     def test_job_transition(self):
         """Test retrieving a job that transitions to final status."""
         client = WebsocketClient('ws://{}:{}'.format(
-            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_JOB_TRANSITION)
+            TEST_IP_ADDRESS, VALID_PORT), TOKEN_JOB_TRANSITION)
         response = asyncio.get_event_loop().run_until_complete(
             client.get_job_status('job_id'))
         self.assertIsInstance(response, dict)
@@ -93,7 +93,7 @@ class TestWebsocketClientMock(QiskitTestCase):
     def test_timeout(self):
         """Test timeout during retrieving a job status."""
         client = WebsocketClient('ws://{}:{}'.format(
-            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_TIMEOUT)
+            TEST_IP_ADDRESS, VALID_PORT), TOKEN_TIMEOUT)
         with self.assertRaises(WebsocketTimeoutError):
             _ = asyncio.get_event_loop().run_until_complete(
                 client.get_job_status('job_id', timeout=2))
@@ -101,7 +101,7 @@ class TestWebsocketClientMock(QiskitTestCase):
     def test_invalid_response(self):
         """Test unparseable response from the server."""
         client = WebsocketClient('ws://{}:{}'.format(
-            TEST_IP_ADDRESS, TEST_WS_PORT), TOKEN_WRONG_FORMAT)
+            TEST_IP_ADDRESS, VALID_PORT), TOKEN_WRONG_FORMAT)
         with self.assertRaises(WebsocketIBMQProtocolError):
             _ = asyncio.get_event_loop().run_until_complete(
                 client.get_job_status('job_id'))

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -27,8 +27,11 @@ from qiskit.test import QiskitTestCase
 
 from .websocket_server import (
     TOKEN_JOB_COMPLETED, TOKEN_JOB_TRANSITION, TOKEN_WRONG_FORMAT,
-    TOKEN_TIMEOUT, TEST_IP_ADDRESS, TEST_WSS_PORT, TEST_WS_PORT,
-    websocket_handler)
+    TOKEN_TIMEOUT, websocket_handler)
+
+TEST_IP_ADDRESS = '127.0.0.1'
+TEST_WSS_PORT = '9876'
+TEST_WS_PORT = '8765'
 
 
 class TestWebsocketClient(QiskitTestCase):

--- a/test/ibmq/websocket/websocket_server.py
+++ b/test/ibmq/websocket/websocket_server.py
@@ -24,7 +24,9 @@ TOKEN_JOB_COMPLETED = 'token_job_completed'
 TOKEN_JOB_TRANSITION = 'token_job_transition'
 TOKEN_TIMEOUT = 'token_timeout'
 TOKEN_WRONG_FORMAT = 'token_wrong_format'
-
+TEST_IP_ADDRESS = '127.0.0.1'
+TEST_WSS_PORT = '9876'
+TEST_WS_PORT = '8765'
 
 @asyncio.coroutine
 def websocket_handler(websocket, path):

--- a/test/ibmq/websocket/websocket_server.py
+++ b/test/ibmq/websocket/websocket_server.py
@@ -28,6 +28,7 @@ TEST_IP_ADDRESS = '127.0.0.1'
 TEST_WSS_PORT = '9876'
 TEST_WS_PORT = '8765'
 
+
 @asyncio.coroutine
 def websocket_handler(websocket, path):
     """Entry point for the websocket mock server."""

--- a/test/ibmq/websocket/websocket_server.py
+++ b/test/ibmq/websocket/websocket_server.py
@@ -24,9 +24,6 @@ TOKEN_JOB_COMPLETED = 'token_job_completed'
 TOKEN_JOB_TRANSITION = 'token_job_transition'
 TOKEN_TIMEOUT = 'token_timeout'
 TOKEN_WRONG_FORMAT = 'token_wrong_format'
-TEST_IP_ADDRESS = '127.0.0.1'
-TEST_WSS_PORT = '9876'
-TEST_WS_PORT = '8765'
 
 
 @asyncio.coroutine


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Define `IP` and `port`s used by the `Websocket` tests at the class level. See #105.


### Details and comments


