### PR TITLE
Revise generic JobError exceptions In IBMQJob

### DIFF
--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -25,3 +25,8 @@ class IBMQJobApiError(JobError):
 class IBMQJobFailureError(JobError):
     """Error that occurs because the job failed."""
     pass
+
+
+class IBMQJobInvalidStateError(JobError):
+    """Error that occurs when a job is in an invalid state."""
+    pass

--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -28,5 +28,5 @@ class IBMQJobFailureError(JobError):
 
 
 class IBMQJobInvalidStateError(JobError):
-    """Error that occurs when a job is in an invalid state."""
+    """Error that occurs because a job is not in a state for the operation."""
     pass

--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2018, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Exceptions related to IBMQJob."""
+
+from qiskit.providers.exceptions import JobError
+
+
+class JobApiError(JobError):
+    """Error that occurs unexpectedly when querying the API."""
+    pass
+
+
+class JobFailureError(JobError):
+    """Error that occurs because the job failed."""
+    pass

--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -17,11 +17,11 @@
 from qiskit.providers.exceptions import JobError
 
 
-class JobApiError(JobError):
+class IBMQJobApiError(JobError):
     """Error that occurs unexpectedly when querying the API."""
     pass
 
 
-class JobFailureError(JobError):
+class IBMQJobFailureError(JobError):
     """Error that occurs because the job failed."""
     pass

--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2019.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -64,7 +64,7 @@ class IBMQJob(BaseModel, BaseJob):
             if job_status is JobStatus.RUNNING:
                 print('The job is still running')
 
-        except JobError as ex:
+        except IBMQJobApiError as ex:
             print("Something wrong happened!: {}".format(ex))
 
     A call to ``status()`` can raise if something happens at the server level
@@ -83,7 +83,7 @@ class IBMQJob(BaseModel, BaseJob):
         except JobError as ex:
             print("Something wrong happened!: {}".format(ex))
 
-    Many of the ``IBMQJob`` methods can raise ``JobError`` if unexpected
+    Many of the ``IBMQJob`` methods can raise ``IBMQJobApiError`` if unexpected
     failures happened at the server level.
 
     Job information retrieved from the API server is attached to the ``IBMQJob``
@@ -153,7 +153,7 @@ class IBMQJob(BaseModel, BaseJob):
             the Qobj for this job.
 
         Raises:
-            JobError: if there was some unexpected failure in the server.
+            IBMQJobApiError: if there was some unexpected failure in the server.
         """
         # pylint: disable=access-member-before-definition,attribute-defined-outside-init
         if not self._qobj:  # type: ignore[has-type]
@@ -173,7 +173,7 @@ class IBMQJob(BaseModel, BaseJob):
                 properties are not available.
 
         Raises:
-            JobError: if there was some unexpected failure in the server.
+            IBMQJobApiError: if there was some unexpected failure in the server.
         """
         with api_to_job_error():
             properties = self._api.job_properties(job_id=self.job_id())
@@ -206,9 +206,9 @@ class IBMQJob(BaseModel, BaseJob):
             Result object
 
         Raises:
-            IBMQJobInvalidStateError: if the job was cancelled or there was some unexpected failure
-                in the server.
+            IBMQJobInvalidStateError: if the job was cancelled.
             IBMQJobFailureError: If the job failed.
+            IBMQJobApiError: If there was some unexpected failure in the server.
         """
         # pylint: disable=arguments-differ
         # pylint: disable=access-member-before-definition,attribute-defined-outside-init
@@ -253,7 +253,7 @@ class IBMQJob(BaseModel, BaseJob):
             The status of the job, once updated.
 
         Raises:
-            JobError: if there was some unexpected failure in the server.
+            IBMQJobApiError: if there was some unexpected failure in the server.
         """
         if self._status in JOB_FINAL_STATES:
             return self._status

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -235,8 +235,7 @@ class IBMQJob(BaseModel, BaseJob):
             might not be possible depending on the environment.
 
         Raises:
-            IBMQJobApiError: if the job has not been submitted or if there was
-                some unexpected failure in the server.
+            IBMQJobApiError: if there was some unexpected failure in the server.
         """
         try:
             response = self._api.job_cancel(self.job_id())
@@ -386,7 +385,7 @@ class IBMQJob(BaseModel, BaseJob):
             The job has started.
 
         Raises:
-            IBMQJobInvalidStateError: If an error occurred during job submit.
+            IBMQJobInvalidStateError: If the job has already been submitted.
         """
         if self.job_id() is not None:
             raise IBMQJobInvalidStateError("We have already submitted the job!")

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -385,6 +385,7 @@ class IBMQJob(BaseModel, BaseJob):
             The job has started.
 
         Raises:
+            IBMQJobApiError: if there was some unexpected failure in the server.
             IBMQJobInvalidStateError: If the job has already been submitted.
         """
         if self.job_id() is not None:

--- a/qiskit/providers/ibmq/job/utils.py
+++ b/qiskit/providers/ibmq/job/utils.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Tuple, Generator, Optional, Any
 from contextlib import contextmanager
 
 from qiskit.providers.jobstatus import JobStatus
-from qiskit.providers import JobError  # type: ignore[attr-defined]
+from qiskit.providers.ibmq.job.exceptions import IBMQJobApiError
 
 from ..apiconstants import ApiJobStatus
 from ..api.exceptions import ApiError
@@ -104,4 +104,4 @@ def api_to_job_error() -> Generator[None, None, None]:
     try:
         yield
     except ApiError as api_err:
-        raise JobError(str(api_err))
+        raise IBMQJobApiError(str(api_err))

--- a/qiskit/providers/ibmq/job/utils.py
+++ b/qiskit/providers/ibmq/job/utils.py
@@ -100,7 +100,7 @@ def api_status_to_job_status(api_status: ApiJobStatus) -> JobStatus:
 
 @contextmanager
 def api_to_job_error() -> Generator[None, None, None]:
-    """Convert an ApiError to a JobError."""
+    """Convert an ApiError to an IBMQJobApiError."""
     try:
         yield
     except ApiError as api_err:

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -22,11 +22,13 @@ import numpy
 from scipy.stats import chi2_contingency
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers import JobError, JobStatus
+from qiskit.providers import JobStatus
 from qiskit.providers.ibmq import least_busy
 from qiskit.providers.ibmq.exceptions import IBMQBackendError
 from qiskit.providers.ibmq.ibmqfactory import IBMQFactory
 from qiskit.providers.ibmq.job.ibmqjob import IBMQJob
+from qiskit.providers.ibmq.job.exceptions import (IBMQJobApiError, IBMQJobFailureError,
+                                                  IBMQJobInvalidStateError)
 from qiskit.test import slow_test
 from qiskit.compiler import assemble, transpile
 
@@ -348,7 +350,7 @@ class TestIBMQJob(JobTestCase):
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         # backend.run() will automatically call job.submit()
         job = backend.run(qobj)
-        with self.assertRaises(JobError):
+        with self.assertRaises(IBMQJobInvalidStateError):
             job.submit()
 
     @requires_provider
@@ -361,7 +363,7 @@ class TestIBMQJob(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(JobError):
+        with self.assertRaises(IBMQJobFailureError):
             job.result()
 
         new_job = provider.backends.retrieve_job(job.job_id())
@@ -378,7 +380,7 @@ class TestIBMQJob(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(JobError):
+        with self.assertRaises(IBMQJobApiError):
             job.result()
 
         new_job = provider.backends.retrieve_job(job.job_id())

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -27,7 +27,7 @@ from qiskit.providers.ibmq import least_busy
 from qiskit.providers.ibmq.exceptions import IBMQBackendError
 from qiskit.providers.ibmq.ibmqfactory import IBMQFactory
 from qiskit.providers.ibmq.job.ibmqjob import IBMQJob
-from qiskit.providers.ibmq.job.exceptions import (IBMQJobApiError, IBMQJobFailureError,
+from qiskit.providers.ibmq.job.exceptions import (IBMQJobFailureError,
                                                   IBMQJobInvalidStateError)
 from qiskit.test import slow_test
 from qiskit.compiler import assemble, transpile
@@ -380,7 +380,7 @@ class TestIBMQJob(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(IBMQJobApiError):
+        with self.assertRaises(IBMQJobFailureError):
             job.result()
 
         new_job = provider.backends.retrieve_job(job.job_id())

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -17,8 +17,8 @@
 import time
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers import JobError
 from qiskit.providers.ibmq import least_busy
+from qiskit.providers.ibmq.job.exceptions import JobFailureError
 from qiskit.compiler import assemble, transpile
 
 from ..jobtestcase import JobTestCase
@@ -117,7 +117,7 @@ class TestIBMQJobAttributes(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(JobError):
+        with self.assertRaises(JobFailureError):
             job.result()
 
         message = job.error_message()
@@ -133,7 +133,7 @@ class TestIBMQJobAttributes(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(JobError):
+        with self.assertRaises(JobFailureError):
             job.result()
 
         message = job.error_message()

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -18,7 +18,7 @@ import time
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers.ibmq import least_busy
-from qiskit.providers.ibmq.job.exceptions import JobFailureError
+from qiskit.providers.ibmq.job.exceptions import IBMQJobFailureError
 from qiskit.compiler import assemble, transpile
 
 from ..jobtestcase import JobTestCase
@@ -117,7 +117,7 @@ class TestIBMQJobAttributes(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(JobFailureError):
+        with self.assertRaises(IBMQJobFailureError):
             job.result()
 
         message = job.error_message()
@@ -133,7 +133,7 @@ class TestIBMQJobAttributes(JobTestCase):
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
 
         job = backend.run(qobj)
-        with self.assertRaises(JobFailureError):
+        with self.assertRaises(IBMQJobFailureError):
             job.result()
 
         message = job.error_message()

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -23,6 +23,7 @@ from unittest import mock
 from qiskit.providers.ibmq.apiconstants import API_JOB_FINAL_STATES, ApiJobStatus
 from qiskit.test.mock import new_fake_qobj
 from qiskit.providers import JobError, JobTimeoutError
+from qiskit.providers.ibmq.job.exceptions import JobApiError
 from qiskit.providers.ibmq.api.exceptions import (ApiError, UserTimeoutExceededError,
                                                   ApiIBMQProtocolError)
 from qiskit.providers.ibmq.exceptions import IBMQBackendError
@@ -235,7 +236,7 @@ class TestIBMQJobStates(JobTestCase):
         self.wait_for_initialization(job)
         job.cancel()
         self._current_api.progress()
-        with self.assertRaises(JobError):
+        with self.assertRaises(JobApiError):
             _ = job.result()
             self.assertEqual(job.status(), JobStatus.CANCELLED)
 
@@ -271,7 +272,7 @@ class TestIBMQJobStates(JobTestCase):
         with ThreadPoolExecutor() as executor:
             executor.submit(_auto_progress_api, self._current_api)
 
-        with self.assertRaises(JobError):
+        with self.assertRaises(JobApiError):
             job.result()
 
         self.assertEqual(job.status(), JobStatus.CANCELLED)

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -23,7 +23,7 @@ from unittest import mock
 from qiskit.providers.ibmq.apiconstants import API_JOB_FINAL_STATES, ApiJobStatus
 from qiskit.test.mock import new_fake_qobj
 from qiskit.providers import JobError, JobTimeoutError
-from qiskit.providers.ibmq.job.exceptions import JobApiError
+from qiskit.providers.ibmq.job.exceptions import IBMQJobApiError
 from qiskit.providers.ibmq.api.exceptions import (ApiError, UserTimeoutExceededError,
                                                   ApiIBMQProtocolError)
 from qiskit.providers.ibmq.exceptions import IBMQBackendError
@@ -236,7 +236,7 @@ class TestIBMQJobStates(JobTestCase):
         self.wait_for_initialization(job)
         job.cancel()
         self._current_api.progress()
-        with self.assertRaises(JobApiError):
+        with self.assertRaises(IBMQJobApiError):
             _ = job.result()
             self.assertEqual(job.status(), JobStatus.CANCELLED)
 
@@ -272,7 +272,7 @@ class TestIBMQJobStates(JobTestCase):
         with ThreadPoolExecutor() as executor:
             executor.submit(_auto_progress_api, self._current_api)
 
-        with self.assertRaises(JobApiError):
+        with self.assertRaises(IBMQJobApiError):
             job.result()
 
         self.assertEqual(job.status(), JobStatus.CANCELLED)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adresses #106 

### Details and comments

This PR aims to further specify some of the exceptions raised in the `IBMJob` class. It draws a distinction between exceptions related to the API and exceptions related to a job failing.