### PR TITLE
Use `kwargs` for requests parameters

### DIFF
--- a/qiskit/providers/ibmq/api_v2/ibmqclient.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqclient.py
@@ -25,25 +25,26 @@ from .exceptions import RequestsApiError, AuthenticationLicenseError
 class IBMQClient:
     """Client for programmatic access to the IBM Q API."""
 
-    def __init__(self, api_token, url, **request_kwargs):
+    def __init__(self, api_token, auth_url, **request_kwargs):
         """IBMQClient constructor.
 
         Args:
             api_token (str): IBM Q api token.
-            url (str): URL for the authentication service.
-            **request_kwargs (dict): arguments for the session and service clients.
+            auth_url (str): URL for the authentication service.
+            **request_kwargs (dict): arguments for the `requests` Session.
         """
         self.api_token = api_token
-        self.auth_url = url
+        self.auth_url = auth_url
 
-        self.client_auth = Auth(RetrySession(url, **request_kwargs))
-        self.client_api, self.client_ws = self._init_service_clients(**request_kwargs)
+        self.client_auth = Auth(RetrySession(auth_url, **request_kwargs))
+        self.client_api, self.client_ws = self._init_service_clients(
+            **request_kwargs)
 
     def _init_service_clients(self, **request_kwargs):
         """Initialize the clients used for communicating with the API and ws.
 
         Args:
-            **request_kwargs (dict): arguments for the session.
+            **request_kwargs (dict): arguments for the `requests` Session.
 
         Returns:
             tuple(Api, WebsocketClient):
@@ -57,7 +58,8 @@ class IBMQClient:
         service_urls = self._user_urls()
 
         # Create the api server client, using the access token.
-        client_api = Api(RetrySession(service_urls['http'], access_token, **request_kwargs))
+        client_api = Api(RetrySession(service_urls['http'], access_token,
+                                      **request_kwargs))
 
         # Create the websocket server client, using the access token.
         client_ws = WebsocketClient(service_urls['ws'], access_token)

--- a/qiskit/providers/ibmq/api_v2/ibmqclient.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqclient.py
@@ -25,30 +25,25 @@ from .exceptions import RequestsApiError, AuthenticationLicenseError
 class IBMQClient:
     """Client for programmatic access to the IBM Q API."""
 
-    def __init__(self, api_token, auth_url, verify=True, proxies=None, auth=None):
+    def __init__(self, api_token, url, **request_kwargs):
         """IBMQClient constructor.
 
         Args:
             api_token (str): IBM Q api token.
-            auth_url (str): URL for the authentication service.
-            verify (bool): if False, ignores SSL certificates errors.
-            proxies (dict): proxies used in the connection.
-            auth (AuthBase): authentication handler.
+            url (str): URL for the authentication service.
+            **request_kwargs (dict): arguments for the session and service clients.
         """
         self.api_token = api_token
-        self.auth_url = auth_url
+        self.auth_url = url
 
-        self.client_auth = Auth(RetrySession(auth_url, verify=verify, proxies=proxies, auth=auth))
-        self.client_api, self.client_ws = self._init_service_clients(
-            verify=verify, proxies=proxies, auth=auth)
+        self.client_auth = Auth(RetrySession(url, **request_kwargs))
+        self.client_api, self.client_ws = self._init_service_clients(**request_kwargs)
 
-    def _init_service_clients(self, verify, proxies, auth):
+    def _init_service_clients(self, **request_kwargs):
         """Initialize the clients used for communicating with the API and ws.
 
         Args:
-            verify (bool): if False, ignores SSL certificates errors.
-            proxies (dict): proxies used in the connection.
-            auth (AuthBase): authentication handler.
+            **request_kwargs (dict): arguments for the session.
 
         Returns:
             tuple(Api, WebsocketClient):
@@ -62,8 +57,7 @@ class IBMQClient:
         service_urls = self._user_urls()
 
         # Create the api server client, using the access token.
-        client_api = Api(RetrySession(service_urls['http'], access_token,
-                                      verify=verify, proxies=proxies, auth=auth))
+        client_api = Api(RetrySession(service_urls['http'], access_token, **request_kwargs))
 
         # Create the websocket server client, using the access token.
         client_ws = WebsocketClient(service_urls['ws'], access_token)

--- a/qiskit/providers/ibmq/api_v2/ibmqversionfinder.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqversionfinder.py
@@ -21,18 +21,14 @@ from .rest.version_finder import VersionFinder
 class IBMQVersionFinder:
     """Client for finding the API version being used."""
 
-    def __init__(self, url, verify=True, proxies=None, auth=None):
+    def __init__(self, url, **request_kwargs):
         """IBMQVersionFinder constructor.
 
         Args:
             url (str): URL for the service.
-            verify (bool): if False, ignores SSL certificates errors.
-            proxies (dict): proxies used in the connection.
-            auth (AuthBase): authentication handler.
+            **request_kwargs (dict): arguments for the session.
         """
-        self.client_version_finder = VersionFinder(
-            RetrySession(url, verify=verify, proxies=proxies, auth=auth)
-        )
+        self.client_version_finder = VersionFinder(RetrySession(url, **request_kwargs))
 
     def version(self):
         """Return the version info.

--- a/qiskit/providers/ibmq/api_v2/ibmqversionfinder.py
+++ b/qiskit/providers/ibmq/api_v2/ibmqversionfinder.py
@@ -26,9 +26,10 @@ class IBMQVersionFinder:
 
         Args:
             url (str): URL for the service.
-            **request_kwargs (dict): arguments for the session.
+            **request_kwargs (dict): arguments for the `requests` Session.
         """
-        self.client_version_finder = VersionFinder(RetrySession(url, **request_kwargs))
+        self.client_version_finder = VersionFinder(
+            RetrySession(url, **request_kwargs))
 
     def version(self):
         """Return the version info.

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -76,19 +76,25 @@ class Credentials:
         return self.hub, self.group, self.project
 
     def connection_parameters(self):
-        """Return a dict of kwargs in the format expected by requests."""
+        """Return a dict of kwargs in the format expected by `requests`.
+
+        Returns:
+            dict: a dict with connection-related arguments in the format
+                expected by `requests`. The following keys can be present:
+                `proxies`, `verify`, `auth`.
+        """
         request_kwargs = {
-            'proxies': self.proxies,
             'verify': self.verify
         }
+
+        if 'urls' in self.proxies:
+            request_kwargs['proxies'] = self.proxies['urls']
 
         if 'username_ntlm' in self.proxies and 'password_ntlm' in self.proxies:
             request_kwargs['auth'] = HttpNtlmAuth(
                 self.proxies['username_ntlm'],
                 self.proxies['password_ntlm']
             )
-        else:
-            request_kwargs['auth'] = None
 
         return request_kwargs
 

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -15,6 +15,7 @@
 """Model for representing IBM Q credentials."""
 
 import re
+from requests_ntlm import HttpNtlmAuth
 
 # Regex that matches a IBMQ URL with hub information
 REGEX_IBMQ_HUBS = (
@@ -77,10 +78,18 @@ class Credentials:
     def connection_parameters(self):
         """Return a dict of kwargs in the format expected by requests."""
         request_kwargs = {
-            'url': self.url,
             'proxies': self.proxies,
             'verify': self.verify
         }
+
+        if 'username_ntlm' in self.proxies and 'password_ntlm' in self.proxies:
+            request_kwargs['auth'] = HttpNtlmAuth(
+                self.proxies['username_ntlm'],
+                self.proxies['password_ntlm']
+            )
+        else:
+            request_kwargs['auth'] = None
+
         return request_kwargs
 
 

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -74,6 +74,15 @@ class Credentials:
         """
         return self.hub, self.group, self.project
 
+    def connection_parameters(self):
+        """Return a dict of kwargs in the format expected by requests."""
+        request_kwargs = {
+            'url': self.url,
+            'proxies': self.proxies,
+            'verify': self.verify
+        }
+        return request_kwargs
+
 
 def _unify_ibmq_url(url, hub=None, group=None, project=None):
     """Return a new-style set of credential values (url and hub parameters).

--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -82,7 +82,8 @@ class IBMQSingleProvider(BaseProvider):
         request_kwargs = credentials.connection_parameters()
 
         # Use an IBMQVersionFinder for finding out the API version.
-        version_finder = IBMQVersionFinder(credentials.url, **request_kwargs)
+        version_finder = IBMQVersionFinder(credentials.base_url,
+                                           **request_kwargs)
         version_info = version_finder.version()
 
         # Check if the URL belongs to auth services of the new API.

--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -92,7 +92,7 @@ class IBMQSingleProvider(BaseProvider):
 
             if version_info['new_api'] and 'api-auth' in version_info:
                 return IBMQClient(api_token=credentials.token,
-                                  url=credentials.url,
+                                  auth_url=credentials.url,
                                   **request_kwargs)
             else:
                 # Prepare the config_dict for IBMQConnector.

--- a/qiskit/providers/ibmq/ibmqsingleprovider.py
+++ b/qiskit/providers/ibmq/ibmqsingleprovider.py
@@ -79,21 +79,19 @@ class IBMQSingleProvider(BaseProvider):
         Raises:
             ConnectionError: if the authentication resulted in error.
         """
-        # handle proxy and auth configuration
-        proxies = credentials.proxies.get('urls')
-
-        if 'username_ntlm' in credentials.proxies and 'password_ntlm' in credentials.proxies:
-            auth = HttpNtlmAuth(
+        # construct kwargs to be used by the session requests
+        request_kwargs = credentials.connection_parameters()
+        if 'username_ntlm' in request_kwargs['proxies']\
+                and 'password_ntlm' in request_kwargs['proxies']:
+            request_kwargs['auth'] = HttpNtlmAuth(
                 credentials.proxies['username_ntlm'],
                 credentials.proxies['password_ntlm']
             )
         else:
-            auth = None
+            request_kwargs['auth'] = None
 
         # Use an IBMQVersionFinder for finding out the API version.
-        version_finder = IBMQVersionFinder(url=credentials.base_url,
-                                           verify=credentials.verify,
-                                           proxies=proxies, auth=auth)
+        version_finder = IBMQVersionFinder(**request_kwargs)
         version_info = version_finder.version()
 
         # Check if the URL belongs to auth services of the new API.
@@ -101,8 +99,7 @@ class IBMQSingleProvider(BaseProvider):
             self.is_new_api = version_info['new_api']
 
             if version_info['new_api'] and 'api-auth' in version_info:
-                return IBMQClient(api_token=credentials.token, auth_url=credentials.url,
-                                  verify=credentials.verify, proxies=proxies, auth=auth)
+                return IBMQClient(api_token=credentials.token, **request_kwargs)
             else:
                 # Prepare the config_dict for IBMQConnector.
                 config_dict = {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Use `kwargs` for `requests` parameters used by `RetrySession`. Add function to `Credentials` to get its relevant connection parameters. Addresses #178.