### PR TITLE
Slightly bump tolerance for certain `IBMQQasmSimulator` tests

### DIFF
--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -43,7 +43,7 @@ class TestIbmqQasmSimulator(QiskitTestCase):
         result = job.result()
         counts = result.get_counts(qc)
         target = {'0': shots / 2, '1': shots / 2}
-        threshold = 0.04 * shots
+        threshold = 0.05 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
 
     @requires_qe_access
@@ -73,7 +73,7 @@ class TestIbmqQasmSimulator(QiskitTestCase):
         target1 = {'00': shots / 4, '01': shots / 4,
                    '10': shots / 4, '11': shots / 4}
         target2 = {'00': shots / 2, '11': shots / 2}
-        threshold = 0.04 * shots
+        threshold = 0.05 * shots
         self.assertDictAlmostEqual(counts1, target1, threshold)
         self.assertDictAlmostEqual(counts2, target2, threshold)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Slightly bump tolerance for `test_execute_one_circuit_simulator_online` and `test_execute_several_circuits_simulator_online` from `0.04` to `0.05`. Fixes #190.