### PR TITLE
Introduce version response schema

### DIFF
--- a/qiskit/providers/ibmq/api_v2/rest/schemas/auth.py
+++ b/qiskit/providers/ibmq/api_v2/rest/schemas/auth.py
@@ -15,7 +15,7 @@
 """Schemas for authentication."""
 
 from qiskit.validation import BaseSchema
-from qiskit.validation.fields import String, Url, Nested, Boolean
+from qiskit.validation.fields import String, Url, Nested
 
 
 # Helper schemas.
@@ -57,9 +57,6 @@ class UserInfoResponseSchema(BaseSchema):
 
 class VersionResponseSchema(BaseSchema):
     """Schema for VersionResponse"""
-
-    # Custom properties
-    new_api = Boolean(missing=False, required=False)
 
     # Required properties.
     api_auth = String(load_from='api-auth', required=True,

--- a/qiskit/providers/ibmq/api_v2/rest/schemas/auth.py
+++ b/qiskit/providers/ibmq/api_v2/rest/schemas/auth.py
@@ -15,7 +15,7 @@
 """Schemas for authentication."""
 
 from qiskit.validation import BaseSchema
-from qiskit.validation.fields import String, Url, Nested
+from qiskit.validation.fields import String, Url, Nested, Boolean
 
 
 # Helper schemas.
@@ -53,3 +53,14 @@ class UserInfoResponseSchema(BaseSchema):
     urls = Nested(UserApiUrlResponseSchema, required=True,
                   description='base URLs for the services. Currently supported keys: '
                               'http and ws')
+
+
+class VersionResponseSchema(BaseSchema):
+    """Schema for VersionResponse"""
+
+    # Custom properties
+    new_api = Boolean(missing=False, required=False)
+
+    # Required properties.
+    api_auth = String(load_from='api-auth', required=True,
+                      description='the versions of auth API component')


### PR DESCRIPTION
### Summary
This PR introduces another schema used for `/version` endpoint.


### Details and comments
This schema contains a custom non-required field `new_api` that's used internally in IBMQ Provider component and defaults to `False`.


