### PR TITLE
Re-enable test.ibmq.test_proxies.TestProxies tests

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7.3 (~/Applications/miniconda3/envs/qiskit/bin/python3)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/qiskit-ibmq-provider.iml" filepath="$PROJECT_DIR$/.idea/qiskit-ibmq-provider.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/qiskit-ibmq-provider.iml
+++ b/.idea/qiskit-ibmq-provider.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.7.3 (~/Applications/miniconda3/envs/qiskit/bin/python3)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="39c615a7-6ca4-4c88-8cb0-f8db18bdf0b4" name="Default" comment="Re-enable test.ibmq.test_proxies.TestProxies tests">
+      <change beforePath="$PROJECT_DIR$/requirements-dev.txt" beforeDir="false" afterPath="$PROJECT_DIR$/requirements-dev.txt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/ibmq/test_proxies.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/ibmq/test_proxies.py" afterDir="false" />
+    </list>
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="master" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+    <option name="RESET_MODE" value="MIXED" />
+  </component>
+  <component name="ProjectId" id="1Oja5BbgJdiC0P2HiHDcb8GZ7E2" />
+  <component name="PropertiesComponent">
+    <property name="SHARE_PROJECT_CONFIGURATION_FILES" value="true" />
+    <property name="SearchEverywhereHistoryKey" value="Job&#9;FILE&#9;file:///Users/Daniyar.Yeralin/Repositories/qiskit/qiskit-ibmq-provider/qiskit/providers/ibmq/api_v2/rest/job.py" />
+    <property name="TODO_SCOPE" value="All Places" />
+    <property name="last_opened_file_path" value="$USER_HOME$/Applications/miniconda3/envs/qiskit/bin/python3" />
+    <property name="settings.editor.selected.configurable" value="com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable" />
+  </component>
+  <component name="RunDashboard">
+    <option name="ruleStates">
+      <list>
+        <RuleState>
+          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
+        </RuleState>
+        <RuleState>
+          <option name="name" value="StatusDashboardGroupingRule" />
+        </RuleState>
+      </list>
+    </option>
+  </component>
+  <component name="RunManager" selected="Python tests.Unittests for test.ibmq.test_proxies.TestProxies">
+    <configuration default="true" type="PythonConfigurationType" factoryName="Python">
+      <module name="qiskit-ibmq-provider" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="$USER_HOME$/Applications/miniconda3/envs/qiskit/bin/python3" />
+      <option name="WORKING_DIRECTORY" value="" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Qiskit Provider Tests" type="tests" factoryName="Unittests">
+      <module name="qiskit-ibmq-provider" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <option name="SDK_HOME" value="$USER_HOME$/Applications/miniconda3/envs/qiskit/bin/python3" />
+      <option name="WORKING_DIRECTORY" value="" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="_new_pattern" value="&quot;&quot;" />
+      <option name="_new_additionalArguments" value="&quot;&quot;" />
+      <option name="_new_target" value="&quot;&quot;" />
+      <option name="_new_targetType" value="&quot;CUSTOM&quot;" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Unittests for test.ibmq.test_proxies.TestProxies" type="tests" factoryName="Unittests" temporary="true" nameIsGenerated="true">
+      <module name="qiskit-ibmq-provider" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <option name="SDK_HOME" value="$USER_HOME$/Applications/miniconda3/envs/qiskit/bin/python3" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="_new_pattern" value="&quot;&quot;" />
+      <option name="_new_additionalArguments" value="&quot;&quot;" />
+      <option name="_new_target" value="&quot;test.ibmq.test_proxies.TestProxies&quot;" />
+      <option name="_new_targetType" value="&quot;PYTHON&quot;" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Unittests for test.ibmq.test_proxies.TestProxies.test_proxies_authclient" type="tests" factoryName="Unittests" temporary="true" nameIsGenerated="true">
+      <module name="qiskit-ibmq-provider" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <option name="SDK_HOME" value="$USER_HOME$/Applications/miniconda3/envs/qiskit/bin/python3" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="_new_pattern" value="&quot;&quot;" />
+      <option name="_new_additionalArguments" value="&quot;&quot;" />
+      <option name="_new_target" value="&quot;test.ibmq.test_proxies.TestProxies.test_proxies_authclient&quot;" />
+      <option name="_new_targetType" value="&quot;PYTHON&quot;" />
+      <method v="2" />
+    </configuration>
+    <configuration default="true" type="tests" factoryName="Unittests">
+      <module name="qiskit-ibmq-provider" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <option name="SDK_HOME" value="$USER_HOME$/Applications/miniconda3/envs/qiskit/bin/python3" />
+      <option name="WORKING_DIRECTORY" value="" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="_new_pattern" value="&quot;&quot;" />
+      <option name="_new_additionalArguments" value="&quot;&quot;" />
+      <option name="_new_target" value="&quot;&quot;" />
+      <option name="_new_targetType" value="&quot;CUSTOM&quot;" />
+      <method v="2" />
+    </configuration>
+    <list>
+      <item itemvalue="Python tests.Qiskit Provider Tests" />
+      <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies" />
+      <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies.test_proxies_authclient" />
+    </list>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies" />
+        <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies.test_proxies_authclient" />
+        <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies.test_proxies_authclient" />
+        <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies" />
+        <item itemvalue="Python tests.Unittests for test.ibmq.test_proxies.TestProxies" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SvnConfiguration">
+    <configuration />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="39c615a7-6ca4-4c88-8cb0-f8db18bdf0b4" name="Default" comment="" />
+      <created>1564407094519</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1564407094519</updated>
+    </task>
+    <task id="LOCAL-00001" summary="Re-enable test.ibmq.test_proxies.TestProxies tests">
+      <created>1564497098491</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1564497098491</updated>
+    </task>
+    <task id="LOCAL-00002" summary="Re-enable test.ibmq.test_proxies.TestProxies tests">
+      <created>1564497947721</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1564497947721</updated>
+    </task>
+    <option name="localTasksCounter" value="3" />
+    <servers />
+  </component>
+  <component name="Vcs.Log.History.Properties">
+    <option name="COLUMN_ORDER">
+      <list>
+        <option value="0" />
+        <option value="2" />
+        <option value="3" />
+        <option value="1" />
+      </list>
+    </option>
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="1">
+          <value>
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="range">
+                    <value>
+                      <list>
+                        <option value="HEAD..origin/master" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
+          </value>
+        </entry>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="Re-enable test.ibmq.test_proxies.TestProxies tests" />
+    <option name="LAST_COMMIT_MESSAGE" value="Re-enable test.ibmq.test_proxies.TestProxies tests" />
+  </component>
+</project>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/Daniyar.Yeralin/Applications/miniconda3/envs/qiskit/bin/python"
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ pycodestyle
 pylint>=2.3,<2.4
 pylintfileheader>=0.0.2
 vcrpy
-pproxy==1.2.2
+pproxy==2.1.8

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -15,20 +15,16 @@
 """Tests for the AuthClient and VersionClient proxy support."""
 
 
-from unittest import skipIf
-import urllib
 import subprocess
-import sys
+import urllib
 
 from requests.exceptions import ProxyError
 
 from qiskit.providers.ibmq.api_v2.clients import (AuthClient,
                                                   VersionClient)
 from qiskit.providers.ibmq.api_v2.exceptions import RequestsApiError
-
-from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_qe_access, requires_new_api_auth
-
+from ..ibmqtestcase import IBMQTestCase
 
 ADDRESS = '127.0.0.1'
 PORT = 8080
@@ -37,7 +33,6 @@ INVALID_PORT_PROXIES = {'https': '{}:{}'.format(ADDRESS, '6666')}
 INVALID_ADDRESS_PROXIES = {'https': '{}:{}'.format('invalid', PORT)}
 
 
-@skipIf(sys.version_info >= (3, 7), 'pproxy version not supported in 3.7')
 class TestProxies(IBMQTestCase):
     """Tests for proxy capabilities."""
 
@@ -45,7 +40,7 @@ class TestProxies(IBMQTestCase):
         super().setUp()
 
         # launch a mock server.
-        command = ['pproxy', '-v', '-i', 'http://{}:{}'.format(ADDRESS, PORT)]
+        command = ['pproxy', '-v', '-l', 'http://{}:{}'.format(ADDRESS, PORT)]
         self.proxy_process = subprocess.Popen(command, stdout=subprocess.PIPE)
 
     def tearDown(self):
@@ -135,4 +130,4 @@ def pproxy_desired_access_log_line(url):
     """Return a desired pproxy log entry given a url."""
     qe_url_parts = urllib.parse.urlparse(url)
     protocol_port = '443' if qe_url_parts.scheme == 'https' else '80'
-    return 'http {}:{}'.format(qe_url_parts.hostname, protocol_port)
+    return '{}:{}'.format(qe_url_parts.hostname, protocol_port)


### PR DESCRIPTION
## What is the expected behavior?
Related to #69
Currently, `test.ibmq.test_proxies.TestProxies` tests are skipped using `@skipIf` decorator
```
@skipIf(sys.version_info >= (3, 7), 'pproxy version not supported in 3.7')
```
The tests can be re-enabled if we update `pproxy` package from version `1.2.2` to `2.1.8` in `requirements-dev.txt` file.
Then, `test.ibmq.test_proxies.TestProxies` can be run under `>= 3.7` python versions.