### PR TITLE
Enable mypy type checks in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,3 @@ jobs:
       script:
         - python3 setup.py sdist bdist_wheel
         - twine upload dist/qiskit*
-
-matrix:
-  allow_failures:
-  - name: mypy type checking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,10 +238,13 @@ The order of precedence in the options is right to left. For example,
 ### Style guide
 
 Please submit clean code and please make effort to follow existing
-conventions in order to keep it as readable as possible. We use
-[Pylint](https://www.pylint.org) and [PEP
-8](https://www.python.org/dev/peps/pep-0008) style guide: to ensure your
-changes respect the style guidelines, run the next commands:
+conventions in order to keep it as readable as possible. We use:
+* [Pylint](https://www.pylint.org) linter
+* [PEP 8](https://www.python.org/dev/peps/pep-0008) style
+* [mypy](http://mypy-lang.org/) type hinting
+
+To ensure your changes respect the style guidelines, you can run the following
+commands:
 
 All platforms:
 
@@ -249,6 +252,7 @@ All platforms:
 $> cd out
 out$> make lint
 out$> make style
+out$> make mypy
 ```
 
 Development cycle


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #265

After the nice work from @luisg5 on getting the codebase typed and coming up with a sensible set of guidelines for type hinting, his PR makes the `mypy` stage enabled and without allowing failures in travis, to keep the effort up and allow for further refining and tuning.

This will still be "experimental" for a while, in the hopes of seeing how it plays out in the daily usage and making more informed decisions afterwards.

### Details and comments


