### PR TITLE
skip api call for defaults if pulse not supported

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -112,6 +112,9 @@ class IBMQBackend(BaseBackend):
             PulseDefaults: the pulse defaults for the backend. IF the backend
             does not support defaults, it returns ``None``.
         """
+        if not self.configuration().open_pulse:
+            return None
+
         backend_defaults = self._api.backend_defaults(self.name())
 
         if backend_defaults:

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -81,7 +81,11 @@ class TestIBMQProvider(providers.ProviderTestCase):
         """Test backend pulse defaults."""
         remotes = self.provider.backends(simulator=False)
         for backend in remotes:
-            _ = backend.defaults()
+            defaults = backend.defaults()
+            if backend.configuration().open_pulse:
+                self.assertIsNotNone(defaults)
+            else:
+                self.assertIsNone(defaults)
 
     def test_qobj_headers_in_result_sims(self):
         """Test that the qobj headers are passed onto the results for sims."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Make the api call for `defaults` only if the backend supports open pulse. This addresses #109 .


### Details and comments


