### PR TITLE
Fix test context managers, individual test

### DIFF
--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -15,7 +15,7 @@
 """Context managers for using with IBMQProvider unit tests."""
 
 import os
-from contextlib import contextmanager
+from contextlib import ContextDecorator
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
@@ -25,76 +25,91 @@ from qiskit.providers.ibmq.credentials.environ import VARIABLES_MAP
 CREDENTIAL_ENV_VARS = VARIABLES_MAP.keys()
 
 
-@contextmanager
-def custom_envs(new_environ):
-    """Context manager that modifies environment variables.
+class custom_envs(ContextDecorator):
+    """Context manager that modifies environment variables."""
+    # pylint: disable=invalid-name
 
-    Args:
-        new_environ (dict): a dictionary of new environment variables to use.
-    """
-    # Remove the original variables from `os.environ`.
-    # Store the original `os.environ`.
-    os_environ_original = os.environ.copy()
-    modified_environ = {**os.environ, **new_environ}
-    try:
+    def __init__(self, new_environ):
+        """custom_envs constructor.
+
+        Args:
+            new_environ (dict): a dictionary of new environment variables to
+                use.
+        """
+        self.new_environ = new_environ
+        self.os_environ_original = os.environ.copy()
+
+    def __enter__(self):
+        # Remove the original variables from `os.environ`.
+        modified_environ = {**os.environ, **self.new_environ}
         os.environ = modified_environ
-        yield
-    finally:
-        # Restore the original `os.environ`.
-        os.environ = os_environ_original
+
+    def __exit__(self, *exc):
+        os.environ = self.os_environ_original
 
 
-@contextmanager
-def no_envs(vars_to_remove):
-    """Context manager that disables environment variables.
+class no_envs(ContextDecorator):
+    """Context manager that disables environment variables."""
+    # pylint: disable=invalid-name
 
-    Args:
-        vars_to_remove (list): environment variables to remove.
+    def __init__(self, vars_to_remove):
+        """no_envs constructor.
 
-    """
-    # Remove the original variables from `os.environ`.
-    # Store the original `os.environ`.
-    os_environ_original = os.environ.copy()
-    modified_environ = {key: value for key, value in os.environ.items()
-                        if key not in vars_to_remove}
-    try:
+        Args:
+            vars_to_remove (list): environment variables to remove.
+        """
+        self.vars_to_remove = vars_to_remove
+        self.os_environ_original = os.environ.copy()
+
+    def __enter__(self):
+        # Remove the original variables from `os.environ`.
+        modified_environ = {key: value for key, value in os.environ.items()
+                            if key not in self.vars_to_remove}
         os.environ = modified_environ
-        yield
-    finally:
-        # Restore the original `os.environ`.
-        os.environ = os_environ_original
+
+    def __exit__(self, *exc):
+        os.environ = self.os_environ_original
 
 
-@contextmanager
-def custom_qiskitrc(contents=b''):
+class custom_qiskitrc(ContextDecorator):
     """Context manager that uses a temporary qiskitrc."""
-    # Create a temporary file with the contents.
-    tmp_file = NamedTemporaryFile()
-    tmp_file.write(contents)
-    tmp_file.flush()
+    # pylint: disable=invalid-name
 
-    # Temporarily modify the default location of the qiskitrc file.
-    default_qiskitrc_file_original = configrc.DEFAULT_QISKITRC_FILE
-    configrc.DEFAULT_QISKITRC_FILE = tmp_file.name
-    yield
+    def __init__(self, contents=b''):
+        # Create a temporary file with the contents.
+        self.tmp_file = NamedTemporaryFile()
+        self.tmp_file.write(contents)
+        self.tmp_file.flush()
+        self.default_qiskitrc_file_original = configrc.DEFAULT_QISKITRC_FILE
 
-    # Delete the temporary file and restore the default location.
-    tmp_file.close()
-    configrc.DEFAULT_QISKITRC_FILE = default_qiskitrc_file_original
+    def __enter__(self):
+        # Temporarily modify the default location of the qiskitrc file.
+        configrc.DEFAULT_QISKITRC_FILE = self.tmp_file.name
+
+    def __exit__(self, *exc):
+        # Delete the temporary file and restore the default location.
+        self.tmp_file.close()
+        configrc.DEFAULT_QISKITRC_FILE = self.default_qiskitrc_file_original
 
 
-@contextmanager
-def no_file(filename):
+class no_file(ContextDecorator):
     """Context manager that disallows access to a file."""
-    def side_effect(filename_):
-        """Return False for the specified file."""
-        if filename_ == filename:
-            return False
-        return isfile_original(filename_)
+    # pylint: disable=invalid-name
 
-    # Store the original `os.path.isfile` function, for mocking.
-    isfile_original = os.path.isfile
-    patcher = patch('os.path.isfile', side_effect=side_effect)
-    patcher.start()
-    yield
-    patcher.stop()
+    def __init__(self, filename):
+        self.filename = filename
+        # Store the original `os.path.isfile` function, for mocking.
+        self.isfile_original = os.path.isfile
+        self.patcher = patch('os.path.isfile', side_effect=self.side_effect)
+
+    def __enter__(self):
+        self.patcher.start()
+
+    def __exit__(self, *exc):
+        self.patcher.stop()
+
+    def side_effect(self, filename_):
+        """Return False for the specified file."""
+        if filename_ == self.filename:
+            return False
+        return self.isfile_original(filename_)

--- a/test/ibmq/test_ibmq_factory.py
+++ b/test/ibmq/test_ibmq_factory.py
@@ -20,7 +20,7 @@ from unittest import skipIf
 
 from qiskit.providers.ibmq.accountprovider import AccountProvider
 from qiskit.providers.ibmq.exceptions import IBMQAccountError, IBMQApiUrlError
-from qiskit.providers.ibmq.ibmqfactory import IBMQFactory
+from qiskit.providers.ibmq.ibmqfactory import IBMQFactory, QX_AUTH_URL
 from qiskit.providers.ibmq.ibmqprovider import IBMQProvider
 
 from ..ibmqtestcase import IBMQTestCase
@@ -223,6 +223,10 @@ class TestIBMQFactoryAccountsOnDisk(IBMQTestCase):
     @requires_new_api_auth
     def test_load_account_v2(self, qe_token, qe_url):
         """Test saving an API 2 account."""
+        if qe_url != QX_AUTH_URL:
+            # .save_account() expects an auth 2 production URL.
+            self.skipTest('Test requires production auth URL')
+
         with no_file('Qconfig.py'), custom_qiskitrc(), no_envs(CREDENTIAL_ENV_VARS):
             self.factory.save_account(qe_token, url=qe_url)
             self.factory.load_account()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is a result of testing the changes in #192 against v2, getting them to pass (except for the 17 ones that depend on #197).

There was only one test failing when using staging, that caused the context managers to exit ungracefully and not be cleaned up. In this PR:
* the context managers are moved to `ContextDecorator`, allowing better usage of enter/exit and preventing side effects
* `test_load_account_v2` is skipped conditionally if using staging.


### Details and comments


