### PR TITLE
Fix version_finder for h/g/p urls

### DIFF
--- a/qiskit/providers/ibmq/api_v2/ibmqversionfinder.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqversionfinder.py
@@ -28,7 +28,6 @@ class IBMQVersionFinder:
             url (str): URL for the service.
             proxies (dict): proxies used in the connection.
         """
-        self.url = url
         self.client_version_finder = VersionFinder(RetrySession(url, proxies=proxies))
 
     def version(self):

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -83,7 +83,7 @@ def write_qiskit_rc(credentials, filename=None):
     """
     def _credentials_object_to_dict(obj):
         return {key: getattr(obj, key) for key in
-                ['token', 'url', 'websocket_url', 'proxies', 'verify']
+                ['token', 'url', 'proxies', 'verify']
                 if getattr(obj, key)}
 
     def _section_name(credentials_):

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -54,7 +54,7 @@ class Credentials:
             communicating with the API.
         """
         self.token = token
-        (self.url,
+        (self.url, self.base_url,
          self.hub, self.group, self.project) = _unify_ibmq_url(
              url, hub, group, project)
         self.proxies = proxies or {}
@@ -85,17 +85,19 @@ def _unify_ibmq_url(url, hub=None, group=None, project=None):
         project (str): the project used for IBM Q.
 
     Returns:
-        tuple[url, hub, group, token]:
+        tuple[url, base_url, hub, group, token]:
             * url (str): new-style Quantum Experience or IBM Q URL (the hub,
-                group and project included in the URL.
+                group and project included in the URL).
+            * base_url (str): base URL for the API, without hub/group/project.
             * hub (str): the hub used for IBM Q.
             * group (str): the group used for IBM Q.
             * project (str): the project used for IBM Q.
     """
     # Check if the URL is "new style", and retrieve embedded parameters from it.
     regex_match = re.match(REGEX_IBMQ_HUBS, url, re.IGNORECASE)
+    base_url = url
     if regex_match:
-        _, hub, group, project = regex_match.groups()
+        base_url, hub, group, project = regex_match.groups()
     else:
         if hub and group and project:
             # Assume it is an IBMQ URL, and update the url.
@@ -105,4 +107,4 @@ def _unify_ibmq_url(url, hub=None, group=None, project=None):
             # Cleanup the hub, group and project, without modifying the url.
             hub = group = project = None
 
-    return url, hub, group, project
+    return url, base_url, hub, group, project

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -34,7 +34,7 @@ class Credentials:
     """
 
     def __init__(self, token, url, hub=None, group=None, project=None,
-                 websocket_url=None, proxies=None, verify=True):
+                 proxies=None, verify=True):
         """Return new set of credentials.
 
         Args:
@@ -43,7 +43,6 @@ class Credentials:
             hub (str): the hub used for IBMQ.
             group (str): the group used for IBMQ.
             project (str): the project used for IBMQ.
-            websocket_url (str): URL for websocket communication with IBM Q.
             proxies (dict): proxy configuration for the API.
             verify (bool): if False, ignores SSL certificates errors
 
@@ -55,9 +54,9 @@ class Credentials:
             communicating with the API.
         """
         self.token = token
-        (self.url, self.websocket_url,
+        (self.url,
          self.hub, self.group, self.project) = _unify_ibmq_url(
-             url, websocket_url, hub, group, project)
+             url, hub, group, project)
         self.proxies = proxies or {}
         self.verify = verify
 
@@ -76,18 +75,17 @@ class Credentials:
         return self.hub, self.group, self.project
 
 
-def _unify_ibmq_url(url, websocket_url=None, hub=None, group=None, project=None):
+def _unify_ibmq_url(url, hub=None, group=None, project=None):
     """Return a new-style set of credential values (url and hub parameters).
 
     Args:
         url (str): URL for Quantum Experience or IBM Q.
-        websocket_url (str): URL for websocket communication with IBM Q.
         hub (str): the hub used for IBM Q.
         group (str): the group used for IBM Q.
         project (str): the project used for IBM Q.
 
     Returns:
-        tuple[url, websocket_url, hub, group, token]:
+        tuple[url, hub, group, token]:
             * url (str): new-style Quantum Experience or IBM Q URL (the hub,
                 group and project included in the URL.
             * hub (str): the hub used for IBM Q.
@@ -107,4 +105,4 @@ def _unify_ibmq_url(url, websocket_url=None, hub=None, group=None, project=None)
             # Cleanup the hub, group and project, without modifying the url.
             hub = group = project = None
 
-    return url, websocket_url, hub, group, project
+    return url, hub, group, project

--- a/qiskit/providers/ibmq/credentials/environ.py
+++ b/qiskit/providers/ibmq/credentials/environ.py
@@ -23,7 +23,6 @@ from .credentials import Credentials
 VARIABLES_MAP = {
     'QE_TOKEN': 'token',
     'QE_URL': 'url',
-    'QE_WEBSOCKET_URL': 'websocket_url',
     'QE_HUB': 'hub',
     'QE_GROUP': 'group',
     'QE_PROJECT': 'project'

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -66,7 +66,8 @@ class IBMQBackend(BaseBackend):
         kwargs = {}
         if isinstance(self._api, IBMQClient):
             # Default to using object storage and websockets for new API.
-            kwargs = {'use_object_storage': True,
+            # TODO: reenable object storage when API is ready.
+            kwargs = {'use_object_storage': False,
                       'use_websockets': True}
 
         job = IBMQJob(self, None, self._api, qobj=qobj, **kwargs)

--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -77,16 +77,9 @@ class IBMQSingleProvider(BaseProvider):
         Raises:
             ConnectionError: if the authentication resulted in error.
         """
-        # Prepare the config_dict for IBMQConnector.
-        config_dict = {
-            'url': credentials.url,
-        }
-        proxies = None
-        if credentials.proxies:
-            config_dict['proxies'] = credentials.proxies
-            proxies = credentials.proxies['urls']
-
-        version_finder = IBMQVersionFinder(url=credentials.url,
+        # Use an IBMQVersionFinder for finding out the API version.
+        proxies = credentials.proxies.get('urls')
+        version_finder = IBMQVersionFinder(url=credentials.base_url,
                                            proxies=proxies)
         version_info = version_finder.version()
 
@@ -99,6 +92,13 @@ class IBMQSingleProvider(BaseProvider):
                                   auth_url=credentials.url,
                                   proxies=proxies)
             else:
+                # Prepare the config_dict for IBMQConnector.
+                config_dict = {
+                    'url': credentials.url,
+                }
+                if credentials.proxies:
+                    config_dict['proxies'] = credentials.proxies
+
                 return IBMQConnector(credentials.token, config_dict,
                                      credentials.verify)
         except AuthenticationLicenseError as ex:

--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -85,8 +85,6 @@ class IBMQSingleProvider(BaseProvider):
         if credentials.proxies:
             config_dict['proxies'] = credentials.proxies
             proxies = credentials.proxies['urls']
-        if credentials.websocket_url:
-            config_dict['websocket_url'] = credentials.websocket_url
 
         version_finder = IBMQVersionFinder(url=credentials.url,
                                            proxies=proxies)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #155 by adding a new attribute to `Credentials` that contains the base url.

Additionally, this PR:
* removes old traces of `websocket` support in the `Credentials`, as the websocket url is automatically retrieved during the auth dance.
* disables object support, as some issues were found during testing due to partial support in the API.

### Details and comments


