### PR TITLE
Fix nested schema

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -223,6 +223,7 @@ class IBMQJob(BaseModel, BaseJob):
             raise JobError('Unable to retrieve job result. Job status '
                            'is {}'.format(str(self._status)))
 
+        # TODO Can look for and reuse qObjectResult
         if not self._result:
             with api_to_job_error():
                 result_response = self._api.job_result(self.job_id(), self._use_object_storage)

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -19,8 +19,6 @@ from marshmallow.validate import Range
 
 from qiskit.validation import BaseSchema
 from qiskit.validation.fields import Dict, String, Nested, Integer
-from qiskit.qobj.qobj import QobjSchema
-from qiskit.result.models import ResultSchema
 from qiskit.providers.ibmq.apiconstants import ApiJobKind, ApiJobStatus
 
 from ..utils.validators import EnumType
@@ -52,7 +50,7 @@ class JobResponseSchema(BaseSchema):
     backend = Nested(JobResponseBackendSchema, required=False)
     error = String(required=False)
     name = String(required=False)
-    qObjectResult = Nested(ResultSchema, required=False)
-    qObject = Nested(QobjSchema, required=False)
+    qObjectResult = Dict(required=False)
+    qObject = Dict(required=False)
     shots = Integer(required=False, validate=Range(min=0))
     timePerStep = Dict(required=False, keys=String, values=String)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -202,10 +202,12 @@ class TestIBMQJob(JobTestCase):
         job_ids = [job.job_id() for job in job_array]
         self.assertEqual(sorted(job_ids), sorted(list(set(job_ids))))
 
-    @run_on_staging
+    @requires_provider
     def test_cancel(self, provider):
-        """Test job cancelation."""
-        backend = least_busy(provider.backends(simulator=False))
+        """Test job cancellation."""
+        # Find the most busy backend
+        backend = max([b for b in provider.backends() if b.status().operational],
+                      key=lambda b: b.status().pending_jobs)
 
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         job = backend.run(qobj)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes an issue introduced by #329 that breaks job submit to backends that don't use object storage.

### Details and comments
#329 binds `IBMQJob` to `JobResponseSchema`, which includes a nested `QobjSchema`:
```
qObject = Nested(QobjSchema, required=False)
```

`QobjSchema` is defined in `qiskit-terra` and is bound to `Qobj`. When `qObject` is returned in a job response (e.g. from a backend that doesn't support object storage), marshmallow deserialize it first, and `post_load()` converts it to a `Qobj` object. Deserializing the entire response will then fail because marshmallow is expecting a dictionary when a `Qobj` is passed in. 

This PR uses `Dict` instead of `Nested` for the nested schemas, and the validation will happen individually.

Also stop running `test_cancel` on staging since it's not currently working correctly. 
