### PR TITLE
Managed results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog].
   `AccountProvider.backends.<tab>` to see a list of backend
   names (\#303).
 - A new `IBMQJobManager` class that takes a list of circuits or pulse schedules as 
-  input, splits them into one or more jobs, and submits the jobs (\#389).
+  input, splits them into one or more jobs, and submits the jobs (\#389, \#400, \#407).
 - Added `provider.backends().jobs()` and `provider.backends().retrieve_job()`
   (\#354).
 

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -47,6 +47,6 @@ def least_busy(backends: List[BaseBackend]) -> BaseBackend:
     """
     try:
         return min([b for b in backends if b.status().operational],
-                   key=lambda b: b.status().pending_jobs)
+                   key=lambda b: b.statuses().pending_jobs)
     except (ValueError, TypeError):
         raise QiskitError("Can only find least_busy backend from a non-empty list.")

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -47,6 +47,6 @@ def least_busy(backends: List[BaseBackend]) -> BaseBackend:
     """
     try:
         return min([b for b in backends if b.status().operational],
-                   key=lambda b: b.statuses().pending_jobs)
+                   key=lambda b: b.status().pending_jobs)
     except (ValueError, TypeError):
         raise QiskitError("Can only find least_busy backend from a non-empty list.")

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -186,7 +186,7 @@ class IBMQJob(BaseModel, BaseJob):
             self,
             timeout: Optional[float] = None,
             wait: float = 5,
-            partial: Optional[bool] = False
+            partial: bool = False
     ) -> Result:
         """Return the result of the job.
 

--- a/qiskit/providers/ibmq/managed/exceptions.py
+++ b/qiskit/providers/ibmq/managed/exceptions.py
@@ -30,3 +30,13 @@ class IBMQJobManagerInvalidStateError(IBMQJobManagerError):
 class IBMQJobManagerTimeoutError(IBMQJobManagerError):
     """Errors raised when a job manager operation times out."""
     pass
+
+
+class IBMQJobManagerJobNotFound(IBMQJobManagerError):
+    """Errors raised when a job cannot be found."""
+    pass
+
+
+class IBMQManagedResultDataNotAvailable(IBMQJobManagerError):
+    """Errors raised when result data is not available."""
+    pass

--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -88,7 +88,7 @@ class ManagedJob:
            timeout: number of seconds to wait for job
 
         Returns:
-            Result object
+            Result object or ``None`` if result could not be retrieved.
 
         Raises:
             JobTimeoutError: if the job does not return results before a

--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -81,7 +81,7 @@ class ManagedJob:
 
         return None
 
-    def result(self, timeout: Optional[float] = None) -> Result:
+    def result(self, timeout: Optional[float] = None) -> Optional[Result]:
         """Return the result of the job.
 
         Args:

--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -108,11 +108,16 @@ class ManagedJob:
 
         return None
 
-    def result(self, timeout: Optional[float] = None) -> Optional[Result]:
+    def result(
+            self,
+            timeout: Optional[float] = None,
+            partial: bool = False
+    ) -> Optional[Result]:
         """Return the result of the job.
 
         Args:
            timeout: number of seconds to wait for job
+           partial: If true, attempt to retrieve partial job results.
 
         Returns:
             Result object or ``None`` if result could not be retrieved.
@@ -124,8 +129,7 @@ class ManagedJob:
         result = None
         if self.job is not None:
             try:
-                # TODO Revise this when partial result is supported
-                result = self.job.result(timeout=timeout)
+                result = self.job.result(timeout=timeout, partial=partial)
             except JobTimeoutError:
                 raise
             except JobError as err:

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -15,7 +15,7 @@
 """A set of jobs being managed by the IBMQJobManager."""
 
 from datetime import datetime
-from typing import List, Optional, Union, Any
+from typing import List, Optional, Union, Any, Tuple
 from concurrent.futures import ThreadPoolExecutor
 import time
 import logging
@@ -25,13 +25,14 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.pulse import Schedule
 from qiskit.compiler import assemble
 from qiskit.qobj import Qobj
-from qiskit.result import Result
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.providers.exceptions import JobError, JobTimeoutError
 
 from .managedjob import ManagedJob
+from .managedresults import ManagedResults
 from .utils import requires_submit, format_status_counts, format_job_details
-from .exceptions import IBMQJobManagerInvalidStateError, IBMQJobManagerTimeoutError
+from .exceptions import (IBMQJobManagerInvalidStateError, IBMQJobManagerTimeoutError,
+                         IBMQJobManagerJobNotFound)
 from ..job import IBMQJob
 from ..ibmqbackend import IBMQBackend
 
@@ -46,9 +47,10 @@ class ManagedJobSet:
         self._managed_jobs = []  # type: List[ManagedJob]
         self._name = name or datetime.utcnow().isoformat()
         self._submit_collector = None  # type: Optional[Thread]
+        self._backend = None  # type: Optional[IBMQBackend]
 
         # Used for caching
-        self._results = []  # type: Optional[List[Union[Result, None]]]
+        self._managed_results = None  # type: Optional[ManagedResults]
         self._error_msg = None  # type: Optional[str]
 
     def run(
@@ -87,6 +89,7 @@ class ManagedJobSet:
         # Give the collector its own thread so it's not stuck behind the submits.
         self._submit_collector = Thread(target=self.submit_results, daemon=True)
         self._submit_collector.start()
+        self._backend = backend
 
     def _async_submit(
             self,
@@ -142,7 +145,7 @@ class ManagedJobSet:
         return '\n'.join(report)
 
     @requires_submit
-    def results(self, timeout: Optional[float] = None) -> List[Union[Result, None]]:
+    def results(self, timeout: Optional[float] = None) -> ManagedResults:
         """Return the results of the jobs.
 
         This call will block until all job results become available or
@@ -152,24 +155,26 @@ class ManagedJobSet:
            timeout: Number of seconds to wait for job results.
 
         Returns:
-            A list of job results. The entry is ``None`` if the job result
-                cannot be retrieved.
+            A ``ManagedResults`` instance that can be used to retrieve results
+                for individual experiments.
 
         Raises:
             IBMQJobManagerTimeoutError: if unable to retrieve all job results before the
                 specified timeout.
         """
-        if self._results:
-            return self._results
+        if self._managed_results is not None:
+            return self._managed_results
 
-        self._results = []
         start_time = time.time()
         original_timeout = timeout
+        success = True
 
         # TODO We can potentially make this multithreaded
         for mjob in self._managed_jobs:
             try:
-                self._results.append(mjob.result(timeout=timeout))
+                result = mjob.result(timeout=timeout)
+                if result is None or not result.success:
+                    success = False
             except JobTimeoutError:
                 raise IBMQJobManagerTimeoutError(
                     "Timeout waiting for results for experiments {}-{}.".format(
@@ -182,7 +187,9 @@ class ManagedJobSet:
                         "Timeout waiting for results for experiments {}-{}.".format(
                             mjob.start_index, self._managed_jobs[-1].end_index))
 
-        return self._results
+        self._managed_results = ManagedResults(self, self._backend.name(), success)
+
+        return self._managed_results
 
     @requires_submit
     def error_messages(self) -> Optional[str]:
@@ -233,6 +240,49 @@ class ManagedJobSet:
                 entry is ``None`` if the job submit failed.
         """
         return [mjob.job for mjob in self._managed_jobs]
+
+    @requires_submit
+    def job(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int]
+    ) -> Tuple[Optional[IBMQJob], int]:
+        """Returns the job used to submit the experiment and the experiment index.
+
+        For example, if ``IBMQJobManager`` is used to submit 1000 experiments,
+            and ``IBMQJobManager`` divides them into 2 jobs: job 1
+            has experiments 0-499, and job 2 has experiments 500-999. In this
+            case ``job_set.job(501)`` will return (job2, 1).
+
+        Args:
+            experiment: the index of the experiment. Several types are
+                accepted for convenience::
+                * str: the name of the experiment.
+                * QuantumCircuit: the name of the circuit instance will be used.
+                * Schedule: the name of the schedule instance will be used.
+                * int: the position of the experiment.
+
+        Returns:
+            A tuple of the job used to submit the experiment, or ``None`` if
+                the job submit failed, and the experiment index.
+
+        Raises:
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        if isinstance(experiment, int):
+            for mjob in self._managed_jobs:
+                if mjob.end_index >= experiment >= mjob.start_index:
+                    return mjob.job, experiment - mjob.start_index
+        else:
+            if isinstance(experiment, (QuantumCircuit, Schedule)):
+                experiment = experiment.name
+            for mjob in self._managed_jobs:
+                for i, exp in enumerate(mjob.experiments):
+                    if exp.name == experiment:
+                        return mjob.job, i
+
+        raise IBMQJobManagerJobNotFound("Unable to find the job for experiment {}".format(
+            experiment))
 
     @requires_submit
     def qobjs(self) -> List[Qobj]:

--- a/qiskit/providers/ibmq/managed/managedresults.py
+++ b/qiskit/providers/ibmq/managed/managedresults.py
@@ -185,7 +185,6 @@ class ManagedResults:
                 "Job for experiment {} was not successfully submitted.".format(experiment))
 
         try:
-            # TODO Update when partial result is supported
             result = job.result()
             return result, exp_index
         except JobError as err:

--- a/qiskit/providers/ibmq/managed/managedresults.py
+++ b/qiskit/providers/ibmq/managed/managedresults.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Results managed by the job manager."""
+
+from typing import List, Optional, Union, Tuple, Dict
+
+from qiskit.result import Result
+from qiskit.circuit import QuantumCircuit
+from qiskit.pulse import Schedule
+
+from .exceptions import IBMQManagedResultDataNotAvailable
+from ..job.exceptions import JobError
+
+
+class ManagedResults:
+    """Results managed by job manager.
+
+    This class is a wrapper around the `Result` class. It provides the same
+    methods as the `Result` class. Please refer to the `Result` class for
+    more information on the methods.
+    """
+
+    def __init__(
+            self,
+            job_set: 'ManagedJobSet',  # type: ignore[name-defined]
+            backend_name: str,
+            success: bool
+    ):
+        """Creates a new ManagedResults instance.
+
+        Args:
+            job_set: Managed job set for these results.
+            backend_name: Name of the backend used to run the experiments.
+            success: True if all experiments were successful and results
+                available. False otherwise.
+        """
+        self._job_set = job_set
+        self.backend_name = backend_name
+        self.success = success
+
+    def data(self, experiment: Union[str, QuantumCircuit, Schedule, int]) -> Dict:
+        """Get the raw data for an experiment.
+
+        Args:
+            experiment: the index of the experiment. Several types are
+                accepted for convenience::
+                * str: the name of the experiment.
+                * QuantumCircuit: the name of the circuit instance will be used.
+                * Schedule: the name of the schedule instance will be used.
+                * int: the position of the experiment.
+
+        Returns:
+            Refer to the ``Result.data()`` documentation for return information.
+
+        Raises:
+            IBMQManagedResultDataNotAvailable: If data for the experiment could not be retrieved.
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.data(exp_index)
+
+    def get_memory(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int]
+    ) -> Union[list, 'numpy.ndarray']:  # type: ignore[name-defined]
+        """Get the sequence of memory states (readouts) for each shot.
+        The data from the experiment is a list of format
+        ['00000', '01000', '10100', '10100', '11101', '11100', '00101', ..., '01010']
+
+        Args:
+            experiment: the index of the experiment, as specified by ``data()``.
+
+        Returns:
+            Refer to the ``Result.get_memory()`` documentation for return information.
+
+        Raises:
+            IBMQManagedResultDataNotAvailable: If data for the experiment could not be retrieved.
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_memory(exp_index)
+
+    def get_counts(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int]
+    ) -> Dict[str, int]:
+        """Get the histogram data of an experiment.
+
+        Args:
+            experiment: the index of the experiment, as specified by ``data()``.
+
+        Returns:
+            Refer to the ``Result.get_counts()`` documentation for return information.
+
+        Raises:
+            IBMQManagedResultDataNotAvailable: If data for the experiment could not be retrieved.
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_counts(exp_index)
+
+    def get_statevector(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int],
+            decimals: Optional[int] = None
+    ) -> List[complex]:
+        """Get the final statevector of an experiment.
+
+        Args:
+            experiment: the index of the experiment, as specified by ``data()``.
+            decimals: the number of decimals in the statevector.
+                If None, does not round.
+
+        Returns:
+            Refer to the ``Result.get_statevector()`` documentation for return information.
+
+        Raises:
+            IBMQManagedResultDataNotAvailable: If data for the experiment could not be retrieved.
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_statevector(experiment=exp_index, decimals=decimals)
+
+    def get_unitary(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int],
+            decimals: Optional[int] = None
+    ) -> List[List[complex]]:
+        """Get the final unitary of an experiment.
+
+        Args:
+            experiment: the index of the experiment, as specified by ``data()``.
+            decimals: the number of decimals in the unitary.
+                If None, does not round.
+
+        Returns:
+            Refer to the ``Result.get_unitary()`` documentation for return information.
+
+        Raises:
+            IBMQManagedResultDataNotAvailable: If data for the experiment could not be retrieved.
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+        result, exp_index = self._get_result(experiment)
+        return result.get_unitary(experiment=exp_index, decimals=decimals)
+
+    def _get_result(
+            self,
+            experiment: Union[str, QuantumCircuit, Schedule, int]
+    ) -> Tuple[Result, int]:
+        """Get the result of the job used to submit the experiment.
+
+        Args:
+            experiment: the index of the experiment, as specified by ``data()``.
+
+        Returns:
+            A tuple of the result of the job used to submit the experiment and
+                the experiment index within the job.
+
+        Raises:
+            IBMQManagedResultDataNotAvailable: If data for the experiment could not be retrieved.
+            IBMQJobManagerJobNotFound: If the job for the experiment could not
+                be found.
+        """
+
+        (job, exp_index) = self._job_set.job(experiment)
+        if job is None:
+            raise IBMQManagedResultDataNotAvailable(
+                "Job for experiment {} was not successfully submitted.".format(experiment))
+
+        try:
+            # TODO Update when partial result is supported
+            result = job.result()
+            return result, exp_index
+        except JobError as err:
+            raise IBMQManagedResultDataNotAvailable(
+                "Result data for experiment {} is not available.".format(experiment)) from err

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -49,8 +49,8 @@ class TestIBMQJobManager(IBMQTestCase):
         for _ in range(max_circs+2):
             circs.append(self._qc)
         job_set = self._jm.run(circs, backend=backend)
-        statuses = job_set.statuses()
         job_set.results()
+        statuses = job_set.statuses()
 
         self.assertEqual(len(statuses), 2)
         self.assertTrue(all(s is JobStatus.DONE for s in statuses))
@@ -66,8 +66,8 @@ class TestIBMQJobManager(IBMQTestCase):
         for _ in range(max_circs+2):
             circs.append(transpile(self._qc, backend=backend))
         job_set = self._jm.run(circs, backend=backend)
-        statuses = job_set.statuses()
         job_set.results()
+        statuses = job_set.statuses()
 
         self.assertEqual(len(statuses), 2)
         self.assertTrue(all(s is JobStatus.DONE for s in statuses))

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2019.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -19,7 +19,7 @@ import time
 
 from qiskit import QuantumCircuit
 from qiskit.providers.ibmq.managed.ibmqjobmanager import IBMQJobManager
-from qiskit.providers.ibmq.managed.exceptions import (IBMQJobManagerInvalidStateError,
+from qiskit.providers.ibmq.managed.exceptions import (IBMQJobManagerJobNotFound,
                                                       IBMQManagedResultDataNotAvailable)
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.providers.ibmq import least_busy
@@ -255,7 +255,7 @@ class TestResultManager(IBMQTestCase):
         backend = provider.get_backend('ibmq_qasm_simulator')
         job_set = self._jm.run([self._qc], backend=backend)
         result_manager = job_set.results()
-        with self.assertRaises(IBMQJobManagerInvalidStateError):
+        with self.assertRaises(IBMQJobManagerJobNotFound):
             result_manager.get_counts(1)
 
     @requires_provider
@@ -269,7 +269,7 @@ class TestResultManager(IBMQTestCase):
             circs.append(self._qc)
         job_set = self._jm.run(circs, backend=backend)
         jobs = job_set.jobs()
-        cjob = jobs[0]
+        cjob = jobs[1]
         cancelled = False
         for _ in range(2):
             # Try twice in case job is not in a cancellable state

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -19,6 +19,8 @@ import time
 
 from qiskit import QuantumCircuit
 from qiskit.providers.ibmq.managed.ibmqjobmanager import IBMQJobManager
+from qiskit.providers.ibmq.managed.exceptions import (IBMQJobManagerInvalidStateError,
+                                                      IBMQManagedResultDataNotAvailable)
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.providers.ibmq import least_busy
 from qiskit.providers import JobError
@@ -34,11 +36,7 @@ class TestIBMQJobManager(IBMQTestCase):
     """Tests for IBMQJobManager."""
 
     def setUp(self):
-        self._qc = QuantumCircuit(2, 2)
-        self._qc.h(0)
-        self._qc.cx(0, 1)
-        self._qc.measure([0, 1], [0, 1])
-
+        self._qc = _bell_circuit()
         self._jm = IBMQJobManager()
 
     @requires_provider
@@ -51,12 +49,12 @@ class TestIBMQJobManager(IBMQTestCase):
         for _ in range(max_circs+2):
             circs.append(self._qc)
         job_set = self._jm.run(circs, backend=backend)
-        results = job_set.results()
         statuses = job_set.statuses()
+        job_set.results()
 
-        self.assertEqual(len(results), 2)
         self.assertEqual(len(statuses), 2)
         self.assertTrue(all(s is JobStatus.DONE for s in statuses))
+        self.assertTrue(len(job_set.jobs()), 2)
 
     @run_on_staging
     def test_split_circuits_device(self, provider):
@@ -68,12 +66,12 @@ class TestIBMQJobManager(IBMQTestCase):
         for _ in range(max_circs+2):
             circs.append(transpile(self._qc, backend=backend))
         job_set = self._jm.run(circs, backend=backend)
-        results = job_set.results()
         statuses = job_set.statuses()
+        job_set.results()
 
-        self.assertEqual(len(results), 2)
         self.assertEqual(len(statuses), 2)
         self.assertTrue(all(s is JobStatus.DONE for s in statuses))
+        self.assertTrue(len(job_set.jobs()), 2)
 
     @requires_provider
     def test_no_split_circuits(self, provider):
@@ -85,11 +83,7 @@ class TestIBMQJobManager(IBMQTestCase):
         for _ in range(int(max_circs/2)):
             circs.append(self._qc)
         job_set = self._jm.run(circs, backend=backend)
-        results = job_set.results()
-        statuses = job_set.statuses()
-
-        self.assertEqual(len(results), 1)
-        self.assertEqual(len(statuses), 1)
+        self.assertTrue(len(job_set.jobs()), 1)
 
     @requires_provider
     def test_custom_split_circuits(self, provider):
@@ -100,28 +94,7 @@ class TestIBMQJobManager(IBMQTestCase):
         for _ in range(2):
             circs.append(self._qc)
         job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=1)
-        results = job_set.results()
-        statuses = job_set.statuses()
-
-        self.assertEqual(len(results), 2)
-        self.assertEqual(len(statuses), 2)
-
-    @requires_provider
-    def test_result(self, provider):
-        """Test getting results for multiple jobs."""
-        backend = provider.get_backend('ibmq_qasm_simulator')
-
-        circs = []
-        for _ in range(2):
-            circs.append(self._qc)
-        job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=1)
-        results = job_set.results()
-        jobs = job_set.jobs()
-
-        self.assertEqual(len(results), 2)
-        for i, result in enumerate(results):
-            self.assertIsNotNone(result)
-            self.assertDictEqual(result.get_counts(0), jobs[i].result().get_counts(0))
+        self.assertTrue(len(job_set.jobs()), 2)
 
     @requires_provider
     def test_job_report(self, provider):
@@ -136,37 +109,6 @@ class TestIBMQJobManager(IBMQTestCase):
         report = self._jm.report()
         for job in jobs:
             self.assertIn(job.job_id(), report)
-
-    @requires_provider
-    def test_skipped_result(self, provider):
-        """Test one of jobs has no result."""
-        backend = provider.get_backend('ibmq_qasm_simulator')
-        max_circs = backend.configuration().max_experiments
-
-        circs = []
-        for _ in range(max_circs+2):
-            circs.append(self._qc)
-        job_set = self._jm.run(circs, backend=backend)
-        jobs = job_set.jobs()
-        cjob = jobs[0]
-        cancelled = False
-        for _ in range(2):
-            # Try twice in case job is not in a cancellable state
-            try:
-                cancelled = cjob.cancel()
-                if cancelled:
-                    break
-            except JobError:
-                pass
-
-        results = job_set.results()
-        statuses = job_set.statuses()
-        if cancelled:
-            self.assertTrue(statuses[0] is JobStatus.CANCELLED)
-            self.assertIsNone(
-                results[0], "Job {} cancelled but result is not None.".format(cjob.job_id()))
-        else:
-            self.log.warning("Unable to cancel job %s", cjob.job_id())
 
     @requires_provider
     def test_skipped_status(self, provider):
@@ -207,8 +149,7 @@ class TestIBMQJobManager(IBMQTestCase):
         job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=1)
 
         jobs = job_set.jobs()
-        results = job_set.results()
-        self.assertIsNone(results[1])
+        job_set.results()
 
         error_report = job_set.error_messages()
         self.assertIsNotNone(error_report)
@@ -259,3 +200,97 @@ class TestIBMQJobManager(IBMQTestCase):
                                name=name, max_experiments_per_job=1)
         rjob_set = self._jm.job_sets(name=name)[0]
         self.assertEqual(job_set, rjob_set)
+
+
+class TestResultManager(IBMQTestCase):
+    """Tests for ResultManager."""
+
+    def setUp(self):
+        self._qc = _bell_circuit()
+        self._jm = IBMQJobManager()
+
+    @requires_provider
+    def test_index_by_number(self, provider):
+        """Test indexing results by number."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        max_per_job = 5
+        circs = []
+        for _ in range(max_per_job*2):
+            circs.append(self._qc)
+        job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=max_per_job)
+        result_manager = job_set.results()
+        jobs = job_set.jobs()
+
+        for i in [0, max_per_job-1, max_per_job+1]:
+            with self.subTest(i=i):
+                job_index = int(i / max_per_job)
+                exp_index = i % max_per_job
+                self.assertEqual(result_manager.get_counts(i),
+                                 jobs[job_index].result().get_counts(exp_index))
+
+    @requires_provider
+    def test_index_by_name(self, provider):
+        """Test indexing results by name."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        max_per_job = 5
+        circs = []
+        for i in range(max_per_job*2+1):
+            new_qc = copy.deepcopy(self._qc)
+            new_qc.name = "test_qc_{}".format(i)
+            circs.append(new_qc)
+        job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=max_per_job)
+        result_manager = job_set.results()
+        jobs = job_set.jobs()
+
+        for i in [1, max_per_job, len(circs)-1]:
+            with self.subTest(i=i):
+                job_index = int(i / max_per_job)
+                exp_index = i % max_per_job
+                self.assertEqual(result_manager.get_counts(circs[i].name),
+                                 jobs[job_index].result().get_counts(exp_index))
+
+    @requires_provider
+    def test_index_out_of_range(self, provider):
+        """Test result index out of range."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        job_set = self._jm.run([self._qc], backend=backend)
+        result_manager = job_set.results()
+        with self.assertRaises(IBMQJobManagerInvalidStateError):
+            result_manager.get_counts(1)
+
+    @requires_provider
+    def test_skipped_result(self, provider):
+        """Test one of jobs has no result."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        max_circs = backend.configuration().max_experiments
+
+        circs = []
+        for _ in range(max_circs+2):
+            circs.append(self._qc)
+        job_set = self._jm.run(circs, backend=backend)
+        jobs = job_set.jobs()
+        cjob = jobs[0]
+        cancelled = False
+        for _ in range(2):
+            # Try twice in case job is not in a cancellable state
+            try:
+                cancelled = cjob.cancel()
+                if cancelled:
+                    break
+            except JobError:
+                pass
+
+        result_manager = job_set.results()
+        if cancelled:
+            with self.assertRaises(IBMQManagedResultDataNotAvailable):
+                result_manager.get_counts(max_circs)
+        else:
+            self.log.warning("Unable to cancel job %s", cjob.job_id())
+
+
+def _bell_circuit():
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    return qc


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Addresses #333. This is a follow up to #389 and #400. 

Introduces a `ManagedResults` class that have the same methods (`get_memory()`, `get_counts()`, etc) as `Result`. It allows the user to do
```
job_set = job_manager.run()
result = job_set.results()
result.get_counts(1)
```

### Details and comments


