### PR TITLE
Use nest_asyncio for allowing controlling the event loop in Jupyter

### DIFF
--- a/qiskit/providers/ibmq/api_v2/ibmqclient.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqclient.py
@@ -297,6 +297,8 @@ class IBMQClient:
         Returns:
             dict: job status.
         """
+        # As mentioned in `websocket.py`, in jupyter we need to use
+        # `nest_asyncio` to allow nested event loops.
         return asyncio.get_event_loop().run_until_complete(
             self.client_ws.get_job_status(job_id, timeout=timeout))
 

--- a/qiskit/providers/ibmq/api_v2/websocket.py
+++ b/qiskit/providers/ibmq/api_v2/websocket.py
@@ -20,6 +20,7 @@ import logging
 import time
 from concurrent import futures
 
+import nest_asyncio
 from websockets import connect, ConnectionClosed
 
 from qiskit.providers.ibmq.apiconstants import ApiJobStatus, API_JOB_FINAL_STATES
@@ -29,6 +30,9 @@ from .exceptions import (WebsocketError, WebsocketTimeoutError,
 
 
 logger = logging.getLogger(__name__)
+
+# Patch asyncio to allow nested use of `loop.run_until_complete()`.
+nest_asyncio.apply()
 
 
 class WebsocketMessage:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+nest-asyncio>=1.0.0
 qiskit-terra>=0.8
 requests>=2.19
 requests-ntlm>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ import os
 from setuptools import setup
 
 requirements = [
+    "nest-asyncio>=1.0.0",
     "qiskit-terra>=0.8",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #120

... via the second approach: 

> use another package that allows nesting event loops (might have some implications in the complexity and side effects)

As hinted on the [related Jupyter issue](https://github.com/jupyter/notebook/issues/3397#issuecomment-419474214), `nest_asyncio` can be a viable alternative for being able to manage the event loop directly (allowing nested loops via patching). In theory, recent Jupyter versions would not require this patch, but for preserving compatibility it seems a good compromise. We should however explore cleaner alternatives and revise the websockets usage in upcoming PRs after the release, but hopefully this will avoid fixing the bug for the time being - I'll expand after merging on the issues.

### Details and comments


