### PR TITLE
Promote some job attributes to methods

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -81,9 +81,9 @@ class IBMQJob(BaseModel, BaseJob):
     failures happened at the server level.
 
     Job information retrieved from the API server is attached to the ``IBMQJob``
-    as attributes. Given Qiskit and the API server can be updated
-    independently, some of these attributes can be deprecated or experimental.
-    The ones known to be supported are converted to methods. For example, you
+    instance as attributes. Given that Qiskit and the API server can be updated
+    independently, some of these attributes might be deprecated or experimental.
+    Supported attributes can be retrieved via methods. For example, you
     can use ``IBMQJob.creation_date()`` to retrieve the job creation date,
     which is a supported attribute.
 

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -352,7 +352,7 @@ class IBMQJob(BaseModel, BaseJob):
         """Return the name assigned to this job.
 
         Returns:
-            str: the job name.
+            str: the job name or ``None`` if no name was assigned to the job.
         """
         return self._name
 
@@ -374,7 +374,8 @@ class IBMQJob(BaseModel, BaseJob):
         """Submit job to IBM-Q.
 
         Note:
-            This function waits for a job ID to become available.
+            This function is deprecated, please use ``IBMQBackend.run()`` to
+                submit a job.
 
         Events:
             ibmq.job.start: The job has started.
@@ -385,7 +386,8 @@ class IBMQJob(BaseModel, BaseJob):
         if self.job_id() is not None:
             raise JobError("We have already submitted the job!")
 
-        warnings.warn("Please use IBMQBackend.run() to submit a job.")
+        warnings.warn("job.submit() is deprecated. Please use "
+                      "IBMQBackend.run() to submit a job.", DeprecationWarning)
 
     def refresh(self) -> None:
         """Obtain the latest job information from the API."""

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -268,6 +268,9 @@ class IBMQJob(BaseModel, BaseJob):
             if queued:
                 self._status = JobStatus.QUEUED
 
+        if self._status is not JobStatus.QUEUED:
+            self._queue_position = None
+
     def error_message(self) -> Optional[str]:
         """Provide details about the reason of failure.
 
@@ -309,7 +312,8 @@ class IBMQJob(BaseModel, BaseJob):
         """Return the position in the server queue.
 
         Returns:
-            int: Position in the queue or ``None`` if position is unknown.
+            int: Position in the queue or ``None`` if position is unknown or
+                not applicable.
         """
         # Get latest position
         self.status()

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -144,8 +144,6 @@ class IBMQJob(BaseModel, BaseJob):
         """
         # pylint: disable=access-member-before-definition,attribute-defined-outside-init
         if not self._qobj:
-            # Populate self._qobj_dict by retrieving the results.
-            # TODO Can qobj be retrieved if the job was cancelled?
             self._wait_for_completion()
             with api_to_job_error():
                 qobj = self._api.job_download_qobj(
@@ -330,6 +328,27 @@ class IBMQJob(BaseModel, BaseJob):
             str: the job ID.
         """
         return self._job_id
+
+    def name(self) -> Optional[str]:
+        """Return the name assigned to this job.
+
+        Returns:
+            str: the job name.
+        """
+        return self._name
+
+    def time_per_step(self) -> Optional[Dict]:
+        """Return the date and time information on each step of the job processing.
+
+        Returns:
+            dict: a dictionary containing the date and time information on each
+                step of the job processing. The keys of the dictionary are the
+                names of the steps, and the values are the date and time
+                information. ``None`` is returned if the information is not
+                yet available.
+        """
+        # TODO refresh job data
+        return self._time_per_step
 
     def submit(self) -> None:
         """Submit job to IBM-Q.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -80,6 +80,13 @@ class IBMQJob(BaseModel, BaseJob):
     Many of the ``IBMQJob`` methods can raise ``JobError`` if unexpected
     failures happened at the server level.
 
+    Job information retrieved from the API server is attached to the ``IBMQJob``
+    as attributes. Given Qiskit and the API server can be updated
+    independently, some of these attributes can be deprecated or experimental.
+    The ones known to be supported are converted to methods. For example, you
+    can use ``IBMQJob.creation_date()`` to retrieve the job creation date,
+    which is a supported attribute.
+
     Note:
         When querying the server for getting the job information, two kinds
         of errors are possible. The most severe is the one preventing Qiskit

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -36,7 +36,9 @@ FIELDS_MAP = {
     'backend': '_backend_info',
     'creationDate': '_creation_date',
     'qObject': '_qobj',
-    'qObjectResult': '_result'
+    'qObjectResult': '_result',
+    'name': '_name',
+    'timePerStep': '_time_per_step'
 }
 
 
@@ -77,9 +79,9 @@ class JobResponseSchema(BaseSchema):
     _status = Enum(required=True, enum_cls=ApiJobStatus)
 
     # Optional properties with a default value.
-    name = String(missing=None)
+    _name = String(missing=None)
     shots = Integer(validate=Range(min=0), missing=None)
-    time_per_step = Dict(keys=String, values=String, missing=None)
+    _time_per_step = Dict(keys=String, values=String, missing=None)
     _result = Nested(ResultSchema, missing=None)
     _qobj = Nested(QobjSchema, missing=None)
 

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -364,7 +364,6 @@ class TestIBMQJob(JobTestCase):
         with self.assertRaises(JobError):
             job.result()
 
-        time.sleep(3)
         new_job = provider.backends.retrieve_job(job.job_id())
         message = new_job.error_message()
         self.assertIn('Experiment 1: ERROR', message)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -352,22 +352,6 @@ class TestIBMQJob(JobTestCase):
             job.submit()
 
     @requires_provider
-    def test_error_message_simulator(self, provider):
-        """Test retrieving job error messages from a simulator backend."""
-        backend = provider.get_backend('ibmq_qasm_simulator')
-
-        qc_new = transpile(self._qc, backend)
-        qobj = assemble([qc_new, qc_new], backend=backend)
-        qobj.experiments[1].instructions[1].name = 'bad_instruction'
-
-        job = backend.run(qobj)
-        with self.assertRaises(JobError):
-            job.result()
-
-        message = job.error_message()
-        self.assertIn('Experiment 1: ERROR', message)
-
-    @requires_provider
     def test_retrieve_failed_job_simulator(self, provider):
         """Test retrieving job error messages from a simulator backend."""
         backend = provider.get_backend('ibmq_qasm_simulator')
@@ -386,22 +370,6 @@ class TestIBMQJob(JobTestCase):
         self.assertIn('Experiment 1: ERROR', message)
 
     @run_on_staging
-    def test_error_message_device(self, provider):
-        """Test retrieving job error messages from a device backend."""
-        backend = least_busy(provider.backends(simulator=False))
-
-        qc_new = transpile(self._qc, backend)
-        qobj = assemble([qc_new, qc_new], backend=backend)
-        qobj.experiments[1].instructions[1].name = 'bad_instruction'
-
-        job = backend.run(qobj)
-        with self.assertRaises(JobError):
-            job.result()
-
-        message = job.error_message()
-        self.assertTrue(message)
-
-    @run_on_staging
     def test_retrieve_failed_job_device(self, provider):
         """Test retrieving a failed job from a device backend."""
         backend = least_busy(provider.backends(simulator=False))
@@ -416,15 +384,6 @@ class TestIBMQJob(JobTestCase):
 
         new_job = provider.backends.retrieve_job(job.job_id())
         self.assertTrue(new_job.error_message())
-
-    @run_on_staging
-    def test_running_job_properties(self, provider):
-        """Test fetching properties of a running job."""
-        backend = least_busy(provider.backends(simulator=False))
-
-        qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
-        job = backend.run(qobj)
-        _ = job.properties()
 
     @slow_test
     @requires_qe_access

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -17,7 +17,7 @@
 import time
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers import JobError, JobStatus
+from qiskit.providers import JobError
 from qiskit.providers.ibmq import least_busy
 from qiskit.compiler import assemble, transpile
 

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -15,24 +15,14 @@
 """IBMQJob Test."""
 
 import time
-import warnings
-from concurrent import futures
-
-import numpy
-from scipy.stats import chi2_contingency
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers import JobError, JobStatus
+from qiskit.providers import JobError
 from qiskit.providers.ibmq import least_busy
-from qiskit.providers.ibmq.exceptions import IBMQBackendError
-from qiskit.providers.ibmq.ibmqfactory import IBMQFactory
-from qiskit.providers.ibmq.job.ibmqjob import IBMQJob
-from qiskit.test import slow_test
 from qiskit.compiler import assemble, transpile
 
 from ..jobtestcase import JobTestCase
-from ..decorators import (requires_provider, requires_qe_access,
-                          run_on_staging)
+from ..decorators import requires_provider, run_on_staging
 
 
 class TestIBMQJobAttributes(JobTestCase):

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -51,27 +51,6 @@ class TestIBMQJobAttributes(JobTestCase):
         job = backend.run(qobj)
         self.assertTrue(job.backend().name() == backend.name())
 
-    @requires_provider
-    def test_error_message_qasm(self, provider):
-        """Test retrieving job error messages including QASM status(es)."""
-        backend = provider.get_backend('ibmq_qasm_simulator')
-
-        qr = QuantumRegister(5)  # 5 is sufficient for this test
-        cr = ClassicalRegister(2)
-        qc = QuantumCircuit(qr, cr)
-        qc.cx(qr[0], qr[1])
-        qc_new = transpile(qc, backend)
-
-        qobj = assemble(qc_new, shots=1000)
-        qobj.experiments[0].instructions[0].name = 'test_name'
-
-        job_sim = backend.run(qobj)
-        with self.assertRaises(JobError):
-            job_sim.result()
-
-        message = job_sim.error_message()
-        self.assertTrue(message)
-
     @run_on_staging
     def test_running_job_properties(self, provider):
         """Test fetching properties of a running job."""

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -53,6 +53,9 @@ MOCKED_ERROR_RESULT = {
 
 VALID_QOBJ_RESPONSE = {
     'status': 'COMPLETED',
+    'kind': 'q-object',
+    'creationDate': '2019-01-01T12:57:15.052Z',
+    'id': '0123456789',
     'qObjectResult': {
         'backend_name': 'ibmqx2',
         'backend_version': '1.1.1',
@@ -319,6 +322,7 @@ class TestIBMQJobStates(JobTestCase):
         backend = IBMQBackend(mock.Mock(), mock.Mock(), mock.Mock(), api=api)
         self._current_api = api
         self._current_qjob = backend.run(qobj=new_fake_qobj())
+        self._current_qjob.refresh = mock.Mock()
         return self._current_qjob
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Promoting `name` and `time_per_step` to methods. Closes #375 . Addresses #118 .

This PR also splits `test_ibmq_job.py` into `test_ibmq_job.py` and `test_ibmq_job_attributes`, with the latter dealing with methods that retrieve job attributes, since `test_ibmq_job.py` was getting really large. 

Also refreshes job attributes when it enters a final state.
### Details and comments


