### PR TITLE
add timeout to staging tests

### DIFF
--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -191,7 +191,7 @@ class TestIBMQJob(JobTestCase):
         self.assertTrue(num_jobs - num_error - num_done > 0)
 
         # Wait for all the results.
-        result_array = [job.result(timeout=60) for job in job_array]
+        result_array = [job.result(timeout=180) for job in job_array]
 
         # Ensure all jobs have finished.
         self.assertTrue(
@@ -381,7 +381,7 @@ class TestIBMQJob(JobTestCase):
 
         job = backend.run(qobj)
         with self.assertRaises(IBMQJobFailureError):
-            job.result(timeout=60)
+            job.result(timeout=180)
 
         new_job = provider.backends.retrieve_job(job.job_id())
         self.assertTrue(new_job.error_message())

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -191,7 +191,7 @@ class TestIBMQJob(JobTestCase):
         self.assertTrue(num_jobs - num_error - num_done > 0)
 
         # Wait for all the results.
-        result_array = [job.result() for job in job_array]
+        result_array = [job.result(timeout=60) for job in job_array]
 
         # Ensure all jobs have finished.
         self.assertTrue(
@@ -381,7 +381,7 @@ class TestIBMQJob(JobTestCase):
 
         job = backend.run(qobj)
         with self.assertRaises(IBMQJobFailureError):
-            job.result()
+            job.result(timeout=60)
 
         new_job = provider.backends.retrieve_job(job.job_id())
         self.assertTrue(new_job.error_message())

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -121,7 +121,7 @@ class TestIBMQJobAttributes(JobTestCase):
 
         job = backend.run(qobj)
         with self.assertRaises(IBMQJobFailureError):
-            job.result()
+            job.result(timeout=60)
 
         message = job.error_message()
         self.assertTrue(message)

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -121,7 +121,7 @@ class TestIBMQJobAttributes(JobTestCase):
 
         job = backend.run(qobj)
         with self.assertRaises(IBMQJobFailureError):
-            job.result(timeout=60)
+            job.result(timeout=180)
 
         message = job.error_message()
         self.assertTrue(message)

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -196,7 +196,7 @@ class TestIBMQJobManager(IBMQTestCase):
         job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=1)
 
         jobs = job_set.jobs()
-        results = job_set.results(timeout=60)
+        results = job_set.results(timeout=180)
         self.assertIsNone(results[1])
 
         error_report = job_set.error_messages()

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -196,7 +196,7 @@ class TestIBMQJobManager(IBMQTestCase):
         job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=1)
 
         jobs = job_set.jobs()
-        results = job_set.results()
+        results = job_set.results(timeout=60)
         self.assertIsNone(results[1])
 
         error_report = job_set.error_messages()

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -78,7 +78,7 @@ class TestWebsocketIntegration(IBMQTestCase):
         job = backend.run(qobj)
         # Manually disable the non-websocket polling.
         job._api._job_final_status_polling = None
-        result = job.result(timeout=60)
+        result = job.result(timeout=180)
 
         self.assertTrue(result.success)
 

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -78,7 +78,7 @@ class TestWebsocketIntegration(IBMQTestCase):
         job = backend.run(qobj)
         # Manually disable the non-websocket polling.
         job._api._job_final_status_polling = None
-        result = job.result()
+        result = job.result(timeout=60)
 
         self.assertTrue(result.success)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Addresses #410. There was an issue with staging websockets not receiving data. This PR adds timeout to those tests so in the future they would just fail instead of hang.


### Details and comments


