### PR TITLE
Add Factory.update_account helper for credentials

### DIFF
--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -26,8 +26,8 @@ REGEX_IBMQ_HUBS = (
     '(?P<prefix>http[s]://.+/api)'
     '/Hubs/(?P<hub>[^/]+)/Groups/(?P<group>[^/]+)/Projects/(?P<project>[^/]+)'
 )
+
 # Template for creating an IBMQ URL with hub information
-# TODO: verify compatibility with old premium API
 TEMPLATE_IBMQ_HUBS = '{prefix}/Network/{hub}/Groups/{group}/Projects/{project}'
 
 

--- a/qiskit/providers/ibmq/credentials/updater.py
+++ b/qiskit/providers/ibmq/credentials/updater.py
@@ -117,12 +117,12 @@ def update_credentials(force=False):
     if final_credentials.proxies:
         print('The existing proxy configuration will be preserved.')
 
+    print('In order to access the provider, please use the new '
+          '"IBMQ.get_provider()" methods:')
+    print('\n  provider0 = IBMQ.load_account()')
     if hub_lines:
-        print('In order to access the provider, please use the new '
-              '"IBMQ.get_provider()" methods:')
-        print('\n  provider0 = IBMQ.load_account()')
         print('\n'.join(hub_lines))
-        print('  backends = provider0.backends()')
+    print('  backends = provider0.backends()')
     if warnings:
         print('\nWarnings:')
         print('\n'.join(warnings))

--- a/qiskit/providers/ibmq/credentials/updater.py
+++ b/qiskit/providers/ibmq/credentials/updater.py
@@ -32,9 +32,25 @@ QE2_AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
 def update_credentials(force=False):
     """Update or provide information about updating stored credentials.
 
+    This function is an interactive helper to update credentials stored in
+    disk from the API version 1 to the API version 2. Upon invocation, the
+    function will inspect the credentials stored in disk and attempt to
+    convert them to the new version, displaying the changes and asking for
+    confirmation before overwriting the credentials.
+
+    The function attempts to preserve the existing advanced parameters (such
+    as proxies), but has limited conflict resolution handling. For complex
+    configurations with multiple credentials, an alternative is to directly
+    clear the existing credentials via `IBMQ.delete_accounts()` and recreate
+    the configuration from the instructions at the IBM Q Experience site.
+
     Args:
         force (bool): if `True`, disable interactive prompts and perform the
             changes.
+
+    Returns:
+        Credentials: if the updating is possible, credentials for the API
+            version 2; and `None` otherwise.
     """
     # Get the list of stored credentials.
     credentials_list = list(read_credentials_from_qiskitrc().values())

--- a/qiskit/providers/ibmq/credentials/updater.py
+++ b/qiskit/providers/ibmq/credentials/updater.py
@@ -63,7 +63,7 @@ def update_credentials(force=False):
     # Parse the credentials found.
     for credentials in credentials_list:
         if is_directly_updatable(credentials):
-            # Credentials for known URLs without
+            # Credentials can be updated to the new URL directly.
             new_credentials.append(Credentials(credentials.token, QE2_AUTH_URL,
                                                proxies=credentials.proxies,
                                                verify=credentials.verify))
@@ -96,7 +96,7 @@ def update_credentials(force=False):
         print('No credentials available for updating could be found. No '
               'action will be performed.')
         if warnings:
-            print('Details:')
+            print('Warnings:')
             print('\n'.join(warnings))
 
         return None
@@ -117,15 +117,16 @@ def update_credentials(force=False):
     if final_credentials.proxies:
         print('The existing proxy configuration will be preserved.')
 
-    print('In order to access the provider, please use the new '
+    if warnings:
+        print('\nWarnings:')
+        print('\n'.join(warnings))
+
+    print('\nIn order to access the provider, please use the new '
           '"IBMQ.get_provider()" methods:')
     print('\n  provider0 = IBMQ.load_account()')
     if hub_lines:
         print('\n'.join(hub_lines))
     print('  backends = provider0.backends()')
-    if warnings:
-        print('\nWarnings:')
-        print('\n'.join(warnings))
 
     # Ask for confirmation from the user.
     if not force:

--- a/qiskit/providers/ibmq/credentials/updater.py
+++ b/qiskit/providers/ibmq/credentials/updater.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Helper for updating credentials from API 1 to API 2."""
+
+from .credentials import Credentials
+from .configrc import read_credentials_from_qiskitrc
+
+
+QE_URL = 'https://quantumexperience.ng.bluemix.net/api'
+QCONSOLE_URL = 'https://q-console-api.mybluemix.net/api'
+
+QE2_URL = 'https://api.quantum-computing.ibm.com/api'
+QCONSOLE2_URL = 'https://api-qcon.quantum-computing.ibm.com/api'
+
+QE2_AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
+
+
+def update_credentials(force=False):
+    """Update or provide information about updating stored credentials.
+
+    Args:
+        force (bool): if `True`, disable interactive prompts and perform the
+            changes.
+    """
+    # Get the list of stored credentials.
+    credentials_list = list(read_credentials_from_qiskitrc().values())
+
+    new_credentials = []
+    hub_lines = []
+    warnings = []
+    provider_number = 1
+    first_converted_url = None
+
+    # Parse the credentials found.
+    for credentials in credentials_list:
+        if is_directly_updatable(credentials):
+            new_credentials.append(Credentials(credentials.token, QE2_AUTH_URL,
+                                               proxies=credentials.proxies,
+                                               verify=credentials.verify))
+            if not first_converted_url:
+                first_converted_url = credentials.url
+        else:
+            if credentials.is_ibmq():
+                new_credentials.append(Credentials(credentials.token,
+                                                   QE2_AUTH_URL,
+                                                   proxies=credentials.proxies,
+                                                   verify=credentials.verify))
+                if not first_converted_url:
+                    first_converted_url = credentials.url
+
+                hub_lines.append(
+                    "provider{} = IBMQ.get_provider(hub='{}', group='{}',"
+                    "project='{})".format(provider_number,
+                                          credentials.hub,
+                                          credentials.group,
+                                          credentials.project))
+                provider_number += 1
+            else:
+                # Unknown URL - do not act on it.
+                warnings.append('The stored account with url "{}" could not be '
+                                'parsed and will be discarded.')
+
+    # Check if any of the meaningful fields differ.
+    tuples = [(credentials.token, credentials.proxies, credentials.verify)
+              for credentials in new_credentials]
+
+    if not all(field_tuple==tuples[0] for field_tuple in tuples):
+        warnings.append("The credentials stored differ in several fields. The "
+                        "conversion will use the settings previously stored "
+                        "for the v1 account at '{}'.".format(first_converted_url))
+
+    return credentials_list
+
+
+def is_directly_updatable(credentials):
+    """Returns `True` if credentials can be updated directly."""
+    if credentials.base_url in (QE_URL, QE2_AUTH_URL):
+        return True
+
+    if credentials.base_url in (QCONSOLE_URL, QE2_URL, QCONSOLE2_URL):
+        if credentials.base_url == credentials.url:
+            return True
+
+    return False

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -19,10 +19,11 @@ import warnings
 from collections import OrderedDict
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+from qiskit.providers.ibmq.credentials.updater import update_credentials
 
 from .accountprovider import AccountProvider
 from .api_v2.clients import AuthClient, VersionClient
-from .credentials import Credentials
+from .credentials import Credentials, discover_credentials
 from .exceptions import IBMQAccountError, IBMQApiUrlError, IBMQProviderError
 from .ibmqprovider import IBMQProvider
 
@@ -118,6 +119,20 @@ class IBMQFactory:
     def stored_account(self):
         """List the account stored on disk"""
         raise NotImplementedError
+
+    @staticmethod
+    def update_account(force=False):
+        """Interactive helper from migrating stored credentials to API 2.
+
+        Args:
+            force (bool): if `True`, disable interactive prompts and perform
+                the changes.
+
+        Returns:
+            Credentials: if the updating is possible, credentials for the API
+            version 2; and `None` otherwise.
+        """
+        return update_credentials(force)
 
     # Provider management functions.
 
@@ -230,7 +245,7 @@ class IBMQFactory:
                 in the session.
 
         Raises:
-            IBMQAccountError: if the method is used with a v1 account.
+            IBMQAccountError: if the method is used with a v2 account.
         """
         if self._credentials:
             raise IBMQAccountError('active_accounts() is not available when '
@@ -252,7 +267,7 @@ class IBMQFactory:
         If no filter is passed, all accounts in the current session will be disabled.
 
         Raises:
-            IBMQAccountError: if the method is used with a v1 account, or
+            IBMQAccountError: if the method is used with a v2 account, or
                 if no account matched the filter.
         """
         if self._credentials:
@@ -280,12 +295,23 @@ class IBMQFactory:
         3. in the `qiskitrc` configuration file
 
         Raises:
-            IBMQAccountError: if the method is used with a v1 account, or
+            IBMQAccountError: if the method is used with a v2 account, or
                 if no credentials are found.
+            IBMQApiUrlError: if any of the credentials stored belong to API 2.
         """
         if self._credentials:
             raise IBMQAccountError('load_accounts() is not available when '
-                                   'using and IBM Q Experience 2 account.')
+                                   'using an IBM Q Experience 2 account.')
+
+        # Check if any stored credentials are from API v2.
+        for credentials in discover_credentials().values():
+            version_info = self._check_api_version(credentials)
+            if version_info['new_api']:
+                raise IBMQApiUrlError(
+                    'Credentials for API 2 have been found. Please use '
+                    'IBMQ.update_account() for updating your stored '
+                    'credentials, and IBMQ.load_account() (in singular form) '
+                    'for using an API 2 account.')
 
         warnings.warn('load_accounts() is being deprecated. '
                       'Please use IBM Q Experience 2 and load_account() instead.',
@@ -303,12 +329,12 @@ class IBMQFactory:
         If no filter is passed, all accounts will be deleted from disk.
 
         Raises:
-            IBMQAccountError: if the method is used with a v1 account, or
+            IBMQAccountError: if the method is used with a v2 account, or
                 if no account matched the filter.
         """
         if self._credentials:
             raise IBMQAccountError('delete_accounts() is not available when '
-                                   'using and IBM Q Experience 2 account.')
+                                   'using an IBM Q Experience 2 account.')
 
         warnings.warn('delete_accounts() is being deprecated. '
                       'Please use IBM Q Experience 2 and delete_account() instead.',
@@ -327,11 +353,11 @@ class IBMQFactory:
                 on disk.
 
         Raises:
-            IBMQAccountError: if the method is used with a v1 account.
+            IBMQAccountError: if the method is used with a v2 account.
         """
         if self._credentials:
             raise IBMQAccountError('stored_accounts() is not available when '
-                                   'using and IBM Q Experience 2 account.')
+                                   'using an IBM Q Experience 2 account.')
 
         warnings.warn('stored_accounts() is being deprecated. '
                       'Please use IBM Q Experience 2 and stored_account() instead.',

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -345,7 +345,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
         # Reenable stdout output.
         self.patcher.stop()
 
-    def assertCorrectApi2Credentials(self, credentials_dict):
+    def assertCorrectApi2Credentials(self, token, credentials_dict):
         """Asserts that there is only one credentials belonging to API 2."""
         self.assertEqual(len(credentials_dict), 1)
         credentials = list(credentials_dict.values())[0]
@@ -353,6 +353,8 @@ class TestIBMQAccountUpdater(QiskitTestCase):
         self.assertIsNone(credentials.hub)
         self.assertIsNone(credentials.group)
         self.assertIsNone(credentials.project)
+        if token:
+            self.assertEqual(credentials.token, token)
 
     def test_qe_credentials(self):
         """Test converting QE credentials."""
@@ -362,7 +364,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertCorrectApi2Credentials(loaded_accounts)
+            self.assertCorrectApi2Credentials('A', loaded_accounts)
 
     def test_qconsole_credentials(self):
         """Test converting Qconsole credentials."""
@@ -373,7 +375,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertCorrectApi2Credentials(loaded_accounts)
+            self.assertCorrectApi2Credentials('A', loaded_accounts)
 
     def test_proxy_credentials(self):
         """Test converting credentials with proxy values."""
@@ -385,7 +387,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertCorrectApi2Credentials(loaded_accounts)
+            self.assertCorrectApi2Credentials('A', loaded_accounts)
 
             # Extra assert on preserving proxies.
             credentials = list(loaded_accounts.values())[0]
@@ -404,7 +406,9 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertCorrectApi2Credentials(loaded_accounts)
+            # We don't assert over the token, as it depends on the order of
+            # the qiskitrc, which is not guaranteed.
+            self.assertCorrectApi2Credentials(None, loaded_accounts)
 
     def test_api2_non_auth_credentials(self):
         """Test converting api 2 non auth credentials."""
@@ -414,7 +418,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertCorrectApi2Credentials(loaded_accounts)
+            self.assertCorrectApi2Credentials('A', loaded_accounts)
 
     def test_auth2_credentials(self):
         """Test converting already API 2 auth credentials."""

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -16,6 +16,7 @@
 
 import os
 import warnings
+from io import StringIO
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from unittest import skipIf
@@ -334,7 +335,17 @@ class TestIBMQAccountUpdater(QiskitTestCase):
         # Reference for saving accounts.
         self.ibmq = IBMQProvider()
 
-    def assertSingleCredentialWithApi2Url(self, credentials_dict):
+        # Avoid stdout output during tests.
+        self.patcher = patch('sys.stdout', new=StringIO())
+        self.patcher.start()
+
+    def tearDown(self):
+        super().tearDown()
+
+        # Reenable stdout output.
+        self.patcher.stop()
+
+    def assertCorrectApi2Credentials(self, credentials_dict):
         """Asserts that there is only one credentials belonging to API 2."""
         self.assertEqual(len(credentials_dict), 1)
         credentials = list(credentials_dict.values())[0]
@@ -351,7 +362,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertSingleCredentialWithApi2Url(loaded_accounts)
+            self.assertCorrectApi2Credentials(loaded_accounts)
 
     def test_qconsole_credentials(self):
         """Test converting Qconsole credentials."""
@@ -362,7 +373,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertSingleCredentialWithApi2Url(loaded_accounts)
+            self.assertCorrectApi2Credentials(loaded_accounts)
 
     def test_proxy_credentials(self):
         """Test converting credentials with proxy values."""
@@ -374,7 +385,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertSingleCredentialWithApi2Url(loaded_accounts)
+            self.assertCorrectApi2Credentials(loaded_accounts)
 
             # Extra assert on preserving proxies.
             credentials = list(loaded_accounts.values())[0]
@@ -393,7 +404,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertSingleCredentialWithApi2Url(loaded_accounts)
+            self.assertCorrectApi2Credentials(loaded_accounts)
 
     def test_api2_non_auth_credentials(self):
         """Test converting api 2 non auth credentials."""
@@ -403,7 +414,7 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
             # Assert over the stored (updated) credentials.
             loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertSingleCredentialWithApi2Url(loaded_accounts)
+            self.assertCorrectApi2Credentials(loaded_accounts)
 
     def test_auth2_credentials(self):
         """Test converting already API 2 auth credentials."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #196.

Adds a `IBMQFactory.update_account` (really delegating in `credentials.updater.update_credentials`) that makes a best-effort approach of parsing the credentials stored in disk, displaying a summary of the changes, and prompts the user for overwriting the `.qiskitrc` with the proposed changes.

Some docstring tweaks for the factory and an extra check for `load_accounts()` (the deprecated one - mostly to follow up on the philosophy and prevent API2 accounts being loaded there, as there might be a few cases of users that have been experimenting with it) are included.


### Details and comments

The changes always amount to either 1 credential for the API 2 authentication API, or no changes at all. The implementation is a bit funky but tries to ensure the most common cases are covered (only 1 set of old QE credentials, combining QE/QConsole credentials, already converted credentials, etc), using `print` and trying to sprinkle some information in a user-friendly format. The function is intended to be used in an interactive session (although some minimal support for using as a library can be performed by the `force` flag), and is mostly a helper for dealing with the transition.

