### PR TITLE
disable, save, and stored account

### DIFF
--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -16,6 +16,9 @@
 
 import os
 from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
+from qiskit.providers.ibmq.credentials import configrc
 
 
 @contextmanager
@@ -56,3 +59,21 @@ def no_envs(vars_to_remove):
     finally:
         # Restore the original `os.environ`.
         os.environ = os_environ_original
+
+
+@contextmanager
+def custom_qiskitrc(contents=b''):
+    """Context manager that uses a temporary qiskitrc."""
+    # Create a temporary file with the contents.
+    tmp_file = NamedTemporaryFile()
+    tmp_file.write(contents)
+    tmp_file.flush()
+
+    # Temporarily modify the default location of the qiskitrc file.
+    default_qiskitrc_file_original = configrc.DEFAULT_QISKITRC_FILE
+    configrc.DEFAULT_QISKITRC_FILE = tmp_file.name
+    yield
+
+    # Delete the temporary file and restore the default location.
+    tmp_file.close()
+    configrc.DEFAULT_QISKITRC_FILE = default_qiskitrc_file_original

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -25,7 +25,7 @@ from requests_ntlm import HttpNtlmAuth
 
 from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.ibmq.credentials import (
-    Credentials, configrc, discover_credentials, qconfig,
+    Credentials, discover_credentials, qconfig,
     read_credentials_from_qiskitrc, store_credentials)
 from qiskit.providers.ibmq.credentials.environ import VARIABLES_MAP
 from qiskit.providers.ibmq.credentials.updater import update_credentials, QE2_AUTH_URL, QE2_URL
@@ -34,7 +34,7 @@ from qiskit.providers.ibmq.ibmqprovider import QE_URL, IBMQProvider
 from qiskit.providers.ibmq.ibmqsingleprovider import IBMQSingleProvider
 from qiskit.test import QiskitTestCase
 
-from ..contextmanagers import custom_envs, no_envs
+from ..contextmanagers import custom_envs, no_envs, custom_qiskitrc
 
 IBMQ_TEMPLATE = 'https://localhost/api/Hubs/{}/Groups/{}/Projects/{}'
 
@@ -459,24 +459,6 @@ def no_file(filename):
     patcher.start()
     yield
     patcher.stop()
-
-
-@contextmanager
-def custom_qiskitrc(contents=b''):
-    """Context manager that uses a temporary qiskitrc."""
-    # Create a temporary file with the contents.
-    tmp_file = NamedTemporaryFile()
-    tmp_file.write(contents)
-    tmp_file.flush()
-
-    # Temporarily modify the default location of the qiskitrc file.
-    default_qiskitrc_file_original = configrc.DEFAULT_QISKITRC_FILE
-    configrc.DEFAULT_QISKITRC_FILE = tmp_file.name
-    yield
-
-    # Delete the temporary file and restore the default location.
-    tmp_file.close()
-    configrc.DEFAULT_QISKITRC_FILE = default_qiskitrc_file_original
 
 
 @contextmanager


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This addresses #193. 


### Details and comments
Since the signature for `save_account` remains the same as IBMQProvider, I think we should take v1 token and issue a warning, similar to what we do with `enable_account`.

