### PR TITLE
Fix cancel for v2

### DIFF
--- a/qiskit/providers/ibmq/api_v2/rest/job.py
+++ b/qiskit/providers/ibmq/api_v2/rest/job.py
@@ -24,7 +24,7 @@ class Job(RestAdapterBase):
 
     URL_MAP = {
         'callback_upload': '/jobDataUploaded',
-        'cancel': 'cancel',
+        'cancel': '/cancel',
         'download_url': '/jobDownloadUrl',
         'self': '',
         'status': '/status',

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -264,6 +264,10 @@ class IBMQJob(BaseJob):
     def cancel(self):
         """Attempt to cancel a job.
 
+        Note:
+            This function waits for a job ID to become available if the job
+            has been submitted but not yet queued.
+
         Returns:
             bool: True if job can be cancelled, else False. Note this operation
             might not be possible depending on the environment.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -271,6 +271,9 @@ class IBMQJob(BaseJob):
         Raises:
             JobError: if there was some unexpected failure in the server.
         """
+        # Wait for the job ID to become available.
+        self._wait_for_submission()
+
         try:
             response = self._api.cancel_job(self._job_id)
             self._cancelled = 'error' not in response
@@ -551,7 +554,7 @@ class IBMQJob(BaseJob):
         """Waits for the request to return a job ID"""
         if self._job_id is None:
             if self._future is None:
-                raise JobError("You have to submit before asking for status or results!")
+                raise JobError("You have to submit the job before doing a job related operation!")
             try:
                 submit_info = self._future.result(timeout=timeout)
                 if self._future_captured_exception is not None:

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -292,12 +292,6 @@ class TestIBMQJobStates(JobTestCase):
         with self.assertRaises(JobTimeoutError):
             job.result(timeout=0.2)
 
-    def test_cancel_while_initializing_fails(self):
-        job = self.run_with_api(CancellableAPI())
-        can_cancel = job.cancel()
-        self.assertFalse(can_cancel)
-        self.assertEqual(job.status(), JobStatus.INITIALIZING)
-
     def test_only_final_states_cause_detailed_request(self):
         from unittest import mock
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This fixes #189 . `job.cancel()` will wait for job submission to ensure a job id is available to do the cancel. 


### Details and comments
The new test case is in `test_ibmq_client_v2` but will likely be moved/refactored per #93 .
An existing test case `test_cancel_while_initializing_fails` was deleted because it looks for failure to cancel when a job is in initializing state. However, I think `job.cancel()` should wait for a job id to be available then do the cancel; otherwise the user would need to know to poll for the job status to become non initializing before calling the cancel.

