### PR TITLE
Add subclass for retired backend during retrieve_job

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -18,7 +18,7 @@ import logging
 import warnings
 
 from typing import Dict, List, Union, Optional, Any
-from datetime import datetime  as python_datetime
+from datetime import datetime as python_datetime
 from marshmallow import ValidationError
 
 from qiskit.qobj import Qobj, validate_qobj_against_schema

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -18,7 +18,7 @@ import logging
 import warnings
 
 from typing import Dict, List, Union, Optional, Any
-from datetime import datetime  # pylint: disable=unused-import
+from datetime import datetime  as python_datetime
 from marshmallow import ValidationError
 
 from qiskit.qobj import Qobj, validate_qobj_against_schema
@@ -141,7 +141,7 @@ class IBMQBackend(BaseBackend):
     def properties(
             self,
             refresh: bool = False,
-            datetime: Optional[datetime] = None  # pylint: disable=redefined-outer-name
+            datetime: Optional[python_datetime] = None
     ) -> Optional[BackendProperties]:
         """Return the online backend properties with optional filtering.
 
@@ -306,7 +306,7 @@ class IBMQSimulator(IBMQBackend):
     def properties(
             self,
             refresh: bool = False,
-            datetime: Optional[datetime] = None  # pylint: disable=redefined-outer-name
+            datetime: Optional[python_datetime] = None
     ) -> None:
         """Return the online backend properties.
 
@@ -368,7 +368,7 @@ class IBMQRetiredBackend(IBMQBackend):
     def properties(
             self,
             refresh: bool = False,
-            datetime: Optional[datetime] = None  # pylint: disable=redefined-outer-name
+            datetime: Optional[python_datetime] = None
     ) -> None:
         """Return the online backend properties."""
         return None

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -363,14 +363,17 @@ class IBMQRetiredBackend(IBMQBackend):
             backend_version=self.configuration().backend_version,
             operational=False,
             pending_jobs=0,
-            status_msg='retired')
+            status_msg='This backend is no longer available.')
 
-    @staticmethod
-    def properties(self, **kwargs: Any) -> None:
+    def properties(
+            self,
+            refresh: bool = False,
+            datetime: Optional[datetime] = None  # pylint: disable=redefined-outer-name
+    ) -> None:
         """Return the online backend properties."""
         return None
 
-    def defaults(self, **kwargs: Any) -> None:
+    def defaults(self, refresh: bool = False) -> None:
         """Return the pulse defaults for the backend."""
         return None
 
@@ -378,12 +381,14 @@ class IBMQRetiredBackend(IBMQBackend):
         """Return the online backend status."""
         return self._status
 
-    def run(self, **kwargs: Any) -> None:
+    def run(self, qobj: Qobj, job_name: Optional[str] = None) -> None:
         """Run a Qobj."""
         raise IBMQBackendError('This backend is no longer available.')
 
     @classmethod
-    def from_name(cls, backend_name: str,
+    def from_name(
+            cls,
+            backend_name: str,
             provider: 'AccountProvider',
             credentials: Credentials,
             api: AccountClient
@@ -401,6 +406,6 @@ class IBMQRetiredBackend(IBMQBackend):
             memory=False,
             max_shots=1,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
-            coupling_map=[[0,1]],
+            coupling_map=[[0, 1]],
         )
         return cls(configuration, provider, credentials, api)

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -18,14 +18,14 @@ import warnings
 from typing import Dict, List, Callable, Optional, Any, Union
 from types import SimpleNamespace
 
-from qiskit.providers import JobStatus
+from qiskit.providers import JobStatus, QiskitBackendNotFoundError
 from qiskit.providers.providerutils import filter_backends
 from qiskit.validation.exceptions import ModelValidationError
 
 from .api.exceptions import ApiError
 from .apiconstants import ApiJobStatus
 from .exceptions import IBMQBackendError, IBMQBackendValueError
-from .ibmqbackend import IBMQBackend
+from .ibmqbackend import IBMQBackend, IBMQRetiredBackend
 from .job import IBMQJob
 from .utils import to_python_identifier
 
@@ -261,10 +261,18 @@ class IBMQBackendService(SimpleNamespace):
             raise IBMQBackendError('Failed to get job "{}": {}'
                                    .format(job_id, str(ex)))
 
-        # TODO: in a similar way to IBMQJob creation during `.jobs()`,
-        # temporarily leaving the first argument as `None`.
+        # Recreate the backend used for this job.
+        backend_name = job_info.get('backend', {}).get('name', 'unknown')
+        try:
+            backend = self._provider.get_backend(backend_name)
+        except QiskitBackendNotFoundError:
+            backend = IBMQRetiredBackend.from_name(backend_name,
+                                                   self._provider,
+                                                   self._provider.credentials,
+                                                   self._provider._api)
+
         job_info.update({
-            '_backend': None,
+            '_backend': backend,
             'api': self._provider._api
         })
         try:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Partially addresses #363 

Introduce a new subclass of `IBMQBackend` with limited capabilities, that allow `job.backend()` to return a backend instance even for jobs whose backend is no longer available. The subclass has very limited functionality, bound to be expanded depending on conversations with the API team (ie. we _might_ be able to retrieve calibrations and properties for a retired backend through its endpoints).

The PR does not address backend instantiation during `.jobs()` yet  - only at `.retrieve_job()`, as it is the place where we are guaranteed to have a backend name at the moment.

### Details and comments


