### PR TITLE
Allow partial matching and regexp in job_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ The format is based on [Keep a Changelog].
 - The `IBMQBackend.run()` function now accepts an optional `job_name` parameter.
   If specified, the `job_name` is assigned to the job. This `job_name` can 
   subsequently be used as a filter in the `IBMQBackend.jobs()` function, which
-  now accepts an optional `job_name` parameter. `job_name` does not need to be 
+  now accepts an optional `job_name` parameter (allowing partial matching and
+  use of regular expressions). `job_name` does not need to be
   unique among jobs. These new parameters are ignored if IBM Q Experience 
-  v1 account is used (\#300).
+  v1 account is used (\#300, \#384).
 - The signature of `IBMQBackend.jobs()` is changed. `db_filter`, which was the 
   4th parameter, is now the 5th parameter (\#300).
 - The `backend.properties()` function now accepts an optional `datetime` 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -238,7 +238,10 @@ class IBMQBackend(BaseBackend):
             status (None or qiskit.providers.JobStatus or str): only get jobs
                 with this status, where status is e.g. `JobStatus.RUNNING` or
                 `'RUNNING'`
-            job_name (str): only get jobs with this job name.
+            job_name (str): filter by job name. The `job_name` is matched
+                partially and `regular expressions
+                <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions>
+                `_ can be used.
             db_filter (dict): `loopback-based filter
                 <https://loopback.io/doc/en/lb2/Querying-data.html>`_.
                 This is an interface to a database ``where`` filter. Some

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -151,7 +151,7 @@ class IBMQBackendService(SimpleNamespace):
             IBMQBackendValueError: status keyword value unrecognized
         """
         # Build the filter for the query.
-        api_filter = {}
+        api_filter = {}  # type: Dict[str, Any]
 
         if backend_name:
             api_filter['backend.name'] = backend_name
@@ -174,7 +174,7 @@ class IBMQBackendService(SimpleNamespace):
             else:
                 raise IBMQBackendValueError('unrecognized value for "status" keyword '
                                             'in job filter')
-            api_filter.update(this_filter)  # type: ignore[assignment]
+            api_filter.update(this_filter)
 
         if job_name:
             api_filter['name'] = {"regexp": job_name}
@@ -185,7 +185,7 @@ class IBMQBackendService(SimpleNamespace):
 
         # Retrieve the requested number of jobs, using pagination. The API
         # might limit the number of jobs per request.
-        job_responses = []  # type: ignore[var-annotated]
+        job_responses = []  # type: List[Dict[str, Any]]
         current_page_limit = limit
 
         while True:

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -117,7 +117,10 @@ class IBMQBackendService(SimpleNamespace):
             status (None or qiskit.providers.JobStatus or str): only get jobs
                 with this status, where status is e.g. `JobStatus.RUNNING` or
                 `'RUNNING'`
-            job_name (str): only get jobs with this job name.
+            job_name (str): filter by job name. The `job_name` is matched
+                partially and `regular expressions
+                <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions>
+                `_ can be used.
             db_filter (dict): `loopback-based filter
                 <https://loopback.io/doc/en/lb2/Querying-data.html>`_.
                 This is an interface to a database ``where`` filter. Some
@@ -174,7 +177,7 @@ class IBMQBackendService(SimpleNamespace):
             api_filter.update(this_filter)  # type: ignore[assignment]
 
         if job_name:
-            api_filter['name'] = job_name
+            api_filter['name'] = {"regexp": job_name}
 
         if db_filter:
             # status takes precedence over db_filter for same keys
@@ -210,15 +213,12 @@ class IBMQBackendService(SimpleNamespace):
                 continue
 
             job_id = job_info.get('id', "")
-            # TODO Extract job name from job_info instead of passing it in
-            # once it becomes available from the API.
             # TODO: first argument for IBMQJob should be a Backend, but as
             # `job_responses` comes from `jobs_statuses`, the backend name
             # might not be present. Revise during IBMQJob refactoring.
             job_info.update({
                 '_backend': None,
                 'api': self._provider._api,
-                'name': job_name
             })
             try:
                 job = IBMQJob.from_dict(job_info)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #118 and after #378, revise the handling of `job_name` during `.jobs()` by:
* defaulting to doing partial matching and allowing regular expressions
* avoid overwriting the `job_name` coming from the job list response from the API, now that we can count on it being present in the response


### Details and comments


