### PR TITLE
Enable api_v2 pulse_defaults endpoint

### DIFF
--- a/qiskit/providers/ibmq/api_v2/ibmqclient.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqclient.py
@@ -171,9 +171,7 @@ class IBMQClient:
         Returns:
             dict: backend pulse defaults.
         """
-        # pylint: disable=unused-argument
-        # return self.api_client.backend(backend_name).pulse_defaults()
-        return None
+        return self.client_api.backend(backend_name).pulse_defaults()
 
     # Jobs-related public functions.
 

--- a/qiskit/providers/ibmq/api_v2/rest/backend.py
+++ b/qiskit/providers/ibmq/api_v2/rest/backend.py
@@ -21,8 +21,9 @@ class Backend(RestAdapterBase):
     """Rest adapter for backend related endpoints."""
 
     URL_MAP = {
+        'properties': '/properties',
+        'pulse_defaults': '/defaults',
         'status': '/queue/status',
-        'properties': '/properties'
     }
 
     def __init__(self, session, backend_name):
@@ -34,6 +35,22 @@ class Backend(RestAdapterBase):
         """
         self.backend_name = backend_name
         super().__init__(session, '/Backends/{}'.format(backend_name))
+
+    def properties(self):
+        """Return backend properties."""
+        url = self.get_url('properties')
+        response = self.session.get(url, params={'version': 1}).json()
+
+        # Adjust name of the backend.
+        if response:
+            response['backend_name'] = self.backend_name
+
+        return response
+
+    def pulse_defaults(self):
+        """Return backend pulse defaults."""
+        url = self.get_url('pulse_defaults')
+        return self.session.get(url).json()
 
     def status(self):
         """Return backend status."""
@@ -59,14 +76,3 @@ class Backend(RestAdapterBase):
             ret['dedicated'] = response['busy']
 
         return ret
-
-    def properties(self):
-        """Return backend properties."""
-        url = self.get_url('properties')
-        response = self.session.get(url, params={'version': 1}).json()
-
-        # Adjust name of the backend.
-        if response:
-            response['backend_name'] = self.backend_name
-
-        return response


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #108

The `pulse_defaults` endpoint was disabled for api v2 while sorting out its usage and details - is time to bring it back to life.


### Details and comments


