### PR TITLE
Move job submit responsibilities to ManagedJob

### DIFF
--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -16,7 +16,7 @@
 
 import warnings
 from typing import List, Optional, Union
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.providers.ibmq import IBMQBackend
@@ -68,7 +68,7 @@ class ManagedJob:
             qobj: Qobj,
             job_name: str,
             backend: IBMQBackend,
-    ) -> IBMQJob:
+    ) -> None:
         """Run a Qobj asynchronously and populate instance attributes.
 
         Args:

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -45,7 +45,6 @@ class ManagedJobSet:
         """Creates a new ManagedJobSet instance."""
         self._managed_jobs = []  # type: List[ManagedJob]
         self._name = name or datetime.utcnow().isoformat()
-        self._submit_collector = None  # type: Optional[Thread]
 
         # Used for caching
         self._results = []  # type: Optional[List[Union[Result, None]]]
@@ -75,41 +74,15 @@ class ManagedJobSet:
             raise IBMQJobManagerInvalidStateError("Jobs were already submitted.")
 
         exp_index = 0
-        for i, experiment in enumerate(experiment_list):
-            qobj = assemble(experiment, backend=backend, **assemble_config)
+        for i, experiments in enumerate(experiment_list):
+            qobj = assemble(experiments, backend=backend, **assemble_config)
             job_name = "{}_{}_".format(self._name, i)
-            future = executor.submit(
-                self._async_submit, qobj=qobj, job_name=job_name, backend=backend)
             self._managed_jobs.append(
-                ManagedJob(experiment, start_index=exp_index, future=future))
-            exp_index += len(experiment)
-
-        # Give the collector its own thread so it's not stuck behind the submits.
-        self._submit_collector = Thread(target=self.submit_results, daemon=True)
-        self._submit_collector.start()
-
-    def _async_submit(
-            self,
-            qobj: Qobj,
-            job_name: str,
-            backend: IBMQBackend,
-    ) -> IBMQJob:
-        """Run a Qobj asynchronously.
-
-        Args:
-            qobj: Qobj to run.
-            job_name: Name of the job.
-            backend: Backend to execute the experiments on.
-
-        Returns:
-            IBMQJob instance for the job.
-        """
-        return backend.run(qobj=qobj, job_name=job_name)
-
-    def submit_results(self) -> None:
-        """Collect job submit responses."""
-        for mjob in self._managed_jobs:
-            mjob.submit_result()
+                ManagedJob(experiments, start_index=exp_index,
+                           qobj=qobj, job_name=job_name, backend=backend,
+                           executor=executor)
+            )
+            exp_index += len(experiments)
 
     def statuses(self) -> List[Union[JobStatus, None]]:
         """Return the status of each job.

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -19,7 +19,6 @@ from typing import List, Optional, Union, Any
 from concurrent.futures import ThreadPoolExecutor
 import time
 import logging
-from threading import Thread
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.pulse import Schedule

--- a/qiskit/providers/ibmq/managed/utils.py
+++ b/qiskit/providers/ibmq/managed/utils.py
@@ -22,7 +22,6 @@ from concurrent.futures import wait
 from qiskit.providers.jobstatus import JobStatus
 
 from .managedjob import ManagedJob
-from .exceptions import IBMQJobManagerInvalidStateError
 
 
 def requires_submit(func: Callable) -> Callable:

--- a/qiskit/providers/ibmq/managed/utils.py
+++ b/qiskit/providers/ibmq/managed/utils.py
@@ -17,6 +17,7 @@
 from typing import Callable, Any, List, Union
 from functools import wraps
 from collections import Counter
+from concurrent.futures import wait
 
 from qiskit.providers.jobstatus import JobStatus
 
@@ -51,13 +52,9 @@ def requires_submit(func: Callable) -> Callable:
 
         Returns:
             return value of the decorated function.
-
-        Raises:
-            IBMQJobManagerInvalidStateError: If jobs have not been submitted.
         """
-        if job_set._submit_collector is None:
-            raise IBMQJobManagerInvalidStateError("Jobs need to be submitted first!")
-        job_set._submit_collector.join()
+        futures = [managed_job.future for managed_job in job_set._managed_jobs]
+        wait(futures)
         return func(job_set, *args, **kwargs)
 
     return _wrapper


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is an alternative to part of the current `master` version of the Job Manager async functionalities, specifically aimed at removing the need for a `Thread` to collect the submission results. In order to do so, more responsibilities have been pushed to `ManagerJob`, during its construction.

### Details and comments

Overall, this PR is mostly experimental - if this is a good direction to go, some extra tuning is likely needed (name/order of arguments, cleaning up, etc).
