### PR TITLE
Fix proxy arguments passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format is based on [Keep a Changelog].
 - Support for the legacy Quantum Experience and QConsole is fully deprecated.
   Only credentials from the new Quantum Experience can be used. (\#344)
 
+## [0.3.3] - 2019-09-30
+
+### Fixed
+
+- Fixed an issue where proxy parameters were not fully passed to the final
+  sessions, leading to incomplete proxy support.
 
 ## [0.3.2] - 2019-08-20
 
@@ -178,7 +184,8 @@ The format is based on [Keep a Changelog].
 - Support for non-qobj format has been removed. (\#26, \#28)
 
 
-[UNRELEASED]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.3.2...HEAD
+[UNRELEASED]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.3.3...HEAD
+[0.3.3]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.3.2...0.3.3
 [0.3.2]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.2.2...0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The format is based on [Keep a Changelog].
 ### Fixed
 
 - Fixed an issue where proxy parameters were not fully passed to the final
-  sessions, leading to incomplete proxy support.
+  sessions, leading to incomplete proxy support. (\#353)
 
 ## [0.3.2] - 2019-08-20
 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -81,9 +81,13 @@ class IBMQBackend(BaseBackend):
             IBMQJob: an instance derived from BaseJob
         """
         # pylint: disable=arguments-differ
-        kwargs = {'use_object_storage': True,
-                  'use_websockets': True}
-        job = IBMQJob(self, None, self._api, qobj=qobj, **kwargs)
+        use_websockets = True
+        if self._credentials.proxies:
+            # Disable using websockets through proxies.
+            use_websockets = False
+        job = IBMQJob(self, None, self._api, qobj=qobj,
+                      use_object_storage=True,
+                      use_websockets=use_websockets)
         job.submit(job_name=job_name)
 
         return job
@@ -281,6 +285,9 @@ class IBMQBackend(BaseBackend):
                 break
 
             kwargs['use_websockets'] = True
+            if self._credentials.proxies:
+                # Disable using websockets through proxies.
+                kwargs['use_websockets'] = False
             if job_kind == ApiJobKind.QOBJECT_STORAGE:
                 kwargs['use_object_storage'] = True
 
@@ -329,6 +336,9 @@ class IBMQBackend(BaseBackend):
                 job_kind = ApiJobKind(job_info.get('kind', None))
 
                 kwargs['use_websockets'] = True
+                if self._credentials.proxies:
+                    # Disable using websockets through proxies.
+                    kwargs['use_websockets'] = False
                 if job_kind == ApiJobKind.QOBJECT_STORAGE:
                     kwargs['use_object_storage'] = True
 

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -351,7 +351,8 @@ class IBMQFactory:
                 Experience authentication URL.
         """
         auth_client = AuthClient(credentials.token,
-                                 credentials.base_url)
+                                 credentials.base_url,
+                                 **credentials.connection_parameters())
         service_urls = auth_client.current_service_urls()
         user_hubs = auth_client.user_hubs()
 

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -22,6 +22,7 @@ import sys
 
 from requests.exceptions import ProxyError
 
+from qiskit.providers.ibmq import IBMQFactory
 from qiskit.providers.ibmq.api.clients import (AuthClient,
                                                VersionClient)
 from qiskit.providers.ibmq.api.exceptions import RequestsApiError
@@ -66,8 +67,26 @@ class TestProxies(IBMQTestCase):
             self.proxy_process.wait()
 
     @requires_qe_access
+    def test_proxies_factory(self, qe_token, qe_url):
+        """Should reach the proxy using factory.enable_account."""
+        factory = IBMQFactory()
+        provider = factory.enable_account(qe_token, qe_url,
+                                          proxies={'urls': VALID_PROXIES})
+
+        self.proxy_process.terminate()  # kill to be able of reading the output
+
+        auth_line = pproxy_desired_access_log_line(qe_url)
+        api_line = pproxy_desired_access_log_line(provider.credentials.url)
+        proxy_output = self.proxy_process.stdout.read().decode('utf-8')
+
+        # Check if the authentication call went through proxy.
+        self.assertIn(auth_line, proxy_output)
+        # Check if the API call (querying providers list) went through proxy.
+        self.assertIn(api_line, proxy_output)
+
+    @requires_qe_access
     def test_proxies_authclient(self, qe_token, qe_url):
-        """Should reach the proxy using IBMQClient."""
+        """Should reach the proxy using AuthClient."""
         pproxy_desired_access_log_line_ = pproxy_desired_access_log_line(qe_url)
 
         _ = AuthClient(qe_token, qe_url, proxies=VALID_PROXIES)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #350 

As reported during #350, the proxy parameters used by the session where not fully passed in all instances. This PR covers the missing case (the creation of `AuthClient` during client discovery), after double-checking the rest of instantiations of clients, and adds an extra test case.

### Details and comments

Additionally, it prepares the changelog for a new release, in order to get the critical fix out soon - another PR will be made against stable that takes care of the actual release.
