### PR TITLE
no breaking line in UPDATE_ACCOUNT_TEXT

### DIFF
--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -30,9 +30,9 @@ from .exceptions import IBMQAccountError, IBMQApiUrlError, IBMQProviderError
 logger = logging.getLogger(__name__)
 
 QX_AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
-UPDATE_ACCOUNT_TEXT = (
-    "Please update your accounts and programs by following the instructions here:",
-    "https://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience")
+UPDATE_ACCOUNT_TEXT = "Please update your accounts and programs by following the " \
+                      "instructions here: https://github.com/Qiskit/qiskit-ibmq-provider#" \
+                      "updating-to-the-new-ibm-q-experience "
 
 
 class IBMQFactory:
@@ -128,8 +128,8 @@ class IBMQFactory:
                 'No IBM Q Experience credentials found on disk.')
 
         if len(credentials_list) > 1:
-            raise IBMQAccountError('Multiple IBM Q Experience credentials found.',
-                                   *UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Multiple IBM Q Experience credentials found. ' +
+                                   UPDATE_ACCOUNT_TEXT)
 
         credentials = credentials_list[0]
         # Explicitly check via an API call, to allow environment auth URLs
@@ -138,8 +138,8 @@ class IBMQFactory:
 
         # Check the URL is a valid authentication URL.
         if not version_info['new_api'] or 'api-auth' not in version_info:
-            raise IBMQAccountError('Invalid IBM Q Experience credentials found.',
-                                   *UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Invalid IBM Q Experience credentials found. ' +
+                                   UPDATE_ACCOUNT_TEXT)
 
         # Initialize the providers.
         if self._credentials:
@@ -181,8 +181,8 @@ class IBMQFactory:
                 authentication URL.
         """
         if url != QX_AUTH_URL:
-            raise IBMQApiUrlError('Invalid IBM Q Experience credentials found.',
-                                  *UPDATE_ACCOUNT_TEXT)
+            raise IBMQApiUrlError(
+                'Invalid IBM Q Experience credentials found. ' + UPDATE_ACCOUNT_TEXT)
 
         credentials = Credentials(token, url, **kwargs)
 
@@ -200,13 +200,13 @@ class IBMQFactory:
             raise IBMQAccountError('No credentials found.')
 
         if len(stored_credentials) != 1:
-            raise IBMQAccountError('Multiple credentials found.', *UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Multiple credentials found. ' + UPDATE_ACCOUNT_TEXT)
 
         credentials = list(stored_credentials.values())[0]
 
         if credentials.url != QX_AUTH_URL:
-            raise IBMQAccountError('Invalid IBM Q Experience credentials found.',
-                                   *UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError(
+                'Invalid IBM Q Experience credentials found. ' + UPDATE_ACCOUNT_TEXT)
 
         remove_credentials(credentials)
 
@@ -226,8 +226,8 @@ class IBMQFactory:
 
         if (len(stored_credentials) > 1 or
                 list(stored_credentials.values())[0].url != QX_AUTH_URL):
-            raise IBMQAccountError('Invalid IBM Q Experience credentials found.',
-                                   *UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError(
+                'Invalid IBM Q Experience credentials found. ' + UPDATE_ACCOUNT_TEXT)
 
         credentials = list(stored_credentials.values())[0]
         return {

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # This code is part of Qiskit.
@@ -28,13 +27,12 @@ from .credentials.configrc import (read_credentials_from_qiskitrc,
 from .credentials.updater import update_credentials
 from .exceptions import IBMQAccountError, IBMQApiUrlError, IBMQProviderError
 
-
 logger = logging.getLogger(__name__)
 
 QX_AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
 UPDATE_ACCOUNT_TEXT = (
-    'Please update your accounts and programs by following the instructions here:\n'
-    'https://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience')
+    "Please update your accounts and programs by following the instructions here:",
+    "https://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience""")
 
 
 class IBMQFactory:
@@ -130,8 +128,8 @@ class IBMQFactory:
                 'No IBM Q Experience credentials found on disk.')
 
         if len(credentials_list) > 1:
-            raise IBMQAccountError('Multiple IBM Q Experience credentials '
-                                   'found. ' + UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Multiple IBM Q Experience credentials found.',
+                                   *UPDATE_ACCOUNT_TEXT)
 
         credentials = credentials_list[0]
         # Explicitly check via an API call, to allow environment auth URLs
@@ -140,8 +138,8 @@ class IBMQFactory:
 
         # Check the URL is a valid authentication URL.
         if not version_info['new_api'] or 'api-auth' not in version_info:
-            raise IBMQAccountError('Invalid IBM Q Experience credentials '
-                                   'found. ' + UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Invalid IBM Q Experience credentials found.',
+                                   *UPDATE_ACCOUNT_TEXT)
 
         # Initialize the providers.
         if self._credentials:
@@ -183,8 +181,8 @@ class IBMQFactory:
                 authentication URL.
         """
         if url != QX_AUTH_URL:
-            raise IBMQApiUrlError('Invalid IBM Q Experience credentials '
-                                  'found. ' + UPDATE_ACCOUNT_TEXT)
+            raise IBMQApiUrlError('Invalid IBM Q Experience credentials found.',
+                                  *UPDATE_ACCOUNT_TEXT)
 
         credentials = Credentials(token, url, **kwargs)
 
@@ -202,14 +200,13 @@ class IBMQFactory:
             raise IBMQAccountError('No credentials found.')
 
         if len(stored_credentials) != 1:
-            raise IBMQAccountError('Multiple credentials found. ' +
-                                   UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Multiple credentials found.', *UPDATE_ACCOUNT_TEXT)
 
         credentials = list(stored_credentials.values())[0]
 
         if credentials.url != QX_AUTH_URL:
-            raise IBMQAccountError('Invalid IBM Q Experience credentials '
-                                   'found. ' + UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Invalid IBM Q Experience credentials found.',
+                                   *UPDATE_ACCOUNT_TEXT)
 
         remove_credentials(credentials)
 
@@ -229,8 +226,8 @@ class IBMQFactory:
 
         if (len(stored_credentials) > 1 or
                 list(stored_credentials.values())[0].url != QX_AUTH_URL):
-            raise IBMQAccountError('Invalid IBM Q Experience credentials '
-                                   'found. ' + UPDATE_ACCOUNT_TEXT)
+            raise IBMQAccountError('Invalid IBM Q Experience credentials found.',
+                                   *UPDATE_ACCOUNT_TEXT)
 
         credentials = list(stored_credentials.values())[0]
         return {
@@ -364,7 +361,7 @@ class IBMQFactory:
                 websockets_url=service_urls['ws'],
                 proxies=credentials.proxies,
                 verify=credentials.verify,
-                **hub_info,)
+                **hub_info, )
 
             # Build the provider.
             try:

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 QX_AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
 UPDATE_ACCOUNT_TEXT = (
     "Please update your accounts and programs by following the instructions here:",
-    "https://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience""")
+    "https://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience")
 
 
 class IBMQFactory:


### PR DESCRIPTION
There is a `\n` in `UPDATE_ACCOUNT_TEXT`, which results in exception messages like this one:
```
qiskit.providers.ibmq.exceptions.IBMQApiUrlError: 'Invalid IBM Q Experience credentials found. Please update your accounts and programs by following the instructions here:\nhttps://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience'
```
Notice that `\n` shows up in the message, making the url unclickable in those terminals that support it.

This PR removes that `\n`. Now it looks like this one:

```
qiskit.providers.ibmq.exceptions.IBMQApiUrlError: 'Invalid IBM Q Experience credentials found. Please update your accounts and programs by following the instructions here: https://github.com/Qiskit/qiskit-ibmq-provider#updating-to-the-new-ibm-q-experience'
```