### PR TITLE
Test `Credentials.connection_parameters`

### DIFF
--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -84,17 +84,20 @@ class Credentials:
                 `proxies`, `verify`, `auth`.
         """
         request_kwargs = {
-            'verify': self.verify
+            'verify': self.verify,
+            'proxies': None,
+            'auth': None
         }
 
-        if 'urls' in self.proxies:
+        if self.proxies:
+            # make the 'proxies' entry just a dict of urls
             request_kwargs['proxies'] = self.proxies['urls']
 
-        if 'username_ntlm' in self.proxies and 'password_ntlm' in self.proxies:
-            request_kwargs['auth'] = HttpNtlmAuth(
-                self.proxies['username_ntlm'],
-                self.proxies['password_ntlm']
-            )
+            if 'username_ntlm' in self.proxies and 'password_ntlm' in self.proxies:
+                request_kwargs['auth'] = HttpNtlmAuth(
+                    self.proxies['username_ntlm'],
+                    self.proxies['password_ntlm']
+                )
 
         return request_kwargs
 

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -88,8 +88,8 @@ class Credentials:
         }
 
         if self.proxies:
-            # make the 'proxies' entry just a dict of urls
-            request_kwargs['proxies'] = self.proxies['urls']
+            if 'urls' in self.proxies:
+                request_kwargs['proxies'] = self.proxies['urls']
 
             if 'username_ntlm' in self.proxies and 'password_ntlm' in self.proxies:
                 request_kwargs['auth'] = HttpNtlmAuth(

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -84,9 +84,7 @@ class Credentials:
                 `proxies`, `verify`, `auth`.
         """
         request_kwargs = {
-            'verify': self.verify,
-            'proxies': None,
-            'auth': None
+            'verify': self.verify
         }
 
         if self.proxies:

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -283,13 +283,13 @@ class TestCredentialsKwargs(QiskitTestCase):
             'dummy_token', 'https://dummy_url', proxies=proxies_with_ntlm_dict)
         result = proxies_with_ntlm_credentials.connection_parameters()
 
-        # verify the NTLM credentials
+        # Verify the NTLM credentials.
         self.assertEqual(
             ntlm_expected_result['auth'].username, result['auth'].username)
         self.assertEqual(
             ntlm_expected_result['auth'].password, result['auth'].password)
 
-        # remove the HttpNtlmAuth objects for direct comparison of the dicts
+        # Remove the HttpNtlmAuth objects for direct comparison of the dicts.
         ntlm_expected_result.pop('auth')
         result.pop('auth')
         self.assertDictEqual(ntlm_expected_result, result)
@@ -301,8 +301,11 @@ class TestCredentialsKwargs(QiskitTestCase):
         malformed_nested_credentials = Credentials(
             'dummy_token', 'https://dummy_url',
             proxies=malformed_nested_proxies_dict)
-        with self.assertRaises(KeyError):
-            _ = dict(malformed_nested_credentials.connection_parameters())
+
+        # Malformed proxy entries should be ignored.
+        expected_result = {'verify': True}
+        result = malformed_nested_credentials.connection_parameters()
+        self.assertDictEqual(expected_result, result)
 
     def test_malformed_ntlm_params(self):
         """Test input with malformed NTLM credentials."""
@@ -315,10 +318,10 @@ class TestCredentialsKwargs(QiskitTestCase):
         malformed_ntlm_credentials = Credentials(
             'dummy_token', 'https://dummy_url',
             proxies=malformed_ntlm_credentials_dict)
-        # should raise when trying to do username.split('\\', <int>)
-        # in NTLM credentials due to int not facilitating 'split'
+        # Should raise when trying to do username.split('\\', <int>)
+        # in NTLM credentials due to int not facilitating 'split'.
         with self.assertRaises(AttributeError):
-            _ = dict(malformed_ntlm_credentials.connection_parameters())
+            _ = malformed_ntlm_credentials.connection_parameters()
 
 
 # Context managers

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -171,71 +171,6 @@ class TestIBMQAccounts(QiskitTestCase):
                                 proxies=PROXIES)
         self.assertIsInstance(context_manager.exception.original_exception, ProxyError)
 
-    def test_credentials_connection_params(self):
-        """Test Credentials.connection_params."""
-        # test when no proxy information is input
-        no_params_expected_result = {'verify': True}
-        no_params_credentials = Credentials('dummy_token', 'https://dummy_url')
-        result = dict(no_params_credentials.connection_parameters())
-        self.assertDictEqual(no_params_expected_result, result)
-
-        # test 'verify' arg is acknowledged
-        false_verify_expected_result = {'verify': False}
-        false_verify_credentials = Credentials('dummy_token', 'https://dummy_url', verify=False)
-        result = dict(false_verify_credentials.connection_parameters())
-        self.assertDictEqual(false_verify_expected_result, result)
-
-        # test using only proxy urls (no NTLM)
-        urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
-        proxies_only_expected_result = {'verify': True, 'proxies': urls}
-        proxies_only_credentials = Credentials(
-            'dummy_token', 'https://dummy_url', proxies={'urls': urls})
-        result = dict(proxies_only_credentials.connection_parameters())
-        self.assertDictEqual(proxies_only_expected_result, result)
-
-        # test using NTLM
-        proxies_with_ntlm_dict = {
-            'urls': urls,
-            'username_ntlm': 'domain\\username',
-            'password_ntlm': 'password'
-        }
-        ntlm_expected_result = {
-            'verify': True,
-            'proxies': urls,
-            'auth': HttpNtlmAuth('domain\\username', 'password')
-        }
-        proxies_with_ntlm_credentials = Credentials(
-            'dummy_token', 'https://dummy_url', proxies=proxies_with_ntlm_dict)
-        result = dict(proxies_with_ntlm_credentials.connection_parameters())
-
-        # verify the NTLM credentials
-        self.assertEqual(
-            ntlm_expected_result['auth'].username, result['auth'].username)
-        self.assertEqual(
-            ntlm_expected_result['auth'].password, result['auth'].password)
-
-        # remove the NTLM HttpNtlmAuth objects for direct comparison of the dicts
-        ntlm_expected_result.pop('auth')
-        result.pop('auth')
-        self.assertDictEqual(ntlm_expected_result, result)
-
-        # test malformed nesting of the proxies dictionary
-        malformed_nested_proxies_dict = {'proxies': urls}
-        malformed_nested_proxies_result = {'verify': True, 'proxies': urls}
-        malformed_nested_credentials = Credentials(
-            'dummy_token', 'https://dummy_url', proxies=malformed_nested_proxies_dict)
-        result = dict(malformed_nested_credentials.connection_parameters())
-        self.assertNotEqual(malformed_nested_proxies_result, result)
-
-        # test malformed NTLM credentials input
-        malformed_ntlm_credentials_dict = {'username_ntlm': 1234, 'password_ntlm': 5678}
-        malformed_ntlm_credentials = Credentials(
-            'dummy_token', 'https://dummy_url', proxies=malformed_ntlm_credentials_dict)
-        # should raise when trying to do username.split('\\', <int>)
-        # in NTLM credentials due to int not facilitating 'split'
-        with self.assertRaises(AttributeError):
-            _ = dict(malformed_ntlm_credentials.connection_parameters())
-
 
 # TODO: NamedTemporaryFiles do not support name in Windows
 @skipIf(os.name == 'nt', 'Test not supported in Windows')
@@ -302,6 +237,81 @@ class TestCredentials(QiskitTestCase):
 
         self.assertEqual(len(credentials), 1)
         self.assertEqual(list(credentials.values())[0].token, 'QCONFIG_TOKEN')
+
+    def test_no_proxy_params(self):
+        """Test when no proxy parameters are passed."""
+        no_params_expected_result = {'verify': True, 'proxies': None, 'auth': None}
+        no_params_credentials = Credentials('dummy_token', 'https://dummy_url')
+        result = dict(no_params_credentials.connection_parameters())
+        self.assertDictEqual(no_params_expected_result, result)
+
+    def test_verify_param(self):
+        """Test 'verify' arg is acknowledged."""
+        false_verify_expected_result = {'verify': False, 'proxies': None, 'auth': None}
+        false_verify_credentials = Credentials('dummy_token', 'https://dummy_url', verify=False)
+        result = dict(false_verify_credentials.connection_parameters())
+        self.assertDictEqual(false_verify_expected_result, result)
+
+    def test_proxy_param(self):
+        """Test using only proxy urls (no NTLM credentials)."""
+        urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
+        proxies_only_expected_result = {'verify': True, 'proxies': urls, 'auth': None}
+        proxies_only_credentials = Credentials(
+            'dummy_token', 'https://dummy_url', proxies={'urls': urls})
+        result = dict(proxies_only_credentials.connection_parameters())
+        self.assertDictEqual(proxies_only_expected_result, result)
+
+    def test_proxies_param_with_ntlm(self):
+        """Test proxies with NTLM credentials."""
+        urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
+        proxies_with_ntlm_dict = {
+            'urls': urls,
+            'username_ntlm': 'domain\\username',
+            'password_ntlm': 'password'
+        }
+        ntlm_expected_result = {
+            'verify': True,
+            'proxies': urls,
+            'auth': HttpNtlmAuth('domain\\username', 'password')
+        }
+        proxies_with_ntlm_credentials = Credentials(
+            'dummy_token', 'https://dummy_url', proxies=proxies_with_ntlm_dict)
+        result = dict(proxies_with_ntlm_credentials.connection_parameters())
+
+        # verify the NTLM credentials
+        self.assertEqual(
+            ntlm_expected_result['auth'].username, result['auth'].username)
+        self.assertEqual(
+            ntlm_expected_result['auth'].password, result['auth'].password)
+
+        # remove the NTLM HttpNtlmAuth objects for direct comparison of the dicts
+        ntlm_expected_result.pop('auth')
+        result.pop('auth')
+        self.assertDictEqual(ntlm_expected_result, result)
+
+    def test_malformed_proxy_param(self):
+        """Test input with malformed nesting of the proxies dictionary."""
+        urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
+        malformed_nested_proxies_dict = {'proxies': urls}
+        malformed_nested_credentials = Credentials(
+            'dummy_token', 'https://dummy_url', proxies=malformed_nested_proxies_dict)
+        with self.assertRaises(KeyError):
+            _ = dict(malformed_nested_credentials.connection_parameters())
+
+    def test_malformed_ntlm_params(self):
+        """Test input with malformed NTLM credentials."""
+        urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
+        malformed_ntlm_credentials_dict = {
+            'urls': urls,
+            'username_ntlm': 1234,
+            'password_ntlm': 5678
+        }
+        malformed_ntlm_credentials = Credentials(
+            'dummy_token', 'https://dummy_url', proxies=malformed_ntlm_credentials_dict)
+        # should raise when trying to do username.split('\\', <int>)
+        # in NTLM credentials due to int not facilitating 'split'
+        with self.assertRaises(AttributeError):
+            _ = dict(malformed_ntlm_credentials.connection_parameters())
 
 
 # Context managers

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -238,27 +238,32 @@ class TestCredentials(QiskitTestCase):
         self.assertEqual(len(credentials), 1)
         self.assertEqual(list(credentials.values())[0].token, 'QCONFIG_TOKEN')
 
+
+class TestCredentialsKwargs(QiskitTestCase):
+    """Test for `Credentials.connection_parameters()`."""
+
     def test_no_proxy_params(self):
         """Test when no proxy parameters are passed."""
-        no_params_expected_result = {'verify': True, 'proxies': None, 'auth': None}
+        no_params_expected_result = {'verify': True}
         no_params_credentials = Credentials('dummy_token', 'https://dummy_url')
-        result = dict(no_params_credentials.connection_parameters())
+        result = no_params_credentials.connection_parameters()
         self.assertDictEqual(no_params_expected_result, result)
 
     def test_verify_param(self):
         """Test 'verify' arg is acknowledged."""
-        false_verify_expected_result = {'verify': False, 'proxies': None, 'auth': None}
-        false_verify_credentials = Credentials('dummy_token', 'https://dummy_url', verify=False)
-        result = dict(false_verify_credentials.connection_parameters())
+        false_verify_expected_result = {'verify': False}
+        false_verify_credentials = Credentials(
+            'dummy_token', 'https://dummy_url', verify=False)
+        result = false_verify_credentials.connection_parameters()
         self.assertDictEqual(false_verify_expected_result, result)
 
     def test_proxy_param(self):
         """Test using only proxy urls (no NTLM credentials)."""
         urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
-        proxies_only_expected_result = {'verify': True, 'proxies': urls, 'auth': None}
+        proxies_only_expected_result = {'verify': True, 'proxies': urls}
         proxies_only_credentials = Credentials(
             'dummy_token', 'https://dummy_url', proxies={'urls': urls})
-        result = dict(proxies_only_credentials.connection_parameters())
+        result = proxies_only_credentials.connection_parameters()
         self.assertDictEqual(proxies_only_expected_result, result)
 
     def test_proxies_param_with_ntlm(self):
@@ -276,7 +281,7 @@ class TestCredentials(QiskitTestCase):
         }
         proxies_with_ntlm_credentials = Credentials(
             'dummy_token', 'https://dummy_url', proxies=proxies_with_ntlm_dict)
-        result = dict(proxies_with_ntlm_credentials.connection_parameters())
+        result = proxies_with_ntlm_credentials.connection_parameters()
 
         # verify the NTLM credentials
         self.assertEqual(
@@ -284,7 +289,7 @@ class TestCredentials(QiskitTestCase):
         self.assertEqual(
             ntlm_expected_result['auth'].password, result['auth'].password)
 
-        # remove the NTLM HttpNtlmAuth objects for direct comparison of the dicts
+        # remove the HttpNtlmAuth objects for direct comparison of the dicts
         ntlm_expected_result.pop('auth')
         result.pop('auth')
         self.assertDictEqual(ntlm_expected_result, result)
@@ -294,7 +299,8 @@ class TestCredentials(QiskitTestCase):
         urls = {'http': 'localhost:8080', 'https': 'localhost:8080'}
         malformed_nested_proxies_dict = {'proxies': urls}
         malformed_nested_credentials = Credentials(
-            'dummy_token', 'https://dummy_url', proxies=malformed_nested_proxies_dict)
+            'dummy_token', 'https://dummy_url',
+            proxies=malformed_nested_proxies_dict)
         with self.assertRaises(KeyError):
             _ = dict(malformed_nested_credentials.connection_parameters())
 
@@ -307,7 +313,8 @@ class TestCredentials(QiskitTestCase):
             'password_ntlm': 5678
         }
         malformed_ntlm_credentials = Credentials(
-            'dummy_token', 'https://dummy_url', proxies=malformed_ntlm_credentials_dict)
+            'dummy_token', 'https://dummy_url',
+            proxies=malformed_ntlm_credentials_dict)
         # should raise when trying to do username.split('\\', <int>)
         # in NTLM credentials due to int not facilitating 'split'
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add a test for Credentials.connection_parameters covering various proxy configurations. Addresses #182.