### PR TITLE
Factory with provider methods

### DIFF
--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -24,7 +24,7 @@ from .accountprovider import AccountProvider
 from .api_v2.clients import AuthClient, VersionClient
 from .credentials import Credentials
 from .exceptions import IBMQAccountError, IBMQApiUrlError, IBMQProviderError
-from .ibmqprovider import IBMQProvider, QE_URL
+from .ibmqprovider import IBMQProvider
 
 logger = logging.getLogger(__name__)
 
@@ -107,32 +107,9 @@ class IBMQFactory:
         """
         raise NotImplementedError
 
-    def save_account(self, token=None, url=QE_URL, overwrite=False, **kwargs):
-        """Save an account to disk for future use.
-
-        Args:
-            token (str): Quantum Experience or IBM Q API token. This parameter is deprecated.
-            url (str): URL for Quantum Experience or IBM Q (for IBM Q,
-                including the hub, group and project in the URL).
-                This parameter is deprecated.
-            overwrite (bool): overwrite existing credentials. This parameter is deprecated.
-            **kwargs (dict): This parameter is deprecated.
-                * proxies (dict): Proxy configuration for the API.
-                * verify (bool): If False, ignores SSL certificates errors
-
-        Raises:
-            NotImplementedError: TODO delete when implemented
-        """
-        if token is not None:
-            extra_msg = "" if self._credentials is not None else \
-                " Please use IBM Q Experience 2, which offers a single account, instead."
-            warnings.warn('save_account() will no longer take token, url, '
-                          'and other account related parameters.' + extra_msg,
-                          DeprecationWarning)
-        if self._credentials is not None:
-            raise NotImplementedError
-
-        self._v1_provider.save_account(token, url=url, overwrite=overwrite, **kwargs)
+    def save_account(self):
+        """Save an account to disk for future use."""
+        raise NotImplementedError
 
     def delete_account(self):
         """Delete saved account from disk"""
@@ -251,6 +228,9 @@ class IBMQFactory:
         Returns:
             list[dict]: a list with information about the accounts currently
                 in the session.
+
+        Raises:
+            IBMQAccountError: if the method is used with a v1 account.
         """
         if self._credentials:
             raise IBMQAccountError('active_accounts() is not available when '
@@ -272,7 +252,8 @@ class IBMQFactory:
         If no filter is passed, all accounts in the current session will be disabled.
 
         Raises:
-            IBMQAccountError: if no account matched the filter.
+            IBMQAccountError: if the method is used with a v1 account, or
+                if no account matched the filter.
         """
         if self._credentials:
             raise IBMQAccountError('disable_accounts() is not available when '
@@ -299,7 +280,8 @@ class IBMQFactory:
         3. in the `qiskitrc` configuration file
 
         Raises:
-            IBMQAccountError: if no credentials are found.
+            IBMQAccountError: if the method is used with a v1 account, or
+                if no credentials are found.
         """
         if self._credentials:
             raise IBMQAccountError('load_accounts() is not available when '
@@ -321,7 +303,8 @@ class IBMQFactory:
         If no filter is passed, all accounts will be deleted from disk.
 
         Raises:
-            IBMQAccountError: if no account matched the filter.
+            IBMQAccountError: if the method is used with a v1 account, or
+                if no account matched the filter.
         """
         if self._credentials:
             raise IBMQAccountError('delete_accounts() is not available when '
@@ -342,6 +325,9 @@ class IBMQFactory:
         Returns:
             list[dict]: a list with information about the accounts stored
                 on disk.
+
+        Raises:
+            IBMQAccountError: if the method is used with a v1 account.
         """
         if self._credentials:
             raise IBMQAccountError('stored_accounts() is not available when '

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -358,6 +358,13 @@ class IBMQFactory:
     def backends(self, name=None, filters=None, **kwargs):
         """Return all backends accessible via IBMQ provider, subject to optional filtering.
 
+        Note: this method is being deprecated. Please use v2, and::
+
+            provider = IBMQ.get_provider(...)
+            provider.backends()
+
+            instead.
+
         Args:
             name (str): backend name to filter by
             filters (callable): more complex filters, such as lambda functions
@@ -370,8 +377,8 @@ class IBMQFactory:
             list[IBMQBackend]: list of backends available that match the filter
         """
         warnings.warn('IBMQ.backends() is being deprecated. '
-                      'Please use providers() to find the desired AccountProvider and '
-                      'AccountProvider.backends() to find its backends.',
+                      'Please use IBMQ.get_provider() to retrieve a provider '
+                      'and AccountProvider.backends() to find its backends.',
                       DeprecationWarning)
 
         if self._credentials:
@@ -396,6 +403,13 @@ class IBMQFactory:
     def get_backend(self, name=None, **kwargs):
         """Return a single backend matching the specified filtering.
 
+        Note: this method is being deprecated. Please use v2, and::
+
+            provider = IBMQ.get_provider(...)
+            provider.get_backend('name')
+
+            instead.
+
         Args:
             name (str): name of the backend.
             **kwargs (dict): dict used for filtering.
@@ -407,13 +421,14 @@ class IBMQFactory:
             QiskitBackendNotFoundError: if no backend could be found or
                 more than one backend matches the filtering criteria.
         """
-        warnings.warn('IBMQ.get_backend() is being deprecated. '
-                      'Please use providers() to find the desired AccountProvider and '
-                      'AccountProvider.get_backend() to find the backend.',
+        warnings.warn('IBMQ.backends() is being deprecated. '
+                      'Please use IBMQ.get_provider() to retrieve a provider '
+                      'and AccountProvider.get_backend("name") to retrieve a '
+                      'backend.',
                       DeprecationWarning)
 
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
             backends = self.backends(name, **kwargs)
 
         if len(backends) > 1:

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -18,6 +18,8 @@ import logging
 import warnings
 from collections import OrderedDict
 
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
+
 from .accountprovider import AccountProvider
 from .api_v2.clients import AuthClient, VersionClient
 from .credentials import Credentials
@@ -249,7 +251,7 @@ class IBMQFactory:
         """
         warnings.warn('IBMQ.backends() is being deprecated. '
                       'Please use providers() to find the desired AccountProvider and '
-                      'AccountProvider.backends() to find its backends',
+                      'AccountProvider.backends() to find its backends.',
                       DeprecationWarning)
 
         if self._credentials:
@@ -270,6 +272,36 @@ class IBMQFactory:
             return backends
         else:
             return self._v1_provider.backends(name, filters, **kwargs)
+
+    def get_backend(self, name=None, **kwargs):
+        """Return a single backend matching the specified filtering.
+
+        Args:
+            name (str): name of the backend.
+            **kwargs (dict): dict used for filtering.
+
+        Returns:
+            BaseBackend: a backend matching the filtering.
+
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+                more than one backend matches the filtering criteria.
+        """
+        warnings.warn('IBMQ.get_backend() is being deprecated. '
+                      'Please use providers() to find the desired AccountProvider and '
+                      'AccountProvider.get_backend() to find the backend.',
+                      DeprecationWarning)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            backends = self.backends(name, **kwargs)
+
+        if len(backends) > 1:
+            raise QiskitBackendNotFoundError('More than one backend matches the criteria')
+        if not backends:
+            raise QiskitBackendNotFoundError('No backend matches the criteria')
+
+        return backends[0]
 
     # Provider management functions.
 

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -142,167 +142,6 @@ class IBMQFactory:
         """List the account stored on disk"""
         raise NotImplementedError
 
-    # Deprecated account management functions for backward compatibility.
-
-    def active_accounts(self):
-        """List all accounts currently in the session.
-
-        Returns:
-            list[dict]: a list with information about the accounts currently
-                in the session.
-        """
-        warnings.warn('active_accounts() is being deprecated. '
-                      'Please use IBM Q Experience 2, which offers a single account, instead.',
-                      DeprecationWarning)
-
-        if self._credentials is not None:
-            return [{
-                'token': self._credentials.token,
-                'url': self._credentials.url,
-            }]
-        else:
-            return self._v1_provider.active_accounts()
-
-    def disable_accounts(self, **kwargs):
-        """Disable accounts in the current session, subject to optional filtering.
-
-        The filter kwargs can be `token`, `url`, `hub`, `group`, `project`.
-        If no filter is passed, all accounts in the current session will be disabled.
-
-        Raises:
-            IBMQAccountError: if no account matched the filter.
-        """
-        warnings.warn('disable_accounts() is being deprecated. '
-                      'Please use IBM Q Experience 2 and disable_account() instead.',
-                      DeprecationWarning)
-
-        if self._credentials is not None:
-            self.disable_account()
-        else:
-            self._v1_provider.disable_accounts(**kwargs)
-
-    def load_accounts(self, **kwargs):
-        """Load IBMQ accounts found in the system into current session,
-        subject to optional filtering.
-
-        Automatically load the accounts found in the system. This method
-        looks for credentials in the following locations, in order, and
-        returns as soon as credentials are found:
-
-        1. in the `Qconfig.py` file in the current working directory.
-        2. in the environment variables.
-        3. in the `qiskitrc` configuration file
-
-        Raises:
-            IBMQAccountError: if no credentials are found.
-        """
-        warnings.warn('load_accounts() is being deprecated. '
-                      'Please use IBM Q Experience 2 and load_account() instead.',
-                      DeprecationWarning)
-
-        if self._credentials is not None:
-            self.load_account()
-        else:
-            self._v1_provider.load_accounts(**kwargs)
-
-    def delete_accounts(self, **kwargs):
-        """Delete saved accounts from disk, subject to optional filtering.
-
-        The filter kwargs can be `token`, `url`, `hub`, `group`, `project`.
-        If no filter is passed, all accounts will be deleted from disk.
-
-        Raises:
-            IBMQAccountError: if no account matched the filter.
-        """
-        warnings.warn('delete_accounts() is being deprecated. '
-                      'Please use IBM Q Experience 2 and delete_account() instead.',
-                      DeprecationWarning)
-        if self._credentials is not None:
-            self.delete_account()
-        else:
-            self._v1_provider.delete_accounts(**kwargs)
-
-    def stored_accounts(self):
-        """List all accounts stored to disk.
-
-        Returns:
-            list[dict]: a list with information about the accounts stored
-                on disk.
-        """
-        warnings.warn('stored_accounts() is being deprecated. '
-                      'Please use IBM Q Experience 2 and stored_account() instead.',
-                      DeprecationWarning)
-
-        return self._v1_provider.stored_accounts()
-
-    def backends(self, name=None, filters=None, **kwargs):
-        """Return all backends accessible via IBMQ provider, subject to optional filtering.
-
-        Args:
-            name (str): backend name to filter by
-            filters (callable): more complex filters, such as lambda functions
-                e.g. IBMQ.backends(filters=lambda b: b.configuration['n_qubits'] > 5)
-            kwargs: simple filters specifying a true/false criteria in the
-                backend configuration or backend status or provider credentials
-                e.g. IBMQ.backends(n_qubits=5, operational=True, hub='internal')
-
-        Returns:
-            list[IBMQBackend]: list of backends available that match the filter
-        """
-        warnings.warn('IBMQ.backends() is being deprecated. '
-                      'Please use providers() to find the desired AccountProvider and '
-                      'AccountProvider.backends() to find its backends.',
-                      DeprecationWarning)
-
-        if self._credentials:
-            hgp_filter = {}
-
-            # First filter providers by h/g/p
-            for key in ['hub', 'group', 'project']:
-                if key in kwargs:
-                    hgp_filter[key] = kwargs.pop(key)
-            providers = self.providers(**hgp_filter)
-
-            # Aggregate the list of filtered backends.
-            backends = []
-            for provider in providers:
-                backends = backends + provider.backends(
-                    name=name, filters=filters, **kwargs)
-
-            return backends
-        else:
-            return self._v1_provider.backends(name, filters, **kwargs)
-
-    def get_backend(self, name=None, **kwargs):
-        """Return a single backend matching the specified filtering.
-
-        Args:
-            name (str): name of the backend.
-            **kwargs (dict): dict used for filtering.
-
-        Returns:
-            BaseBackend: a backend matching the filtering.
-
-        Raises:
-            QiskitBackendNotFoundError: if no backend could be found or
-                more than one backend matches the filtering criteria.
-        """
-        warnings.warn('IBMQ.get_backend() is being deprecated. '
-                      'Please use providers() to find the desired AccountProvider and '
-                      'AccountProvider.get_backend() to find the backend.',
-                      DeprecationWarning)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            backends = self.backends(name, **kwargs)
-
-        if len(backends) > 1:
-            raise QiskitBackendNotFoundError('More than one backend matches the criteria')
-        if not backends:
-            raise QiskitBackendNotFoundError('No backend matches the criteria')
-
-        return backends[0]
-
     # Provider management functions.
 
     def providers(self, hub=None, group=None, project=None):
@@ -400,3 +239,186 @@ class IBMQFactory:
                 # Catch-all for errors instantiating the provider.
                 logger.warning('Unable to instantiate provider for %s: %s',
                                hub_info, ex)
+
+    # Deprecated account management functions for backward compatibility.
+
+    def active_accounts(self):
+        """List all version 1 accounts currently in the session.
+
+        Note: this method is being deprecated, and only available when using
+            v1 accounts.
+
+        Returns:
+            list[dict]: a list with information about the accounts currently
+                in the session.
+        """
+        if self._credentials:
+            raise IBMQAccountError('active_accounts() is not available when '
+                                   'using an IBM Q Experience 2 account.')
+
+        warnings.warn('active_accounts() is being deprecated. '
+                      'Please use IBM Q Experience 2, which offers a single account, instead.',
+                      DeprecationWarning)
+
+        return self._v1_provider.active_accounts()
+
+    def disable_accounts(self, **kwargs):
+        """Disable version 1 accounts in the current session.
+
+        Note: this method is being deprecated, and only available when using
+            v1 accounts.
+
+        The filter kwargs can be `token`, `url`, `hub`, `group`, `project`.
+        If no filter is passed, all accounts in the current session will be disabled.
+
+        Raises:
+            IBMQAccountError: if no account matched the filter.
+        """
+        if self._credentials:
+            raise IBMQAccountError('disable_accounts() is not available when '
+                                   'using an IBM Q Experience 2 account.')
+
+        warnings.warn('disable_accounts() is being deprecated. '
+                      'Please use IBM Q Experience 2 and disable_account() instead.',
+                      DeprecationWarning)
+
+        self._v1_provider.disable_accounts(**kwargs)
+
+    def load_accounts(self, **kwargs):
+        """Load version 1 IBMQ accounts found in the system into current session.
+
+        Note: this method is being deprecated, and only available when using
+            v1 accounts.
+
+        Automatically load the accounts found in the system. This method
+        looks for credentials in the following locations, in order, and
+        returns as soon as credentials are found:
+
+        1. in the `Qconfig.py` file in the current working directory.
+        2. in the environment variables.
+        3. in the `qiskitrc` configuration file
+
+        Raises:
+            IBMQAccountError: if no credentials are found.
+        """
+        if self._credentials:
+            raise IBMQAccountError('load_accounts() is not available when '
+                                   'using and IBM Q Experience 2 account.')
+
+        warnings.warn('load_accounts() is being deprecated. '
+                      'Please use IBM Q Experience 2 and load_account() instead.',
+                      DeprecationWarning)
+
+        self._v1_provider.load_accounts(**kwargs)
+
+    def delete_accounts(self, **kwargs):
+        """Delete saved accounts from disk, subject to optional filtering.
+
+        Note: this method is being deprecated, and only available when using
+            v1 accounts.
+
+        The filter kwargs can be `token`, `url`, `hub`, `group`, `project`.
+        If no filter is passed, all accounts will be deleted from disk.
+
+        Raises:
+            IBMQAccountError: if no account matched the filter.
+        """
+        if self._credentials:
+            raise IBMQAccountError('delete_accounts() is not available when '
+                                   'using and IBM Q Experience 2 account.')
+
+        warnings.warn('delete_accounts() is being deprecated. '
+                      'Please use IBM Q Experience 2 and delete_account() instead.',
+                      DeprecationWarning)
+
+        self._v1_provider.delete_accounts(**kwargs)
+
+    def stored_accounts(self):
+        """List all accounts stored to disk.
+
+        Note: this method is being deprecated, and only available when using
+            v1 accounts.
+
+        Returns:
+            list[dict]: a list with information about the accounts stored
+                on disk.
+        """
+        if self._credentials:
+            raise IBMQAccountError('stored_accounts() is not available when '
+                                   'using and IBM Q Experience 2 account.')
+
+        warnings.warn('stored_accounts() is being deprecated. '
+                      'Please use IBM Q Experience 2 and stored_account() instead.',
+                      DeprecationWarning)
+
+        return self._v1_provider.stored_accounts()
+
+    # Deprecated backend-related functionality.
+
+    def backends(self, name=None, filters=None, **kwargs):
+        """Return all backends accessible via IBMQ provider, subject to optional filtering.
+
+        Args:
+            name (str): backend name to filter by
+            filters (callable): more complex filters, such as lambda functions
+                e.g. IBMQ.backends(filters=lambda b: b.configuration['n_qubits'] > 5)
+            kwargs: simple filters specifying a true/false criteria in the
+                backend configuration or backend status or provider credentials
+                e.g. IBMQ.backends(n_qubits=5, operational=True, hub='internal')
+
+        Returns:
+            list[IBMQBackend]: list of backends available that match the filter
+        """
+        warnings.warn('IBMQ.backends() is being deprecated. '
+                      'Please use providers() to find the desired AccountProvider and '
+                      'AccountProvider.backends() to find its backends.',
+                      DeprecationWarning)
+
+        if self._credentials:
+            hgp_filter = {}
+
+            # First filter providers by h/g/p
+            for key in ['hub', 'group', 'project']:
+                if key in kwargs:
+                    hgp_filter[key] = kwargs.pop(key)
+            providers = self.providers(**hgp_filter)
+
+            # Aggregate the list of filtered backends.
+            backends = []
+            for provider in providers:
+                backends = backends + provider.backends(
+                    name=name, filters=filters, **kwargs)
+
+            return backends
+        else:
+            return self._v1_provider.backends(name, filters, **kwargs)
+
+    def get_backend(self, name=None, **kwargs):
+        """Return a single backend matching the specified filtering.
+
+        Args:
+            name (str): name of the backend.
+            **kwargs (dict): dict used for filtering.
+
+        Returns:
+            BaseBackend: a backend matching the filtering.
+
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+                more than one backend matches the filtering criteria.
+        """
+        warnings.warn('IBMQ.get_backend() is being deprecated. '
+                      'Please use providers() to find the desired AccountProvider and '
+                      'AccountProvider.get_backend() to find the backend.',
+                      DeprecationWarning)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            backends = self.backends(name, **kwargs)
+
+        if len(backends) > 1:
+            raise QiskitBackendNotFoundError('More than one backend matches the criteria')
+        if not backends:
+            raise QiskitBackendNotFoundError('No backend matches the criteria')
+
+        return backends[0]

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -117,6 +117,9 @@ class IBMQFactory:
             **kwargs (dict): This parameter is deprecated.
                 * proxies (dict): Proxy configuration for the API.
                 * verify (bool): If False, ignores SSL certificates errors
+
+        Raises:
+            NotImplementedError: TODO delete when implemented
         """
         if token is not None:
             extra_msg = "" if self._credentials is not None else \
@@ -126,8 +129,8 @@ class IBMQFactory:
                           DeprecationWarning)
         if self._credentials is not None:
             raise NotImplementedError
-        else:
-            self._v1_provider.save_account(token, url=url, overwrite=overwrite, **kwargs)
+
+        self._v1_provider.save_account(token, url=url, overwrite=overwrite, **kwargs)
 
     def delete_account(self):
         """Delete saved account from disk"""

--- a/test/ibmq/test_ibmq_factory.py
+++ b/test/ibmq/test_ibmq_factory.py
@@ -125,7 +125,6 @@ class TestIBMQClientAccounts(QiskitTestCase):
 
     @requires_qe_access
     @requires_classic_api
-    @skipIf(os.name == 'nt', 'Test not supported in Windows')
     def test_api1_accounts_compatibility(self, qe_token, qe_url):
         """Test backward compatibility for IBMQProvider account methods."""
         ibmq = IBMQFactory()
@@ -146,7 +145,7 @@ class TestIBMQClientAccounts(QiskitTestCase):
     @requires_classic_api
     @skipIf(os.name == 'nt', 'Test not supported in Windows')
     def test_api1_qiskitrc_compatibility(self, qe_token, qe_url):
-        """Test login into API 2 during an already logged-in API 1 account."""
+        """Test backward compatibility for IBMQProvider qiskitrc related methods."""
         ibmq = IBMQFactory()
         ibmq.enable_account(qe_token, qe_url)
 
@@ -162,6 +161,22 @@ class TestIBMQClientAccounts(QiskitTestCase):
             self.assertEqual(len(w), 4)
             for warn in w:
                 self.assertTrue(issubclass(warn.category, DeprecationWarning))
+
+    @requires_qe_access
+    @requires_classic_api
+    def test_api1_backends_compatibility(self, qe_token, qe_url):
+        """Test backward compatibility for IBMQProvider backends method."""
+        ibmq = IBMQFactory()
+        ibmq.enable_account(qe_token, qe_url)
+
+        ibmq_provider = IBMQProvider()
+        ibmq_provider.enable_account(qe_token, qe_url)
+        ibmq_provider_backend_names = [b.name() for b in ibmq_provider.backends()]
+
+        with warnings.catch_warnings(record=True) as w:
+            ibmq_backend_names = [b.name() for b in ibmq.backends()]
+            self.assertEqual(set(ibmq_backend_names), set(ibmq_provider_backend_names))
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
 
 @contextmanager

--- a/test/ibmq/test_ibmq_factory.py
+++ b/test/ibmq/test_ibmq_factory.py
@@ -163,6 +163,7 @@ class TestIBMQClientAccounts(QiskitTestCase):
             for warn in w:
                 self.assertTrue(issubclass(warn.category, DeprecationWarning))
 
+
 @contextmanager
 def custom_qiskitrc(contents=b''):
     """Context manager that uses a temporary qiskitrc."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This addresses #194 . Added the public methods of `IBMQProvider` to `IBMQFactory` for backward compatibility and a small set of tests (may be refactored/merged with `test_registration` later).

### Details and comments
A couple of things I'm on the fence about:
- instead of returning an empty list when `backends()` is called with a v2 credential, I just aggregate all the provider backends to be more backward compatible. Hopefully most users don't have that many accounts to make this a long call.
- both `IBMQProvider` and `IBMQFactory` have a `save_account()` method. The easier way is to have a new name for the `IBMQFactory` one and deprecate the old one, but that is difficult since all the method names follow a nice pattern. I ended up retaining the signature of `IBMQProvider.save_account()` but deprecating the old parameters.