### PR TITLE
Allow v1 credentials in save_account

### DIFF
--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -194,6 +194,9 @@ class IBMQFactory:
     def save_account(token, url=QX_AUTH_URL, overwrite=False, **kwargs):
         """Save the account to disk for future use.
 
+        Note: IBM Q Experience v1 credentials are being deprecated. Please
+            use IBM Q Experience v2 credentials instead.
+
         Args:
             token (str): IBM Q Experience API token.
             url (str): URL for the IBM Q Experience authentication server.
@@ -201,15 +204,13 @@ class IBMQFactory:
             **kwargs (dict):
                 * proxies (dict): Proxy configuration for the API.
                 * verify (bool): If False, ignores SSL certificates errors
-
-        Raises:
-            IBMQAccountError: if attempting to save an IBM Q Experience v1
-                account.
         """
         if url != QX_AUTH_URL:
-            raise IBMQAccountError('Saving IBM Q Experience v1 credentials is '
-                                   'deprecated. Please use IBM Q Experience '
-                                   'v2 credentials instead.')
+            warnings.warn(
+                'IBM Q Experience v1 credentials are being deprecated. Please '
+                'use IBM Q Experience v2 credentials instead. You can use '
+                'IBMQ.update_account() to update your stored credentials, '
+                'if applicable.', DeprecationWarning)
 
         credentials = Credentials(token, url, **kwargs)
 

--- a/test/ibmq/test_ibmq_factory.py
+++ b/test/ibmq/test_ibmq_factory.py
@@ -166,11 +166,11 @@ class TestIBMQFactoryDeprecation(IBMQTestCase):
     @requires_classic_api
     def test_api1_load_accounts(self, qe_token, qe_url):
         """Test backward compatibility for API 1 load_accounts()."""
-        ibmq_provider = IBMQProvider()
         ibmq_factory = IBMQFactory()
 
         with no_file('Qconfig.py'), custom_qiskitrc(), no_envs(CREDENTIAL_ENV_VARS):
-            ibmq_provider.save_account(qe_token, qe_url)
+            with self.assertWarns(DeprecationWarning):
+                ibmq_factory.save_account(qe_token, qe_url)
 
             with self.assertWarns(DeprecationWarning):
                 ibmq_factory.load_accounts()
@@ -253,11 +253,6 @@ class TestIBMQFactoryAccounts(IBMQTestCase):
 
         self.assertEqual(stored_cred['token'], self.v2_token)
         self.assertEqual(stored_cred['url'], AUTH_URL)
-
-    def test_save_account_v1(self):
-        """Test saving an API 1 account."""
-        with custom_qiskitrc(), self.assertRaises(IBMQAccountError):
-            self.factory.save_account(self.v1_token, url=API1_URL)
 
     def test_stored_account_v1(self):
         """Test listing a stored API 1 account."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Issue deprecation warning instead of account error if v1 credentials are used in `save_account`.


### Details and comments


