### PR TITLE
Add IBMQFactory.load_account()

### DIFF
--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -107,20 +107,47 @@ class IBMQFactory:
                                    'Please use IBMQ.disable_accounts() to '
                                    'disable the account.')
 
-        if self._credentials is not None:
-            self._credentials = None
-            self._providers = OrderedDict()
-
-        else:
+        if not self._credentials:
             raise IBMQAccountError('No account is in use for this session.')
+
+        self._credentials = None
+        self._providers = OrderedDict()
 
     def load_account(self):
         """Authenticate against IBM Q Experience from stored credentials.
 
         Returns:
             AccountProvider: the provider for the default open access project.
+
+        Raises:
+            IBMQAccountError: if an IBM Q Experience 1 account is already in
+                use, or no IBM Q Experience 2 accounts can be found.
         """
-        raise NotImplementedError
+        if self._credentials:
+            # For convention, emit a warning instead of raising.
+            warnings.warn('Credentials are already in use.')
+
+        # Prevent mixing API 1 and API 2 credentials.
+        if self._v1_provider.active_accounts():
+            raise IBMQAccountError('An IBM Q Experience 1 account is '
+                                   'already enabled.')
+
+        # Check for valid credentials.
+        credentials_list = list(discover_credentials().values())
+
+        if not credentials_list:
+            raise IBMQAccountError('No IBMQ credentials found on disk.')
+
+        if len(credentials_list) > 1 or credentials_list[0].url != QX_AUTH_URL:
+            raise IBMQAccountError('Credentials from the API 1 found. Please use '
+                                   'IBMQ.update_account() for updating your '
+                                   'stored credentials.')
+
+        # Initialize the API 2 providers.
+        credentials = credentials_list[0]
+        self._initialize_providers(credentials)
+
+        return self.providers()[0]
 
     @staticmethod
     def save_account(token, url=QX_AUTH_URL, overwrite=False, **kwargs):
@@ -379,6 +406,8 @@ class IBMQFactory:
 
         # Check if any stored credentials are from API v2.
         for credentials in discover_credentials().values():
+            # Explicitly check via an API call, to prevent credentials that
+            # contain API 2 URL (but not auth) slipping through.
             version_info = self._check_api_version(credentials)
             if version_info['new_api']:
                 raise IBMQApiUrlError(

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -93,7 +93,13 @@ class IBMQFactory:
         # Initialize the API 2 providers.
         self._initialize_providers(credentials)
 
-        return self.providers()[0]
+        # Prevent edge case where no hubs are available.
+        providers = self.providers()
+        if not providers:
+            warnings.warn('No Hub/Group/Projects could be found.')
+            return None
+
+        return providers[0]
 
     def disable_account(self):
         """Disable the account in the current session.
@@ -162,7 +168,13 @@ class IBMQFactory:
         # Initialize the API 2 providers.
         self._initialize_providers(credentials)
 
-        return self.providers()[0]
+        # Prevent edge case where no hubs are available.
+        providers = self.providers()
+        if not providers:
+            warnings.warn('No Hub/Group/Projects could be found.')
+            return None
+
+        return providers[0]
 
     @staticmethod
     def save_account(token, url=QX_AUTH_URL, overwrite=False, **kwargs):

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -129,10 +129,6 @@ class IBMQFactory:
             IBMQAccountError: if an IBM Q Experience 1 account is already in
                 use, or no IBM Q Experience 2 accounts can be found.
         """
-        if self._credentials:
-            # For convention, emit a warning instead of raising.
-            warnings.warn('Credentials are already in use.')
-
         # Prevent mixing API 1 and API 2 credentials.
         if self._v1_provider.active_accounts():
             raise IBMQAccountError('An IBM Q Experience 1 account is '
@@ -166,6 +162,12 @@ class IBMQFactory:
                                    'updating your stored credentials.')
 
         # Initialize the API 2 providers.
+        if self._credentials:
+            # For convention, emit a warning instead of raising.
+            warnings.warn('Credentials are already in use. The existing '
+                          'account in the session will be replaced.')
+            self.disable_account()
+
         self._initialize_providers(credentials)
 
         # Prevent edge case where no hubs are available.

--- a/test/ibmq/test_ibmq_factory.py
+++ b/test/ibmq/test_ibmq_factory.py
@@ -28,7 +28,8 @@ from qiskit.test import QiskitTestCase
 from ..decorators import (requires_qe_access,
                           requires_new_api_auth,
                           requires_classic_api)
-from ..contextmanagers import custom_qiskitrc
+from ..contextmanagers import (custom_qiskitrc, no_file, no_envs,
+                               CREDENTIAL_ENV_VARS)
 
 
 API1_URL = 'https://quantumexperience.ng.bluemix.net/api'
@@ -218,3 +219,22 @@ class TestIBMQFactoryAccountsOnDisk(QiskitTestCase):
             self.provider.save_account(self.v1_token, url=API1_URL)
             with self.assertRaises(IBMQAccountError):
                 self.factory.delete_account()
+
+    @requires_qe_access
+    @requires_new_api_auth
+    def test_load_account_v2(self, qe_token, qe_url):
+        """Test saving an API 2 account."""
+        with no_file('Qconfig.py'), custom_qiskitrc(), no_envs(CREDENTIAL_ENV_VARS):
+            self.factory.save_account(qe_token, url=qe_url)
+            self.factory.load_account()
+
+        self.assertEqual(self.factory._credentials.token, qe_token)
+        self.assertEqual(self.factory._credentials.url, qe_url)
+        self.assertEqual(self.factory._v1_provider._accounts, {})
+
+    def test_load_account_v1(self):
+        """Test saving an API 1 account."""
+        with no_file('Qconfig.py'), custom_qiskitrc(), no_envs(CREDENTIAL_ENV_VARS):
+            self.provider.save_account(self.v1_token, url=API1_URL)
+            with self.assertRaises(IBMQAccountError):
+                self.factory.load_account()

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -27,14 +27,14 @@ from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.ibmq.credentials import (
     Credentials, discover_credentials, qconfig,
     read_credentials_from_qiskitrc, store_credentials)
-from qiskit.providers.ibmq.credentials.environ import VARIABLES_MAP
 from qiskit.providers.ibmq.credentials.updater import update_credentials, QE2_AUTH_URL, QE2_URL
 from qiskit.providers.ibmq.exceptions import IBMQAccountError
 from qiskit.providers.ibmq.ibmqprovider import QE_URL, IBMQProvider
 from qiskit.providers.ibmq.ibmqsingleprovider import IBMQSingleProvider
 from qiskit.test import QiskitTestCase
 
-from ..contextmanagers import custom_envs, no_envs, custom_qiskitrc
+from ..contextmanagers import custom_envs, no_envs, custom_qiskitrc, no_file, CREDENTIAL_ENV_VARS
+
 
 IBMQ_TEMPLATE = 'https://localhost/api/Hubs/{}/Groups/{}/Projects/{}'
 
@@ -44,8 +44,6 @@ PROXIES = {
         'https': 'https://user:password@127.0.0.1:5678'
     }
 }
-
-CREDENTIAL_ENV_VARS = VARIABLES_MAP.keys()
 
 
 # TODO: NamedTemporaryFiles do not support name in Windows
@@ -443,22 +441,6 @@ class TestIBMQAccountUpdater(QiskitTestCase):
 
 
 # Context managers
-
-@contextmanager
-def no_file(filename):
-    """Context manager that disallows access to a file."""
-    def side_effect(filename_):
-        """Return False for the specified file."""
-        if filename_ == filename:
-            return False
-        return isfile_original(filename_)
-
-    # Store the original `os.path.isfile` function, for mocking.
-    isfile_original = os.path.isfile
-    patcher = patch('os.path.isfile', side_effect=side_effect)
-    patcher.start()
-    yield
-    patcher.stop()
 
 
 @contextmanager


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add the last method to `IBMQFactory`. The method is relatively similar to `enable_account` but is kept separate for the moment, and attempts to follow the rationale for other methods (only allow the method to be used with `v2` accounts).

### Details and comments

In the process, added some clarifications to both `load_accounts` and `load_account` - in these two methods we perform the version check by querying the API instead of using URLs directly, to allow the tests and development against other valid urls (staging) to work as expected (it also explains the inclusion of more context managers in the test). 
