### PR TITLE
Update travis in order to use API v2 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,7 @@ stage_osx: &stage_osx
 stages:
   - lint and pure python test
   - test
-  - ibmq
-  - new api
+  - old api
   - slow tests
 
 # Define the job matrix explicitly, as matrix expansion causes issues when
@@ -147,24 +146,23 @@ jobs:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.7.2
 
-    # "ibmq" stage
+    # "old api" stage
     ###########################################################################
-    # GNU/Linux, Python 3.6, against IBM Q
-    - stage: ibmq
+    # GNU/Linux, Python 3.6, against Qconsole v1
+    - stage: old api
+      name: Python 3.6 API v1 QConsole
       <<: *stage_linux
       if: branch = master and repo = Qiskit/qiskit-ibmq-provider and type = push
       python: 3.6
       env: USE_ALTERNATE_ENV_CREDENTIALS=True
 
-    # "new api" stage
-    ###########################################################################
-    # GNU/Linux, Python 3.6, against IBM Q using the API 2
-    - stage: new api
-      name: Python 3.6 API 2
+    # GNU/Linux, Python 3.6, against QE v1
+    - stage: old api
+      name: Python 3.6 API v1 QE
       <<: *stage_linux
       if: branch = master and repo = Qiskit/qiskit-ibmq-provider and type = push
       python: 3.6
-      env: USE_NEW_API_URL=True
+      env: QE_URL="https://quantumexperience.ng.bluemix.net/api"
 
     # "slow tests" stage
     ###########################################################################
@@ -177,7 +175,3 @@ jobs:
       script:
         # effectively increases timeout to 2h.
         - travis_wait 120 make test
-
-matrix:
-  allow_failures:
-  - name: Python 3.6 API 2

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -19,7 +19,7 @@ from functools import wraps
 from unittest import SkipTest
 
 from qiskit.test.testing_options import get_test_options
-from qiskit.providers.ibmq.ibmqfactory import IBMQFactory, QX_AUTH_URL
+from qiskit.providers.ibmq.ibmqfactory import IBMQFactory
 from qiskit.providers.ibmq.credentials import (Credentials,
                                                discover_credentials)
 
@@ -158,12 +158,6 @@ def _get_credentials():
         # load them from different environment variables. This assumes they
         # will always be in place, as is used by the Travis setup.
         return Credentials(os.getenv('IBMQ_TOKEN'), os.getenv('IBMQ_URL'))
-
-    if os.getenv('USE_NEW_API_URL', ''):
-        # Special case: instead of using the standard credentials mechanism,
-        # load the token from an environment variables and use the default
-        # API 2 authentication URL.
-        return Credentials(os.getenv('QE_TOKEN'), QX_AUTH_URL)
 
     # Attempt to read the standard credentials.
     discovered_credentials = discover_credentials()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #96

Combined with updating the default URL in travis, this PR makes the regular jobs in `master` to use the new API by default, and modifies the last stage in order to keep two jobs against the old api (one for QE, one for Qconsole).

### Details and comments


