### PR TITLE
Allow custom job name in backend.run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ The format is based on [Keep a Changelog].
   If specified, the `job_name` is assigned to the job. This `job_name` can 
   subsequently be used as a filter in the `IBMQBackend.jobs()` function, which
   now accepts an optional `job_name` parameter. `job_name` does not need to be 
-  unique among jobs. 
+  unique among jobs. These new parameters are ignored if IBM Q Experience 
+  v1 account is used (\#300).
+- The signature of `IBMQBackend.jobs()` is changed. `db_filter`, which was the 
+  4th parameter, is now the 5th parameter (\#300).
 - The `backend.properties()` function now accepts an optional `datetime` 
   parameter. If specified, the function returns the backend properties closest 
   to, but older than, the specified datetime filter (\#277).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog].
 
 ### Changed
 
+- The `bakcend.run()` function now accepts an optional `job_name` parameter.
+  If specified, the `job_name` is assigned to the job. This `job_name` can 
+  subsequently be used as a filter in the `backend.jobs()` function, which
+  now accepts an optional `job_name` parameter. The same `job_name` can be 
+  assigned to multiple jobs.
 - The `backend.properties()` function now accepts an optional `datetime` 
   parameter. If specified, the function returns the backend properties closest 
   to, but older than, the specified datetime filter (\#277).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ The format is based on [Keep a Changelog].
 
 ### Changed
 
-- The `bakcend.run()` function now accepts an optional `job_name` parameter.
+- The `IBMQBackend.run()` function now accepts an optional `job_name` parameter.
   If specified, the `job_name` is assigned to the job. This `job_name` can 
-  subsequently be used as a filter in the `backend.jobs()` function, which
-  now accepts an optional `job_name` parameter. The same `job_name` can be 
-  assigned to multiple jobs.
+  subsequently be used as a filter in the `IBMQBackend.jobs()` function, which
+  now accepts an optional `job_name` parameter. `job_name` does not need to be 
+  unique among jobs. 
 - The `backend.properties()` function now accepts an optional `datetime` 
   parameter. If specified, the function returns the backend properties closest 
   to, but older than, the specified datetime filter (\#277).

--- a/qiskit/providers/ibmq/api_v2/clients/account.py
+++ b/qiskit/providers/ibmq/api_v2/clients/account.py
@@ -124,7 +124,7 @@ class AccountClient(BaseClient):
                                     extra_filter=extra_filter)
 
     def job_submit(self, backend_name: str, qobj_dict: Dict[str, Any],
-                   job_name: str = None) -> Dict[str, Any]:
+                   job_name: Optional[str] = None) -> Dict[str, Any]:
         """Submit a Qobj to a device.
 
         Args:
@@ -138,7 +138,7 @@ class AccountClient(BaseClient):
         return self.client_api.submit_job(backend_name, qobj_dict, job_name)
 
     def job_submit_object_storage(self, backend_name: str, qobj_dict: Dict[str, Any],
-                                  job_name: str = None) -> Dict:
+                                  job_name: Optional[str] = None) -> Dict:
         """Submit a Qobj to a device using object storage.
 
         Args:

--- a/qiskit/providers/ibmq/api_v2/clients/account.py
+++ b/qiskit/providers/ibmq/api_v2/clients/account.py
@@ -123,30 +123,34 @@ class AccountClient(BaseClient):
         return self.client_api.jobs(limit=limit, skip=skip,
                                     extra_filter=extra_filter)
 
-    def job_submit(self, backend_name: str, qobj_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def job_submit(self, backend_name: str, qobj_dict: Dict[str, Any],
+                   job_name: str = None) -> Dict[str, Any]:
         """Submit a Qobj to a device.
 
         Args:
             backend_name (str): the name of the backend.
             qobj_dict (dict): the Qobj to be executed, as a dictionary.
+            job_name (str): custom name to be assigned to the job.
 
         Returns:
             dict: job status.
         """
-        return self.client_api.submit_job(backend_name, qobj_dict)
+        return self.client_api.submit_job(backend_name, qobj_dict, job_name)
 
-    def job_submit_object_storage(self, backend_name: str, qobj_dict: Dict[str, Any]) -> Dict:
+    def job_submit_object_storage(self, backend_name: str, qobj_dict: Dict[str, Any],
+                                  job_name: str = None) -> Dict:
         """Submit a Qobj to a device using object storage.
 
         Args:
             backend_name (str): the name of the backend.
             qobj_dict (dict): the Qobj to be executed, as a dictionary.
+            job_name (str): custom name to be assigned to the job.
 
         Returns:
             dict: job status.
         """
         # Get the job via object storage.
-        job_info = self.client_api.submit_job_object_storage(backend_name)
+        job_info = self.client_api.submit_job_object_storage(backend_name, job_name=job_name)
 
         # Get the upload URL.
         job_id = job_info['id']
@@ -325,9 +329,9 @@ class AccountClient(BaseClient):
         # pylint: disable=missing-docstring
         return self.job_status(id_job)
 
-    def submit_job(self, qobj_dict, backend_name):
+    def submit_job(self, qobj_dict, backend_name, job_name=None):
         # pylint: disable=missing-docstring
-        return self.job_submit(backend_name, qobj_dict)
+        return self.job_submit(backend_name, qobj_dict, job_name)
 
     def get_jobs(self, limit=10, skip=0, backend=None, only_completed=False,
                  filter=None):

--- a/qiskit/providers/ibmq/api_v2/rest/root.py
+++ b/qiskit/providers/ibmq/api_v2/rest/root.py
@@ -89,43 +89,49 @@ class Api(RestAdapterBase):
         return self.session.get(
             url, params={'filter': json.dumps(query)}).json()
 
-    def submit_job(self, backend_name, qobj_dict):
+    def submit_job(self, backend_name, qobj_dict, job_name=None):
         """Submit a job for executing.
 
         Args:
             backend_name (str): the name of the backend.
             qobj_dict (dict): the Qobj to be executed, as a dictionary.
+            job_name (str): custom name to be assigned to the job.
 
         Returns:
             dict: json response.
         """
         url = self.get_url('jobs')
+        print(f">>>>>> submitting job normally")
 
         payload = {
             'qObject': qobj_dict,
             'backend': {'name': backend_name},
-            'shots': qobj_dict.get('config', {}).get('shots', 1)
+            'shots': qobj_dict.get('config', {}).get('shots', 1),
+            'job_name': job_name
         }
 
         return self.session.post(url, json=payload).json()
 
-    def submit_job_object_storage(self, backend_name, shots=1):
+    def submit_job_object_storage(self, backend_name, shots=1, job_name=None):
         """Submit a job for executing, using object storage.
 
         Args:
             backend_name (str): the name of the backend.
             shots (int): number of shots.
+            job_name (str): custom name to be assigned to the job.
 
         Returns:
             dict: json response.
         """
         url = self.get_url('jobs')
+        print(">>>>>> submitting job using obj storage")
 
         # TODO: "shots" is currently required by the API.
         payload = {
             'backend': {'name': backend_name},
             'shots': shots,
-            'allowObjectStorage': True
+            'allowObjectStorage': True,
+            'job_name': job_name
         }
 
         return self.session.post(url, json=payload).json()

--- a/qiskit/providers/ibmq/api_v2/rest/root.py
+++ b/qiskit/providers/ibmq/api_v2/rest/root.py
@@ -101,13 +101,12 @@ class Api(RestAdapterBase):
             dict: json response.
         """
         url = self.get_url('jobs')
-        print(f">>>>>> submitting job normally")
 
         payload = {
             'qObject': qobj_dict,
             'backend': {'name': backend_name},
             'shots': qobj_dict.get('config', {}).get('shots', 1),
-            'job_name': job_name
+            'name': job_name
         }
 
         return self.session.post(url, json=payload).json()
@@ -124,14 +123,13 @@ class Api(RestAdapterBase):
             dict: json response.
         """
         url = self.get_url('jobs')
-        print(">>>>>> submitting job using obj storage")
 
         # TODO: "shots" is currently required by the API.
         payload = {
             'backend': {'name': backend_name},
             'shots': shots,
             'allowObjectStorage': True,
-            'job_name': job_name
+            'name': job_name
         }
 
         return self.session.post(url, json=payload).json()

--- a/qiskit/providers/ibmq/api_v2/rest/root.py
+++ b/qiskit/providers/ibmq/api_v2/rest/root.py
@@ -105,9 +105,11 @@ class Api(RestAdapterBase):
         payload = {
             'qObject': qobj_dict,
             'backend': {'name': backend_name},
-            'shots': qobj_dict.get('config', {}).get('shots', 1),
-            'job_name': job_name
+            'shots': qobj_dict.get('config', {}).get('shots', 1)
         }
+
+        if job_name:
+            payload['name'] = job_name
 
         return self.session.post(url, json=payload).json()
 
@@ -128,9 +130,11 @@ class Api(RestAdapterBase):
         payload = {
             'backend': {'name': backend_name},
             'shots': shots,
-            'allowObjectStorage': True,
-            'job_name': job_name
+            'allowObjectStorage': True
         }
+
+        if job_name:
+            payload['name'] = job_name
 
         return self.session.post(url, json=payload).json()
 

--- a/qiskit/providers/ibmq/api_v2/rest/root.py
+++ b/qiskit/providers/ibmq/api_v2/rest/root.py
@@ -106,7 +106,7 @@ class Api(RestAdapterBase):
             'qObject': qobj_dict,
             'backend': {'name': backend_name},
             'shots': qobj_dict.get('config', {}).get('shots', 1),
-            'name': job_name
+            'job_name': job_name
         }
 
         return self.session.post(url, json=payload).json()
@@ -129,7 +129,7 @@ class Api(RestAdapterBase):
             'backend': {'name': backend_name},
             'shots': shots,
             'allowObjectStorage': True,
-            'name': job_name
+            'job_name': job_name
         }
 
         return self.session.post(url, json=payload).json()

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -63,7 +63,10 @@ class IBMQBackend(BaseBackend):
 
         Args:
             qobj (Qobj): description of job.
-            job_name (str): custom name to be assigned to the job.
+            job_name (str): custom name to be assigned to the job. This job
+                name can subsequently be used as a filter in the
+                ``jobs()`` function call. Job names do not need to be unique.
+                This parameter is ignored if IBM Q Experience v1 account is used.
 
         Returns:
             IBMQJob: an instance derived from BaseJob
@@ -73,11 +76,10 @@ class IBMQBackend(BaseBackend):
         if isinstance(self._api, BaseClient):
             # Default to using object storage and websockets for new API.
             kwargs = {'use_object_storage': True,
-                      'use_websockets': True,
-                      'job_name': job_name}
+                      'use_websockets': True}
 
         job = IBMQJob(self, None, self._api, qobj=qobj, **kwargs)
-        job.submit()
+        job.submit(job_name=job_name)
 
         return job
 
@@ -156,7 +158,7 @@ class IBMQBackend(BaseBackend):
 
         return self._defaults
 
-    def jobs(self, limit=10, skip=0, status=None, db_filter=None, job_name=None):
+    def jobs(self, limit=10, skip=0, status=None, job_name=None, db_filter=None):
         """Return the jobs submitted to this backend.
 
         Return the jobs submitted to this backend, with optional filtering and

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -62,12 +62,13 @@ class IBMQBackend(BaseBackend):
         """Run a Qobj asynchronously.
 
         Args:
-            qobj (Qobj): description of job
-            job_name (str): custom name to be assigned to the job
+            qobj (Qobj): description of job.
+            job_name (str): custom name to be assigned to the job.
 
         Returns:
             IBMQJob: an instance derived from BaseJob
         """
+        # pylint: disable=arguments-differ
         kwargs = {}
         if isinstance(self._api, BaseClient):
             # Default to using object storage and websockets for new API.
@@ -228,7 +229,7 @@ class IBMQBackend(BaseBackend):
             api_filter.update(this_filter)
 
         if job_name:
-            api_filter['job_name'] = job_name
+            api_filter['name'] = job_name
 
         if db_filter:
             # status takes precedence over db_filter for same keys

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -177,6 +177,7 @@ class IBMQBackend(BaseBackend):
             status (None or qiskit.providers.JobStatus or str): only get jobs
                 with this status, where status is e.g. `JobStatus.RUNNING` or
                 `'RUNNING'`
+            job_name (str): only get jobs with this job name.
             db_filter (dict): `loopback-based filter
                 <https://loopback.io/doc/en/lb2/Querying-data.html>`_.
                 This is an interface to a database ``where`` filter. Some
@@ -199,7 +200,6 @@ class IBMQBackend(BaseBackend):
                    past_date = datetime.datetime.now() - datetime.timedelta(days=30)
                    date_filter = {'creationDate': {'lt': past_date.isoformat()}}
                    job_list = backend.jobs(limit=5, db_filter=date_filter)
-            job_name (str): only get jobs with this job name.
 
         Returns:
             list(IBMQJob): list of IBMQJob instances

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -461,7 +461,6 @@ class IBMQJob(BaseJob):
             except Exception as err:  # pylint: disable=broad-except
                 # Fall back to submitting the Qobj via POST if object storage
                 # failed.
-                print(f"obj stor failed, err={err}")
                 logger.info('Submitting the job via object storage failed: '
                             'retrying via regular POST upload.')
                 # Disable object storage for this job.

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -455,14 +455,14 @@ class TestIBMQJob(JobTestCase):
 
         # Use a unique job name
         job_name = str(time.time()).replace('.', '')
-        job_ids = []
+        job_ids = set()
         for _ in range(2):
-            job_ids.insert(0, backend.run(qobj, job_name=job_name).job_id())
+            job_ids.add(backend.run(qobj, job_name=job_name).job_id())
 
-        job_list = backend.jobs(job_name=job_name)
-        self.assertEqual(len(job_list), 2)
-        job_list_ids = [job.job_id() for job in job_list]
-        self.assertEqual(job_ids, job_list_ids)
+        retrieved_jobs = backend.jobs(job_name=job_name)
+        self.assertEqual(len(retrieved_jobs), 2)
+        retrieved_job_ids = {job.job_id() for job in retrieved_jobs}
+        self.assertEqual(job_ids, retrieved_job_ids)
 
 
 def _bell_circuit():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is part of #118 . It allows a user to specify a job name when calling `backend.run()` and subsequently use it as a filter to `backend.jobs()`.


### Details and comments
I ended up adding a new attribute `_job_name` to `IBMQJob` since that's the most logical place. The downside is it might make people think that attribute is always available when it's not.

