### PR TITLE
Reenable object storage

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -66,8 +66,7 @@ class IBMQBackend(BaseBackend):
         kwargs = {}
         if isinstance(self._api, BaseClient):
             # Default to using object storage and websockets for new API.
-            # TODO: reenable object storage when API is ready.
-            kwargs = {'use_object_storage': False,
+            kwargs = {'use_object_storage': True,
                       'use_websockets': True}
 
         job = IBMQJob(self, None, self._api, qobj=qobj, **kwargs)

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -444,8 +444,8 @@ class IBMQJob(BaseJob):
             except Exception as err:  # pylint: disable=broad-except
                 # Fall back to submitting the Qobj via POST if object storage
                 # failed.
-                logger.warning('Submitting the job via object storage failed: '
-                               'retrying via regular POST upload.')
+                logger.info('Submitting the job via object storage failed: '
+                            'retrying via regular POST upload.')
                 # Disable object storage for this job.
                 self._use_object_storage = False
 

--- a/test/ibmq/test_ibmq_client_v2.py
+++ b/test/ibmq/test_ibmq_client_v2.py
@@ -89,7 +89,24 @@ class TestAccountClient(QiskitTestCase):
 
         # Run the job through the IBMQClient directly using object storage.
         api = backend._api
-        job = api.job_submit_object_storage(backend_name, qobj.to_dict())
+
+        try:
+            job = api.job_submit_object_storage(backend_name, qobj.to_dict())
+        except RequestsApiError as ex:
+            response = ex.original_exception.response
+            if response.status_code == 400:
+                try:
+                    api_code = response.json()['error']['code']
+
+                    # If we reach that point, it means the backend does not
+                    # support qobject storage.
+                    self.assertEqual(api_code,
+                                     'Q_OBJECT_STORAGE_IS_NOT_ALLOWED')
+                    return
+                except (ValueError, KeyError):
+                    pass
+            raise
+
         job_id = job['id']
         self.assertEqual(job['kind'], 'q-object-external-storage')
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #64 

As the API now seems to provide a way to detect if a backend does not support object storage (at submit time), reenable support in the provider.

This includes tuning the level of the warning when it is not supported to `INFO` (as in the short term, most of the backends will not support object storage, which can turn out to be quite noisy for users), and adjust a test that depends on the backend supporting it.


### Details and comments


