### PR TITLE
Make queue position refresh optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ The format is based on [Keep a Changelog].
 - `IBMQJob` constructor signature has changed (\#329).
 - `IBMQJob.submit()` can no longer be called directly, and jobs are expected
   to be submitted via `IBMQBackend.run()` (\#329).
-- `IBMQJob.error_message()` now gives more information on why a job failed (\#375). 
+- `IBMQJob.error_message()` now gives more information on why a job failed (\#375).
+- `IBMQJob.queue_position()` now accepts an optional `refresh` parameter that 
+  indicates whether it should query the API for the latest queue position (\#387). 
 
 ### Removed
 

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -317,15 +317,20 @@ class IBMQJob(BaseModel, BaseJob):
 
         return self._job_error_msg
 
-    def queue_position(self) -> Optional[int]:
+    def queue_position(self, refresh: bool = False) -> Optional[int]:
         """Return the position in the server queue.
+
+        Args:
+            refresh (bool): if True, query the API and return the latest value.
+                Otherwise return the cached value.
 
         Returns:
             int: Position in the queue or ``None`` if position is unknown or
                 not applicable.
         """
-        # Get latest position
-        self.status()
+        if refresh:
+            # Get latest position
+            self.status()
         return self._queue_position
 
     def creation_date(self) -> str:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Introduce a new `refresh` parameter in `job.queue_position()` and query the API only if `refresh=True`.


### Details and comments
#329 updated `job.queue_position()` to query the latest queue position every time it's called (by calling `job.status()`), with the intent to provide the caller the latest position. This change, however, severs the ties between job status and queue position.  For example, `job_monitor` in `qiskit-terra` has:
```
if status.name == 'QUEUED':
    msg += ' (%s)' % job.queue_position()
```
but the job status may no longer be `QUEUED` when `queue_position()` is called, and `queue_position()` would return `None`. 

To keep backward compatibility for users who rely on `status` and `queue_position` being in sync, this PR refreshes queue position only if `refresh=True`.
