### PR TITLE
don't use newer asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nest-asyncio>=1.0.0
+nest-asyncio==1.0.0
 qiskit-terra>=0.8
 requests>=2.19
 requests-ntlm>=1.1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The newer `nested_asyncio` (1.1.0) doesn't work on Python 3.5. Pin the requirement to `1.0.0` until it's fixed. 


### Details and comments


