### PR TITLE
Revise api client usage

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -27,7 +27,7 @@ from qiskit.providers.models import (BackendStatus, BackendProperties,
                                      PulseDefaults, BackendConfiguration)
 
 from .api import ApiError
-from .api_v2.clients import BaseClient, AccountClient
+from .api_v2.clients import AccountClient
 from .apiconstants import ApiJobStatus, ApiJobKind
 from .credentials import Credentials
 from .exceptions import IBMQBackendError, IBMQBackendValueError
@@ -82,12 +82,8 @@ class IBMQBackend(BaseBackend):
             IBMQJob: an instance derived from BaseJob
         """
         # pylint: disable=arguments-differ
-        kwargs = {}
-        if isinstance(self._api, BaseClient):
-            # Default to using object storage and websockets for new API.
-            kwargs = {'use_object_storage': True,
-                      'use_websockets': True}
-
+        kwargs = {'use_object_storage': True,
+                  'use_websockets': True}
         job = IBMQJob(self, None, self._api, qobj=qobj, **kwargs)
         job.submit(job_name=job_name)
 
@@ -113,12 +109,6 @@ class IBMQBackend(BaseBackend):
         """
         # pylint: disable=arguments-differ
         if datetime:
-            if not isinstance(self._api, BaseClient):
-                warnings.warn('Retrieving the properties of a '
-                              'backend in a specific datetime is '
-                              'only available when using IBM Q v2')
-                return None
-
             # Do not use cache for specific datetime properties.
             api_properties = self._api.backend_properties(self.name(), datetime=datetime)
             if not api_properties:
@@ -291,9 +281,7 @@ class IBMQBackend(BaseBackend):
                 # Discard pre-qobj jobs.
                 break
 
-            if isinstance(self._api, BaseClient):
-                # Default to using websockets for new API.
-                kwargs['use_websockets'] = True
+            kwargs['use_websockets'] = True
             if job_kind == ApiJobKind.QOBJECT_STORAGE:
                 kwargs['use_object_storage'] = True
 
@@ -341,9 +329,7 @@ class IBMQBackend(BaseBackend):
             try:
                 job_kind = ApiJobKind(job_info.get('kind', None))
 
-                if isinstance(self._api, BaseClient):
-                    # Default to using websockets for new API.
-                    kwargs['use_websockets'] = True
+                kwargs['use_websockets'] = True
                 if job_kind == ApiJobKind.QOBJECT_STORAGE:
                     kwargs['use_object_storage'] = True
 

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -32,7 +32,6 @@ from qiskit.tools.events.pubsub import Publisher
 
 from ..api import ApiError
 from ..apiconstants import ApiJobStatus
-from ..api_v2.clients import BaseClient
 from ..api_v2.exceptions import WebsocketTimeoutError, WebsocketError
 
 from .utils import current_utc_time, build_error_report, is_job_queued
@@ -469,9 +468,7 @@ class IBMQJob(BaseJob):
 
         if not submit_info:
             try:
-                kwargs = {}
-                if isinstance(self._api, BaseClient):
-                    kwargs = {'job_name': job_name}
+                kwargs = {'job_name': job_name}
                 submit_info = self._api.job_submit(
                     backend_name=backend_name,
                     qobj_dict=self._qobj_payload,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adresses #267 

### Details and comments

With #345, the `IBMQConnector` class is deprecated. As a result, the `_api` member variables of `IBMQBackend` and `IBMQJob` could only be of the type `AccountClient` 