### PR TITLE
Allow custom qx-client-application header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ The format is based on [Keep a Changelog].
   available when using the new API authentication. (\#100)
 - Added support for using object storage when submitting and retrieving
   jobs. (\#110)
--   Added support for custom qx-client-application request header via the environment
-    variable `QE_CUSTOM_CLIENT_APP_HEADER` when using the new API. (\#165)
+- Added support for custom qx-client-application request header via the environment
+  variable `QE_CUSTOM_CLIENT_APP_HEADER` when using the new API. (\#165)
 
 
 ## [0.2.2] - 2019-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Added
     only available when using the new API authentication. (\#100)
 -   Added support for using object storage when submitting and
     retrieving jobs. (\#110)
+-   Added support for custom client application session header via the environment
+    variable `QE_CUSTOM_CLIENT_APP_HEADER` when using the new API. (\#TBD)
 
 [0.2.2](https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.2.1...0.2.2) - 2019-05-07
 ==========================================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ Added
     only available when using the new API authentication. (\#100)
 -   Added support for using object storage when submitting and
     retrieving jobs. (\#110)
--   Added support for custom client application session header via the environment
-    variable `QE_CUSTOM_CLIENT_APP_HEADER` when using the new API. (\#TBD)
+-   Added support for custom qx-client-application request header via the environment
+    variable `QE_CUSTOM_CLIENT_APP_HEADER` when using the new API. (\#165)
 
 [0.2.2](https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.2.1...0.2.2) - 2019-05-07
 ==========================================================================================

--- a/qiskit/providers/ibmq/api_v2/session.py
+++ b/qiskit/providers/ibmq/api_v2/session.py
@@ -28,7 +28,7 @@ STATUS_FORCELIST = (
     503,  # Service Unavailable
     504,  # Gateway Timeout
 )
-CLIENT_APPLICATION = 'ibmqprovider/version-' + ibmq_provider_version
+CLIENT_APPLICATION = 'ibmqprovider/' + ibmq_provider_version
 CUSTOM_HEADER_ENV_VAR = 'QE_CUSTOM_CLIENT_APP_HEADER'
 
 

--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -20,7 +20,11 @@ from contextlib import contextmanager
 
 @contextmanager
 def custom_envs(new_environ):
-    """Context manager that modifies environment variables."""
+    """Context manager that modifies environment variables.
+
+    Args:
+        new_environ (dict): a dictionary of modified environment variables.
+    """
     # Remove the original variables from `os.environ`.
     # Store the original `os.environ`.
     os_environ_original = os.environ.copy()

--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Context managers for using with IBMQProvider unit tests."""
+
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def custom_envs(new_environ):
+    """Context manager that modifies environment variables."""
+    # Remove the original variables from `os.environ`.
+    # Store the original `os.environ`.
+    os_environ_original = os.environ.copy()
+    modified_environ = {**os.environ, **new_environ}
+    try:
+        os.environ = modified_environ
+        yield
+    finally:
+        # Restore the original `os.environ`.
+        os.environ = os_environ_original
+
+
+@contextmanager
+def no_envs(vars_to_remove):
+    """Context manager that disables environment variables.
+
+    Args:
+        vars_to_remove (list): environment variables to remove.
+
+    """
+    # Remove the original variables from `os.environ`.
+    # Store the original `os.environ`.
+    os_environ_original = os.environ.copy()
+    modified_environ = {key: value for key, value in os.environ.items()
+                        if key not in vars_to_remove}
+    try:
+        os.environ = modified_environ
+        yield
+    finally:
+        # Restore the original `os.environ`.
+        os.environ = os_environ_original

--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -23,7 +23,7 @@ def custom_envs(new_environ):
     """Context manager that modifies environment variables.
 
     Args:
-        new_environ (dict): a dictionary of modified environment variables.
+        new_environ (dict): a dictionary of new environment variables to use.
     """
     # Remove the original variables from `os.environ`.
     # Store the original `os.environ`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Change the request header `X-Qx-Client-Application` from `qiskit-api-py` to either 
`ibmqprovider/version-<version>` or
`ibmqprovider/version-<version>/<additional custom header>`

 where `<additional custom header>` is specified via the environment variable `QE_CUSTOM_CLIENT_APP_HEADER`. This addresses #153 .

Also moved `custom_envs` and `no_envs` context managers to a new `contextmanagers.py` file, so they can be used by multiple test modules.

### Details and comments


