### PR TITLE
Update job field names

### DIFF
--- a/qiskit/providers/ibmq/api/rest/job.py
+++ b/qiskit/providers/ibmq/api/rest/job.py
@@ -81,7 +81,7 @@ class Job(RestAdapterBase):
 
     def callback_download(self) -> Dict[str, Any]:
         """Notify the API after downloading a Qobj via object storage."""
-        url = self.get_url("callback_download")
+        url = self.get_url('callback_download')
         return self.session.post(url).json()
 
     def cancel(self) -> Dict[str, Any]:

--- a/qiskit/providers/ibmq/api/rest/schemas/job.py
+++ b/qiskit/providers/ibmq/api/rest/schemas/job.py
@@ -98,21 +98,21 @@ class UploadUrlResponseSchema(BaseSchema):
     """Schema for UploadUrlResponse"""
 
     # Required properties
-    upload_url = Url(required=True, description="upload object storage URL.")
+    url = Url(required=True, description="upload object storage URL.")
 
 
 class DownloadUrlResponseSchema(BaseSchema):
     """Schema for DownloadUrlResponse"""
 
     # Required properties
-    download_url = Url(required=True, description="download object storage URL.")
+    url = Url(required=True, description="download object storage URL.")
 
 
 class ResultUrlResponseSchema(BaseSchema):
     """Schema for ResultUrlResponse"""
 
     # Required properties
-    download_url = Url(required=True, description="object storage URL.")
+    url = Url(required=True, description="object storage URL.")
 
 
 class CallbackUploadResponseSchema(BaseSchema):

--- a/qiskit/providers/ibmq/api/rest/schemas/root.py
+++ b/qiskit/providers/ibmq/api/rest/schemas/root.py
@@ -144,7 +144,7 @@ class JobsResponseSchema(BaseSchema):
 
     # Required properties
     id = String(required=True)
-    status = String(required=True, validate=OneOf([status.value for status in JobStatus]))
+    status = String(required=True, validate=OneOf([status.name for status in JobStatus]))
     creationDate = String(required=True)
 
 


### PR DESCRIPTION
### Summary
Update `job.download_url`, `job.upload_url`, and `job.result_url` response fields.


### Details and comments
The response format was updated by the API team, and needs to be reflected in Provider's schemas.

