### PR TITLE
Re-enable test.ibmq.test_proxies.TestProxies tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ pycodestyle
 pylint>=2.3,<2.4
 pylintfileheader>=0.0.2
 vcrpy
-pproxy==1.2.2
+pproxy==2.1.8

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -15,20 +15,16 @@
 """Tests for the AuthClient and VersionClient proxy support."""
 
 
-from unittest import skipIf
-import urllib
 import subprocess
-import sys
+import urllib
 
 from requests.exceptions import ProxyError
 
 from qiskit.providers.ibmq.api_v2.clients import (AuthClient,
                                                   VersionClient)
 from qiskit.providers.ibmq.api_v2.exceptions import RequestsApiError
-
-from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_qe_access, requires_new_api_auth
-
+from ..ibmqtestcase import IBMQTestCase
 
 ADDRESS = '127.0.0.1'
 PORT = 8080
@@ -37,7 +33,6 @@ INVALID_PORT_PROXIES = {'https': '{}:{}'.format(ADDRESS, '6666')}
 INVALID_ADDRESS_PROXIES = {'https': '{}:{}'.format('invalid', PORT)}
 
 
-@skipIf(sys.version_info >= (3, 7), 'pproxy version not supported in 3.7')
 class TestProxies(IBMQTestCase):
     """Tests for proxy capabilities."""
 
@@ -45,7 +40,7 @@ class TestProxies(IBMQTestCase):
         super().setUp()
 
         # launch a mock server.
-        command = ['pproxy', '-v', '-i', 'http://{}:{}'.format(ADDRESS, PORT)]
+        command = ['pproxy', '-v', '-l', 'http://{}:{}'.format(ADDRESS, PORT)]
         self.proxy_process = subprocess.Popen(command, stdout=subprocess.PIPE)
 
     def tearDown(self):
@@ -135,4 +130,4 @@ def pproxy_desired_access_log_line(url):
     """Return a desired pproxy log entry given a url."""
     qe_url_parts = urllib.parse.urlparse(url)
     protocol_port = '443' if qe_url_parts.scheme == 'https' else '80'
-    return 'http {}:{}'.format(qe_url_parts.hostname, protocol_port)
+    return '{}:{}'.format(qe_url_parts.hostname, protocol_port)


### PR DESCRIPTION
## What is the expected behavior?
Related to #69
Currently, `test.ibmq.test_proxies.TestProxies` tests are skipped using `@skipIf` decorator
```
@skipIf(sys.version_info >= (3, 7), 'pproxy version not supported in 3.7')
```
The tests can be re-enabled if we update `pproxy` package from version `1.2.2` to `2.1.8` in `requirements-dev.txt` file.
Then, `test.ibmq.test_proxies.TestProxies` can be run under `>= 3.7` python versions.