### PR TITLE
Update job.properties() docstring

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -160,12 +160,8 @@ class IBMQJob(BaseModel, BaseJob):
     def properties(self) -> Optional[BackendProperties]:
         """Return the backend properties for this job.
 
-        The properties might not be available if the job hasn't completed,
-        in which case None is returned.
-
         Returns:
-            BackendProperties: the backend properties used for this job, or None if
-                properties are not available.
+            BackendProperties: the backend properties used for this job.
 
         Raises:
             JobError: if there was some unexpected failure in the server.
@@ -173,10 +169,6 @@ class IBMQJob(BaseModel, BaseJob):
         with api_to_job_error():
             properties = self._api.job_properties(job_id=self.job_id())
 
-        # Backend properties of a job might not be available if the job hasn't
-        # completed. This is to ensure the properties returned are up to date.
-        if not properties:
-            return None
         return BackendProperties.from_dict(properties)
 
     def result(self, timeout: Optional[float] = None, wait: float = 5) -> Result:

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -161,13 +161,17 @@ class IBMQJob(BaseModel, BaseJob):
         """Return the backend properties for this job.
 
         Returns:
-            BackendProperties: the backend properties used for this job.
+            BackendProperties: the backend properties used for this job, or None if
+                properties are not available.
 
         Raises:
             JobError: if there was some unexpected failure in the server.
         """
         with api_to_job_error():
             properties = self._api.job_properties(job_id=self.job_id())
+
+        if not properties:
+            return None
 
         return BackendProperties.from_dict(properties)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As discussed in #116, API now returns backend properties at job creation time if the job hasn't finished. The existing docstring is misleading. The PR left the dostring ambiguous since the behavior is likely to change again.  


### Details and comments


