### PR TITLE
Skip pproxy tests in 3.7+

### DIFF
--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -15,8 +15,10 @@
 """Tests for the AuthClient and VersionClient proxy support."""
 
 
+from unittest import skipIf
 import urllib
 import subprocess
+import sys
 
 from requests.exceptions import ProxyError
 
@@ -35,6 +37,7 @@ INVALID_PORT_PROXIES = {'https': '{}:{}'.format(ADDRESS, '6666')}
 INVALID_ADDRESS_PROXIES = {'https': '{}:{}'.format('invalid', PORT)}
 
 
+@skipIf(sys.version_info >= (3, 7), 'pproxy version not supported in 3.7')
 class TestProxies(IBMQTestCase):
     """Tests for proxy capabilities."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Hotfix for skipping the tests that use `pproxy` in 3.7+, as the version installed is not compatible, resulting in errors for those tests that require passing through the proxy.


### Details and comments


