### PR TITLE
Fix test_ibmq_backends slow_test decorator

### DIFF
--- a/test/ibmq/test_ibmq_backends.py
+++ b/test/ibmq/test_ibmq_backends.py
@@ -36,6 +36,7 @@ class TestIBMQBackends(QiskitTestCase):
         self._local_backend = BasicAer.get_backend('qasm_simulator')
         self._remote_backends = self.get_backends()
 
+    @slow_test
     @requires_qe_access
     def get_backends(self, qe_token=None, qe_url=None):
         """Return all available remote backends."""
@@ -119,7 +120,6 @@ class TestIBMQBackends(QiskitTestCase):
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
-    @slow_test
     def test_multi_register(self):
         """Test one circuit, two registers, out-of-order readout."""
         qr1 = QuantumRegister(2)
@@ -148,7 +148,6 @@ class TestIBMQBackends(QiskitTestCase):
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
-    @slow_test
     def test_multi_circuit(self):
         """Test two circuits, two registers, out-of-order readout."""
         qr1 = QuantumRegister(2)

--- a/test/ibmq/test_ibmq_backends.py
+++ b/test/ibmq/test_ibmq_backends.py
@@ -31,12 +31,12 @@ class TestIBMQBackends(QiskitTestCase):
     local simulator 'local_qasm_simulator' as ground truth.
     """
 
+    @slow_test
     def setUp(self):
         super().setUp()
         self._local_backend = BasicAer.get_backend('qasm_simulator')
         self._remote_backends = self.get_backends()
 
-    @slow_test
     @requires_qe_access
     def get_backends(self, qe_token=None, qe_url=None):
         """Return all available remote backends."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

During #134, some tests slipped by not marked as `slow_test`. This PR ensures they are actually marked as `slow_test` (during the setup() call, for avoiding the registration request), for getting the CI in `master` back as soon as possible.


### Details and comments


