### PR TITLE
Use on_finish instead of after_test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,6 @@ test_script:
     - py.test -s -v --junit-xml=test_results.xml
 
 # Upload the test results to appveyor so they are shown on the "Tests" tab.
-after_test:
+on_finish:
     - ps: $wc = New-Object 'System.Net.WebClient'
     - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_results.xml))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix `appveyor` configuration for using `on_finish` instead of `after_test`, in order to try to invoke test uploading even after failed tests.


### Details and comments


