### PR TITLE
Job error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog].
 - `IBMQJob` constructor signature has changed (\#329).
 - `IBMQJob.submit()` can no longer be called directly, and jobs are expected
   to be submitted via `IBMQBackend.run()` (\#329).
+- `IBMQJob.error_message()` now gives more information on why a job failed (\#375). 
 
 ### Removed
 

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -245,11 +245,6 @@ class IBMQBackendService(SimpleNamespace):
         try:
             job_info = self._provider._api.job_get(job_id)
 
-            # Check for generic errors.
-            if 'error' in job_info:
-                raise IBMQBackendError('Failed to get job "{}": {}'
-                                       .format(job_id, job_info['error']))
-
             # Check for pre-qobj jobs.
             if 'kind' not in job_info:
                 warnings.warn('The result of job {} is in a no longer supported format. '

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -141,7 +141,8 @@ class IBMQJob(BaseModel, BaseJob):
 
         # Properties used for caching.
         self._cancelled = False
-        self._api_error_msg = None
+        self._job_error_report = None
+        self._job_error_message = None
         self._result = None
         self._queue_position = None
 
@@ -213,21 +214,20 @@ class IBMQJob(BaseModel, BaseJob):
             qiskit.Result: Result object
 
         Raises:
-            JobError: if the job has not been submitted or has failed, or if
-                there was some unexpected failure in the server.
+            JobError: if the job has failed or cancelled, or if there was some
+                unexpected failure in the server.
         """
         # pylint: disable=arguments-differ
 
         if not self._wait_for_completion(timeout=timeout, wait=wait,
                                          required_status=(JobStatus.DONE,)):
-            raise JobError('Unable to retrieve job result. Job status '
-                           'is {}'.format(str(self._status)))
+            message = 'Job was cancelled.' if self._status is JobStatus.CANCELLED \
+                else 'Job has failed. Use job.error_message() to get more details.'
+            raise JobError('Unable to retrieve job result. ' + message)
 
-        # TODO Can look for and reuse qObjectResult
         if not self._result:
-            with api_to_job_error():
-                result_response = self._api.job_result(self.job_id(), self._use_object_storage)
-                self._result = Result.from_dict(result_response)
+            result_response = self._get_result_response()
+            self._result = Result.from_dict(result_response)
 
         return self._result
 
@@ -300,23 +300,18 @@ class IBMQJob(BaseModel, BaseJob):
         Returns:
             str: An error report if the job failed or ``None`` otherwise.
         """
-        if self.job_id() is None or \
-                not self._wait_for_completion(required_status=(JobStatus.ERROR,)):
+        if not self._wait_for_completion(required_status=(JobStatus.ERROR,)):
             return None
 
-        if not self._api_error_msg:
-            job_response = self._api.job_get(self.job_id())
-            if 'qObjectResult' in job_response:
-                results = job_response['qObjectResult']['results']
-                self._api_error_msg = build_error_report(results)
-            elif 'qasms' in job_response:
-                qasm_statuses = [qasm['status'] for qasm in job_response['qasms']]
-                self._api_error_msg = 'Job resulted in the following QASM status(es): ' \
-                                      '{}.'.format(', '.join(qasm_statuses))
+        if not self._job_error_report:
+            result_response = self._get_result_response()
+            if 'error' in result_response and not result_response['results']:
+                # If no individual error given.
+                self._job_error_report = 'Job failed: {}'.format(result_response['error']['message'])
             else:
-                self._api_error_msg = job_response.get('status', 'An unknown error occurred.')
+                self._job_error_report = build_error_report(result_response['results'])
 
-        return self._api_error_msg
+        return self._job_error_report
 
     def queue_position(self) -> Optional[int]:
         """Return the position in the server queue.
@@ -395,3 +390,14 @@ class IBMQJob(BaseModel, BaseJob):
         self._update_status_position(ApiJobStatus(status_response['status']),
                                      status_response.get('infoQueue', None))
         return self._status in required_status
+
+    def _get_result_response(self) -> Dict:
+        """Return the API result response.
+
+        Returns:
+            dict: Result response from the API.
+        """
+        if hasattr(self, 'qObjectResult'):
+            return self.qObjectResult
+        with api_to_job_error():
+            return self._api.job_result(self.job_id(), self._use_object_storage)

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -141,8 +141,7 @@ class IBMQJob(BaseModel, BaseJob):
 
         # Properties used for caching.
         self._cancelled = False
-        self._job_error_report = None
-        self._job_error_message = None
+        self._job_error_msg = None
         self._result = None
         self._queue_position = None
 
@@ -303,16 +302,16 @@ class IBMQJob(BaseModel, BaseJob):
         if not self._wait_for_completion(required_status=(JobStatus.ERROR,)):
             return None
 
-        if not self._job_error_report:
+        if not self._job_error_msg:
             result_response = self._get_result_response()
             if 'error' in result_response and not result_response['results']:
                 # If no individual error given.
-                self._job_error_report = 'Job failed: {}'.format(
+                self._job_error_msg = 'Job failed: {}'.format(
                     result_response['error']['message'])
             else:
-                self._job_error_report = build_error_report(result_response['results'])
+                self._job_error_msg = build_error_report(result_response['results'])
 
-        return self._job_error_report
+        return self._job_error_msg
 
     def queue_position(self) -> Optional[int]:
         """Return the position in the server queue.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -307,7 +307,8 @@ class IBMQJob(BaseModel, BaseJob):
             result_response = self._get_result_response()
             if 'error' in result_response and not result_response['results']:
                 # If no individual error given.
-                self._job_error_report = 'Job failed: {}'.format(result_response['error']['message'])
+                self._job_error_report = 'Job failed: {}'.format(
+                    result_response['error']['message'])
             else:
                 self._job_error_report = build_error_report(result_response['results'])
 

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -129,6 +129,7 @@ class IBMQJob(BaseModel, BaseJob):
         self.time_per_step = kwargs.pop('timePerStep', None)
         self.name = kwargs.pop('name', None)
         self._api_backend = kwargs.pop('backend', None)
+        self._job_error_msg = kwargs.pop('error', None)
 
         # Get Qobj from either the API result (qObject) or user input (qobj)
         qobj_dict = kwargs.pop('qObject', None)
@@ -141,7 +142,6 @@ class IBMQJob(BaseModel, BaseJob):
 
         # Properties used for caching.
         self._cancelled = False
-        self._job_error_msg = None
         self._result = None
         self._queue_position = None
 
@@ -306,12 +306,11 @@ class IBMQJob(BaseModel, BaseJob):
             result_response = self._get_result_response()
             if 'error' in result_response and not result_response['results']:
                 # If no individual error given.
-                self._job_error_msg = 'Job failed: {}'.format(
-                    result_response['error']['message'])
+                self._job_error_msg = result_response['error']['message']
             else:
                 self._job_error_msg = build_error_report(result_response['results'])
 
-        return self._job_error_msg
+        return "Error running job. " + self._job_error_msg
 
     def queue_position(self) -> Optional[int]:
         """Return the position in the server queue.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -304,11 +304,14 @@ class IBMQJob(BaseModel, BaseJob):
 
         if not self._job_error_msg:
             result_response = self._get_result_response()
-            if 'error' in result_response and not result_response['results']:
-                # If no individual error given.
+            if result_response['results']:
+                # If individual errors given
+                self._job_error_msg = build_error_report(result_response['results'])
+            elif 'error' in result_response:
                 self._job_error_msg = result_response['error']['message']
             else:
-                self._job_error_msg = build_error_report(result_response['results'])
+                # No error message given
+                self._job_error_msg = "Unknown error."
 
         return "Error running job. " + self._job_error_msg
 

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -36,17 +36,26 @@ FIELDS_MAP = {
     'backend': '_backend_info',
     'creationDate': '_creation_date',
     'qObject': '_qobj',
-    'qObjectResult': '_result'
+    'qObjectResult': '_result',
+    'error': '_error'
 }
 
 
 # Helper schemas.
 
 class JobResponseBackendSchema(BaseSchema):
-    """Nested schema for JobResponseSchema"""
+    """Nested schema for the backend field in JobResponseSchema."""
 
     # Required properties
     name = String(required=True)
+
+
+class JobResponseErrorSchema(BaseSchema):
+    """Nested schema for the error field in JobResponseSchema."""
+
+    # Required properties
+    code = Integer(required=True)
+    message = String(required=True)
 
 
 # Endpoint schemas.
@@ -82,6 +91,7 @@ class JobResponseSchema(BaseSchema):
     time_per_step = Dict(keys=String, values=String, missing=None)
     _result = Nested(ResultSchema, missing=None)
     _qobj = Nested(QobjSchema, missing=None)
+    _error = Nested(JobResponseErrorSchema, missing=None)
 
     # Optional properties
     _backend_info = Nested(JobResponseBackendSchema)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -373,24 +373,35 @@ class TestIBMQJob(JobTestCase):
             job.submit()
 
     @requires_provider
-    def test_error_message_qasm(self, provider):
-        """Test retrieving job error messages including QASM status(es)."""
+    def test_error_message_simulator(self, provider):
+        """Test retrieving job error messages from a simulator backend."""
         backend = provider.get_backend('ibmq_qasm_simulator')
 
-        qr = QuantumRegister(5)  # 5 is sufficient for this test
-        cr = ClassicalRegister(2)
-        qc = QuantumCircuit(qr, cr)
-        qc.cx(qr[0], qr[1])
-        qc_new = transpile(qc, backend)
+        qc_new = transpile(self._qc, backend)
+        qobj = assemble([qc_new, qc_new], backend=backend)
+        qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
-        qobj = assemble(qc_new, shots=1000)
-        qobj.experiments[0].instructions[0].name = 'test_name'
-
-        job_sim = backend.run(qobj)
+        job = backend.run(qobj)
         with self.assertRaises(JobError):
-            job_sim.result()
+            job.result()
 
-        message = job_sim.error_message()
+        message = job.error_message()
+        self.assertIn('Experiment 1: ERROR', message)
+
+    @run_on_staging
+    def test_error_message_device(self, provider):
+        """Test retrieving job error messages from a simulator backend."""
+        backend = least_busy(provider.backends(simulator=False))
+
+        qc_new = transpile(self._qc, backend)
+        qobj = assemble([qc_new, qc_new], backend=backend)
+        qobj.experiments[1].instructions[1].name = 'bad_instruction'
+
+        job = backend.run(qobj)
+        with self.assertRaises(JobError):
+            job.result()
+
+        message = job.error_message()
         self.assertTrue(message)
 
     @run_on_staging

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -384,7 +384,6 @@ class TestIBMQJob(JobTestCase):
             job.result()
 
         message = job.error_message()
-        print(f"message is {message}")
         self.assertIn('Experiment 1: ERROR', message)
 
     @requires_provider


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Addresses #176. This PR focuses on extracting `error` from `qObjectResult` when partial results are not returned. The latter will be revisited when partial result is schema compliant. 


### Details and comments
`job.error_message()` will now return
```
Instruction not in basis gates: instruction: bad_instruction, qubits: [0, 1], params: []
```
or 
```
The following experiments failed:
Experiment 1: ERROR: Circuit contains invalid instructions ( invalid gate instructions: {bad_instruction})
```
if individual experiment status is known. 

