### PR TITLE
Use Any as type hint for kwargs

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -15,7 +15,7 @@
 """Provider for a single IBM Quantum Experience account."""
 
 import logging
-from typing import Dict, List, Callable, Optional
+from typing import Dict, List, Callable, Optional, Any
 from collections import OrderedDict
 
 from qiskit.providers import BaseProvider
@@ -71,7 +71,7 @@ class AccountProvider(BaseProvider):
             name: Optional[str] = None,
             filters: Optional[Callable[[List[IBMQBackend]], bool]] = None,
             timeout: Optional[float] = None,
-            **kwargs: Dict
+            **kwargs: Any
     ) -> List[IBMQBackend]:
         """Return all backends accessible via this provider, subject to optional filtering.
 

--- a/qiskit/providers/ibmq/api_v2/clients/account.py
+++ b/qiskit/providers/ibmq/api_v2/clients/account.py
@@ -42,7 +42,7 @@ class AccountClient(BaseClient):
             access_token: str,
             project_url: str,
             websockets_url: str,
-            **request_kwargs: Dict
+            **request_kwargs: Any
     ) -> None:
         """AccountClient constructor.
 
@@ -302,7 +302,7 @@ class AccountClient(BaseClient):
 
     # Circuits-related public functions.
 
-    def circuit_run(self, name: str, **kwargs: Dict) -> Dict:
+    def circuit_run(self, name: str, **kwargs: Any) -> Dict:
         """Execute a Circuit.
 
         Args:

--- a/qiskit/providers/ibmq/api_v2/clients/auth.py
+++ b/qiskit/providers/ibmq/api_v2/clients/auth.py
@@ -13,7 +13,7 @@
 # that they have been altered from the originals.
 
 """Client for accessing authentication features of IBM Q Experience."""
-from typing import Dict, List
+from typing import Dict, List, Any
 
 from ..exceptions import AuthenticationLicenseError, RequestsApiError
 from ..rest import Api, Auth
@@ -25,7 +25,7 @@ from .base import BaseClient
 class AuthClient(BaseClient):
     """Client for accessing authentication features of IBM Q Experience."""
 
-    def __init__(self, api_token: str, auth_url: str, **request_kwargs: Dict) -> None:
+    def __init__(self, api_token: str, auth_url: str, **request_kwargs: Any) -> None:
         """AuthClient constructor.
 
         Args:
@@ -40,7 +40,7 @@ class AuthClient(BaseClient):
         self.client_auth = Auth(RetrySession(auth_url, **request_kwargs))
         self.client_api = self._init_service_clients(**request_kwargs)
 
-    def _init_service_clients(self, **request_kwargs: Dict) -> Api:
+    def _init_service_clients(self, **request_kwargs: Any) -> Api:
         """Initialize the clients used for communicating with the API and ws.
 
         Args:

--- a/qiskit/providers/ibmq/api_v2/clients/version.py
+++ b/qiskit/providers/ibmq/api_v2/clients/version.py
@@ -14,7 +14,7 @@
 
 """Client for determining the version of an IBM Q Experience service."""
 
-from typing import Dict, Union
+from typing import Dict, Union, Any
 
 from ..session import RetrySession
 from ..rest.version_finder import VersionFinder
@@ -25,7 +25,7 @@ from .base import BaseClient
 class VersionClient(BaseClient):
     """Client for determining the version of an IBM Q Experience service."""
 
-    def __init__(self, url: str, **request_kwargs: Dict) -> None:
+    def __init__(self, url: str, **request_kwargs: Any) -> None:
         """VersionClient constructor.
 
         Args:

--- a/qiskit/providers/ibmq/api_v2/rest/root.py
+++ b/qiskit/providers/ibmq/api_v2/rest/root.py
@@ -162,7 +162,7 @@ class Api(RestAdapterBase):
 
         return self.session.post(url, json=payload).json()
 
-    def circuit(self, name: str, **kwargs: Dict) -> Dict[str, Any]:
+    def circuit(self, name: str, **kwargs: Any) -> Dict[str, Any]:
         """Execute a Circuit.
 
         Args:

--- a/qiskit/providers/ibmq/api_v2/session.py
+++ b/qiskit/providers/ibmq/api_v2/session.py
@@ -15,7 +15,7 @@
 """Session customized for IBM Q Experience access."""
 
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 from requests import Session, RequestException, Response
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
@@ -132,7 +132,7 @@ class RetrySession(Session):
         self.proxies = proxies or {}
         self.verify = verify
 
-    def request(self, method: str, url: str, bare: bool = False, **kwargs: Dict) -> Response:
+    def request(self, method: str, url: str, bare: bool = False, **kwargs: Any) -> Response:
         """Constructs a Request, prepending the base url.
 
         Args:

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -16,7 +16,7 @@
 
 import logging
 import warnings
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, Any
 from collections import OrderedDict
 
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -52,7 +52,7 @@ class IBMQFactory:
             self,
             token: str,
             url: str = QX_AUTH_URL,
-            **kwargs: Dict
+            **kwargs: Any
     ) -> Optional[Union[AccountProvider, IBMQProvider]]:
         """Authenticate against IBM Q Experience for use during this session.
 
@@ -204,7 +204,7 @@ class IBMQFactory:
             token: str,
             url: str = QX_AUTH_URL,
             overwrite: bool = False,
-            **kwargs: Dict
+            **kwargs: Any
     ) -> None:
         """Save the account to disk for future use.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Revise the type hints, in order to use `Any` as the type for `**kwargs` arguments.

Even if it does not seem too intuitive, it brings the hinting closer to [the PEP-0484 instructions for kwargs](https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values), indicating the "types of the values inside kwargs" rather than the "type of kwargs", and actually allows mypy to infer a bit better the types for the arguments (the PR squashes a small number of `make mypy` errors).

### Details and comments


