### PR TITLE
Made datetimes timezone unaware

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -98,6 +98,7 @@ class IBMQBackend(BaseBackend):
                 warnings.warn('Retrieving the properties of a '
                               'backend in a specific datetime is '
                               'only available when using IBM Q v2')
+                return None
 
             # Do not use cache for specific datetime properties.
             api_properties = self._api.backend_properties(self.name(), datetime=datetime)

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -94,6 +94,11 @@ class IBMQBackend(BaseBackend):
         """
         # pylint: disable=arguments-differ
         if datetime:
+            if not isinstance(self._api, BaseClient):
+                warnings.warn('Retrieving the properties of a '
+                              'backend in a specific datetime is '
+                              'only available when using IBM Q v2')
+
             # Do not use cache for specific datetime properties.
             api_properties = self._api.backend_properties(self.name(), datetime=datetime)
             if not api_properties:

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -96,12 +96,13 @@ class TestIBMQProvider(IBMQTestCase, providers.ProviderTestCase):
         """Test backend properties filtered by date."""
         backends = self.provider.backends(simulator=False)
 
-        datetime_filter = datetime.fromisoformat('2019-02-01T00:00:00.000')
+        datetime_filter = datetime(2019, 2, 1).replace(tzinfo=None)
         for backend in backends:
             with self.subTest(backend=backend):
                 properties = backend.properties(datetime=datetime_filter)
                 if isinstance(properties, BackendProperties):
-                    self.assertLessEqual(properties.last_update_date, datetime_filter)
+                    last_update_date = properties.last_update_date.replace(tzinfo=None)
+                    self.assertLessEqual(last_update_date, datetime_filter)
                 else:
                     self.assertEqual(properties, None)
 

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -92,20 +92,6 @@ class TestIBMQProvider(IBMQTestCase, providers.ProviderTestCase):
             if backend.configuration().simulator:
                 self.assertEqual(properties, None)
 
-    def test_remote_backend_properties_filter_date(self):
-        """Test backend properties filtered by date."""
-        backends = self.provider.backends(simulator=False)
-
-        datetime_filter = datetime(2019, 2, 1).replace(tzinfo=None)
-        for backend in backends:
-            with self.subTest(backend=backend):
-                properties = backend.properties(datetime=datetime_filter)
-                if isinstance(properties, BackendProperties):
-                    last_update_date = properties.last_update_date.replace(tzinfo=None)
-                    self.assertLessEqual(last_update_date, datetime_filter)
-                else:
-                    self.assertEqual(properties, None)
-
     def test_remote_backend_defaults(self):
         """Test backend pulse defaults."""
         remotes = self.provider.backends(simulator=False)
@@ -190,3 +176,17 @@ class TestAccountProvider(TestIBMQProvider):
         # pylint: disable=arguments-differ
         ibmq = IBMQFactory()
         return ibmq.enable_account(qe_token, qe_url)
+
+    def test_remote_backend_properties_filter_date(self):
+        """Test backend properties filtered by date."""
+        backends = self.provider.backends(simulator=False)
+
+        datetime_filter = datetime(2019, 2, 1).replace(tzinfo=None)
+        for backend in backends:
+            with self.subTest(backend=backend):
+                properties = backend.properties(datetime=datetime_filter)
+                if isinstance(properties, BackendProperties):
+                    last_update_date = properties.last_update_date.replace(tzinfo=None)
+                    self.assertLessEqual(last_update_date, datetime_filter)
+                else:
+                    self.assertEqual(properties, None)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #288 

### Details and comments

Made the datetime objects timezone unaware. This allows them to be compared without issues.