### PR TITLE
Fix requires_qe_access in test_proxies

### DIFF
--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -23,10 +23,9 @@ from requests.exceptions import ProxyError
 from qiskit.providers.ibmq.api_v2.clients import (AuthClient,
                                                   VersionClient)
 from qiskit.providers.ibmq.api_v2.exceptions import RequestsApiError
-from qiskit.test import requires_qe_access
 
 from ..ibmqtestcase import IBMQTestCase
-from ..decorators import requires_new_api_auth
+from ..decorators import requires_qe_access, requires_new_api_auth
 
 
 ADDRESS = '127.0.0.1'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix the import of `requires_qe_access` in `test_proxies.py`, which was causing the tests to be skipped in the travis CI new API job.

### Details and comments


