### PR TITLE
Refactor RequestsApiError Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,9 @@ The format is based on [Keep a Changelog].
 - `IBMQJob.error_message()` now gives more information on why a job failed (\#375).
 - `IBMQJob.queue_position()` now accepts an optional `refresh` parameter that 
   indicates whether it should query the API for the latest queue position (\#387). 
-- The initializer for the `RequestsApiError` exception is removed. Exception 
-  chaining is now used to examine the complete traceback for more details. (\#395).
+- The Exception hierarchy has been refined with more specialized classes, and
+  exception chaining is used. You can get more information about failures by
+  reviewing the complete traceback. (\#395, \#396)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog].
 - `IBMQJob.error_message()` now gives more information on why a job failed (\#375).
 - `IBMQJob.queue_position()` now accepts an optional `refresh` parameter that 
   indicates whether it should query the API for the latest queue position (\#387). 
+- The initializer for the `RequestsApiError` exception is removed. Exception 
+  chaining is now used to examine the complete traceback for more details. (\#395).
 
 ### Removed
 

--- a/qiskit/providers/ibmq/api/clients/auth.py
+++ b/qiskit/providers/ibmq/api/clients/auth.py
@@ -75,12 +75,12 @@ class AuthClient(BaseClient):
             response = self.client_auth.login(self.api_token)
             return response['id']
         except RequestsApiError as ex:
-            response_obj = ex.original_exception.response
-            if response_obj is not None and response_obj.status_code == 401:
+            error_response = ex.__cause__.response
+            if error_response is not None and error_response.status_code == 401:
                 try:
-                    error_code = response_obj.json()['error']['name']
+                    error_code = error_response.json()['error']['name']
                     if error_code == 'ACCEPT_LICENSE_REQUIRED':
-                        message = response_obj.json()['error']['message']
+                        message = error_response.json()['error']['message']
                         raise AuthenticationLicenseError(message)
                 except (ValueError, KeyError):
                     # the response did not contain the expected json.

--- a/qiskit/providers/ibmq/api/clients/auth.py
+++ b/qiskit/providers/ibmq/api/clients/auth.py
@@ -75,7 +75,7 @@ class AuthClient(BaseClient):
             response = self.client_auth.login(self.api_token)
             return response['id']
         except RequestsApiError as ex:
-            error_response = ex.__cause__.response
+            error_response = ex.__cause__.response    # pylint: disable=no-member
             if error_response is not None and error_response.status_code == 401:
                 try:
                     error_code = error_response.json()['error']['name']

--- a/qiskit/providers/ibmq/api/exceptions.py
+++ b/qiskit/providers/ibmq/api/exceptions.py
@@ -27,13 +27,7 @@ class ApiError(IBMQError):
 
 class RequestsApiError(ApiError):
     """Exception re-raising a RequestException."""
-    def __init__(
-            self,
-            original_exception: RequestException,
-            *args: Any
-    ) -> None:
-        self.original_exception = original_exception
-        super().__init__(*args)
+    pass
 
 
 class WebsocketError(ApiError):

--- a/qiskit/providers/ibmq/api/exceptions.py
+++ b/qiskit/providers/ibmq/api/exceptions.py
@@ -14,9 +14,6 @@
 
 """Exceptions related to the IBM Q Experience API."""
 
-from typing import Any
-from requests.exceptions import RequestException
-
 from ..exceptions import IBMQError
 
 

--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -200,6 +200,6 @@ class RetrySession(Session):
             if self.access_token:
                 message = message.replace(self.access_token, '...')
 
-            raise RequestsApiError(ex, message) from None
+            raise RequestsApiError(message) from ex
 
         return response

--- a/qiskit/providers/ibmq/circuits/manager.py
+++ b/qiskit/providers/ibmq/circuits/manager.py
@@ -58,7 +58,7 @@ class CircuitsManager:
             response = self.client.circuit_run(name=name, **kwargs)
         except RequestsApiError as ex:
             # Revise the original requests exception to intercept.
-            error_response = ex.__cause__.response
+            error_response = ex.__cause__.response  # pylint: disable=no-member
 
             # Check for errors related to the submission.
             try:

--- a/qiskit/providers/ibmq/circuits/manager.py
+++ b/qiskit/providers/ibmq/circuits/manager.py
@@ -58,7 +58,7 @@ class CircuitsManager:
             response = self.client.circuit_run(name=name, **kwargs)
         except RequestsApiError as ex:
             # Revise the original requests exception to intercept.
-            error_response = ex.original_exception.response
+            error_response = ex.__cause__.response
 
             # Check for errors related to the submission.
             try:

--- a/qiskit/providers/ibmq/circuits/manager.py
+++ b/qiskit/providers/ibmq/circuits/manager.py
@@ -15,6 +15,7 @@
 """Manager for interacting with Circuits."""
 
 from typing import List, Any
+from requests.exceptions import RequestException
 
 from qiskit.providers import JobStatus  # type: ignore[attr-defined]
 from qiskit.result import Result
@@ -57,27 +58,32 @@ class CircuitsManager:
         try:
             response = self.client.circuit_run(name=name, **kwargs)
         except RequestsApiError as ex:
-            # Revise the original requests exception to intercept.
-            error_response = ex.__cause__.response  # pylint: disable=no-member
+            # Get the original exception that raised.
+            original_exception = ex.__cause__
 
-            # Check for errors related to the submission.
-            try:
-                body = error_response.json()
-            except ValueError:
-                body = {}
+            if isinstance(original_exception, RequestException):
+                # Get the response from the original request exception.
+                error_response = original_exception.response  # pylint: disable=no-member
 
-            # Generic authorization or unavailable endpoint error.
-            if error_response.status_code in (401, 404):
-                raise CircuitAvailabilityError() from None
+                if error_response is not None:
+                    # Check for errors related to the submission.
+                    try:
+                        body = error_response.json()
+                    except ValueError:
+                        body = {}
 
-            if error_response.status_code == 400:
-                # Hub permission error.
-                if body.get('error', {}).get('code') == 'HUB_NOT_FOUND':
-                    raise CircuitAvailabilityError() from None
+                    # Generic authorization or unavailable endpoint error.
+                    if error_response.status_code in (401, 404):
+                        raise CircuitAvailabilityError() from None
 
-                # Generic error.
-                if body.get('error', {}).get('code') == 'GENERIC_ERROR':
-                    raise CircuitAvailabilityError() from None
+                    if error_response.status_code == 400:
+                        # Hub permission error.
+                        if body.get('error', {}).get('code') == 'HUB_NOT_FOUND':
+                            raise CircuitAvailabilityError() from None
+
+                        # Generic error.
+                        if body.get('error', {}).get('code') == 'GENERIC_ERROR':
+                            raise CircuitAvailabilityError() from None
 
             # Handle the rest of the exceptions as unexpected.
             raise CircuitSubmitError(str(ex))

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -94,7 +94,7 @@ class TestAccountClient(IBMQTestCase):
         try:
             job = api._job_submit_object_storage(backend_name, qobj.to_dict())
         except RequestsApiError as ex:
-            error_response = ex.__cause__.response
+            error_response = ex.__cause__.response    # pylint: disable=no-member
             if error_response.status_code == 400:
                 try:
                     api_code = error_response.json()['error']['code']

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -94,10 +94,10 @@ class TestAccountClient(IBMQTestCase):
         try:
             job = api._job_submit_object_storage(backend_name, qobj.to_dict())
         except RequestsApiError as ex:
-            response = ex.original_exception.response
-            if response.status_code == 400:
+            error_response = ex.__cause__.response
+            if error_response.status_code == 400:
                 try:
-                    api_code = response.json()['error']['code']
+                    api_code = error_response.json()['error']['code']
 
                     # If we reach that point, it means the backend does not
                     # support qobject storage.
@@ -168,7 +168,7 @@ class TestAccountClient(IBMQTestCase):
             api.job_status('foo')
 
         raised_exception = exception_context.exception
-        original_error = raised_exception.original_exception.response.json()['error']
+        original_error = raised_exception.__cause__.response.json()['error']
         self.assertIn(original_error['message'], raised_exception.message,
                       "Original error message not in raised exception")
         self.assertIn(original_error['code'], raised_exception.message,

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -16,6 +16,8 @@
 
 import re
 
+from requests.exceptions import RequestException
+
 from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import assemble, transpile
 from qiskit.providers.ibmq.api.clients import AccountClient, AuthClient
@@ -94,18 +96,22 @@ class TestAccountClient(IBMQTestCase):
         try:
             job = api._job_submit_object_storage(backend_name, qobj.to_dict())
         except RequestsApiError as ex:
-            error_response = ex.__cause__.response    # pylint: disable=no-member
-            if error_response.status_code == 400:
-                try:
-                    api_code = error_response.json()['error']['code']
+            # Get the original connection that was raised.
+            original_exception = ex.__cause__
 
-                    # If we reach that point, it means the backend does not
-                    # support qobject storage.
-                    self.assertEqual(api_code,
-                                     'Q_OBJECT_STORAGE_IS_NOT_ALLOWED')
-                    return
-                except (ValueError, KeyError):
-                    pass
+            if isinstance(original_exception, RequestException):
+                # Get the response from the original request exception.
+                error_response = original_exception.response    # pylint: disable=no-member
+                if error_response is not None and error_response.status_code == 400:
+                    try:
+                        api_code = error_response.json()['error']['code']
+
+                        # If we reach that point, it means the backend does not
+                        # support qobject storage.
+                        self.assertEqual(api_code, 'Q_OBJECT_STORAGE_IS_NOT_ALLOWED')
+                        return
+                    except (ValueError, KeyError):
+                        pass
             raise
 
         job_id = job['id']

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -114,8 +114,7 @@ class TestProxies(IBMQTestCase):
         with self.assertRaises(RequestsApiError) as context_manager:
             _ = AuthClient(qe_token, qe_url, proxies=INVALID_PORT_PROXIES)
 
-        self.assertIsInstance(context_manager.exception.original_exception,
-                              ProxyError)
+        self.assertIsInstance(context_manager.exception.__cause__, ProxyError)
 
     # pylint: disable=unused-argument
     @requires_qe_access
@@ -125,8 +124,7 @@ class TestProxies(IBMQTestCase):
             version_finder = VersionClient(qe_url, proxies=INVALID_PORT_PROXIES)
             version_finder.version()
 
-        self.assertIsInstance(context_manager.exception.original_exception,
-                              ProxyError)
+        self.assertIsInstance(context_manager.exception.__cause__, ProxyError)
 
     @requires_qe_access
     def test_invalid_proxy_address_authclient(self, qe_token, qe_url):
@@ -134,8 +132,7 @@ class TestProxies(IBMQTestCase):
         with self.assertRaises(RequestsApiError) as context_manager:
             _ = AuthClient(qe_token, qe_url, proxies=INVALID_ADDRESS_PROXIES)
 
-        self.assertIsInstance(context_manager.exception.original_exception,
-                              ProxyError)
+        self.assertIsInstance(context_manager.exception.__cause__, ProxyError)
 
     @requires_qe_access
     def test_invalid_proxy_address_versionclient(self, qe_token, qe_url):
@@ -146,8 +143,7 @@ class TestProxies(IBMQTestCase):
                                            proxies=INVALID_ADDRESS_PROXIES)
             version_finder.version()
 
-        self.assertIsInstance(context_manager.exception.original_exception,
-                              ProxyError)
+        self.assertIsInstance(context_manager.exception.__cause__, ProxyError)
 
 
 def pproxy_desired_access_log_line(url):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Addresses #106 

### Details and comments

This PR is a step into unifying the exceptions within the provider. It removes an unnecessary initializer from `RequestsApiError` by using exception chaining to accomplish the same behavior. 