### PR TITLE
Remove asserts over id for job_statuses tests

### DIFF
--- a/test/ibmq/test_account_client_v2.py
+++ b/test/ibmq/test_account_client_v2.py
@@ -328,19 +328,16 @@ class TestAccountClientJobs(IBMQTestCase):
         """Test listing job statuses with a limit."""
         jobs_raw = self.client.list_jobs_statuses(limit=1)
         self.assertEqual(len(jobs_raw), 1)
-        self.assertEqual(jobs_raw[0]['id'], self.job_id)
 
     def test_list_jobs_statuses_skip(self):
         """Test listing job statuses with an offset."""
         jobs_raw = self.client.list_jobs_statuses(limit=1, skip=1)
         self.assertEqual(len(jobs_raw), 1)
-        self.assertNotEqual(jobs_raw[0]['id'], self.job_id)
 
     def test_list_jobs_statuses_filter(self):
         """Test listing job statuses with a filter."""
         jobs_raw = self.client.list_jobs_statuses(extra_filter={'id': self.job_id})
         self.assertEqual(len(jobs_raw), 1)
-        self.assertEqual(jobs_raw[0]['id'], self.job_id)
 
 
 class TestAuthClient(IBMQTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow-up for #245, hot-fix style.

When running in travis (post #249), there is a high chance that two `TestAccountClientJobs` would be [running at the same time](https://travis-ci.com/Qiskit/qiskit-ibmq-provider/builds/118747592) (ie. in concurrent jobs), which in practice causes that the last job id retrieved might not be the one for that testcase. As a temporary measure, this PR removes the specific asserts, leaving those three tests a bit unassertive but hopefully working.

### Details and comments


