### PR TITLE
Method to refresh job data

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -361,6 +361,11 @@ class IBMQJob(BaseModel, BaseJob):
 
         warnings.warn("Please use IBMQBackend.run() to submit a job.")
 
+    def refresh(self) -> None:
+        """Obtain the latest job information from the API."""
+        with api_to_job_error():
+            api_response = self._api.job_get(self.job_id())
+
     def _wait_for_completion(
             self,
             timeout: Optional[float] = None,

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -470,6 +470,21 @@ class TestIBMQJob(JobTestCase):
         retrieved_job_ids = {job.job_id() for job in retrieved_jobs}
         self.assertEqual(job_ids, retrieved_job_ids)
 
+    @requires_provider
+    def test_refresh(self, provider):
+        """Test refreshing job data."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
+        job = backend.run(qobj)
+
+        time_per_step = getattr(job, 'time_per_step', {})
+        job.result()
+        job.refresh()
+        time_per_step_new = job.time_per_step
+        self.assertGreater(len(time_per_step_new), len(time_per_step),
+                           "Initial time_per_step is {}, updated time_per_step is {}".format(
+                               time_per_step, time_per_step_new))
+
 
 def _bell_circuit():
     qr = QuantumRegister(2, 'q')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #364 . A `refresh()` method to update job data.


### Details and comments
This method probably isn't too useful right now given there aren't many dynamic attributes that a user should care about, but it might be needed in the future as API adds more attributes.

I didn't bother adding a callback to `refresh` from `api.job_get()`, since the `job_get()` is only called when object storage is not used, and all backends should support object storage soon. 

