### PR TITLE
AccountProvider representation

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -131,7 +131,7 @@ class AccountProvider(BaseProvider):
 
     def __repr__(self):
         credentials_info = ''
-        if self.credentials.hub:
+        if self.credentials.is_ibmq():
             credentials_info = ' ({}, {}, {})'.format(
                 self.credentials.hub, self.credentials.group, self.credentials.project)
 

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -131,10 +131,9 @@ class AccountProvider(BaseProvider):
 
     def __repr__(self):
         credentials_info = ''
-        hgp = self.credentials.unique_id()
-        if hgp.hub:
+        if self.credentials.hub:
             credentials_info = ' ({}, {}, {})'.format(
-                hgp.hub, hgp.group, hgp.project)
+                self.credentials.hub, self.credentials.group, self.credentials.project)
 
         return "<{} for IBMQ{}>".format(
             self.__class__.__name__, credentials_info)

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -128,3 +128,13 @@ class AccountProvider(BaseProvider):
 
     def __eq__(self, other):
         return self.credentials == other.credentials
+
+    def __repr__(self):
+        credentials_info = ''
+        hgp = self.credentials.unique_id()
+        if hgp.hub:
+            credentials_info = ' ({}, {}, {})'.format(
+                hgp.hub, hgp.group, hgp.project)
+
+        return "<{} for IBMQ{}>".format(
+            self.__class__.__name__, credentials_info)

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -130,10 +130,9 @@ class AccountProvider(BaseProvider):
         return self.credentials == other.credentials
 
     def __repr__(self):
-        credentials_info = ''
-        if self.credentials.is_ibmq():
-            credentials_info = ' ({}, {}, {})'.format(
-                self.credentials.hub, self.credentials.group, self.credentials.project)
+        credentials_info = '{}, {}, {}'.format(self.credentials.hub,
+                                               self.credentials.group,
+                                               self.credentials.project)
 
-        return "<{} for IBMQ{}>".format(
+        return "<{} for IBMQ({})>".format(
             self.__class__.__name__, credentials_info)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is for #198 . Added __repr__ for `AccountProvider`

### Details and comments
`repr(AccountProvider)` should show something like `<AccountProvider for IBMQ (defaultHub, defaultGroup, defaultProject)>`