### PR TITLE
Nested asyncio version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nest-asyncio==1.2.0
+nest-asyncio==1.1.0
 qiskit-terra>=0.8
 requests>=2.19
 requests-ntlm>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nest-asyncio==1.0.0
+nest-asyncio==1.2.0
 qiskit-terra>=0.8
 requests>=2.19
 requests-ntlm>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nest-asyncio==1.1.0
+nest-asyncio>=1.0.0,!=1.1.0
 qiskit-terra>=0.8
 requests>=2.19
 requests-ntlm>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import os
 from setuptools import setup
 
 requirements = [
-    "nest-asyncio==1.0.0",
+    "nest-asyncio>=1.0.0,!=1.1.0",
     "qiskit-terra>=0.8",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #313. The support for Python 3.5 was added back in `nest-asyncio` 1.2.0. However it's not backported to 1.1.0. This PR changes the requirement to `>=1.0.0,!=1.1.0`


### Details and comments


