### PR TITLE
Ignore error fetching results for failed jobs

### DIFF
--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -32,7 +32,7 @@ from ..utils.fields import Enum
 # clashes.
 FIELDS_MAP = {
     'id': '_job_id',
-    'status': '_status',
+    'status': '_api_status',
     'backend': '_backend_info',
     'creationDate': '_creation_date',
     'qObject': '_qobj',
@@ -85,7 +85,7 @@ class JobResponseSchema(BaseSchema):
     _creation_date = DateTime(required=True)
     kind = Enum(required=True, enum_cls=ApiJobKind)
     _job_id = String(required=True)
-    _status = Enum(required=True, enum_cls=ApiJobStatus)
+    _api_status = Enum(required=True, enum_cls=ApiJobStatus)
 
     # Optional properties with a default value.
     _name = String(missing=None)

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -143,6 +143,18 @@ class TestIBMQJobAttributes(JobTestCase):
         self.assertIn('Experiment 1: ERROR', message)
 
     @requires_provider
+    def test_error_message_validation(self, provider):
+        """Test retrieving job error message for a validation error."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        qobj = assemble(transpile(self._qc, backend), shots=10000)
+        job = backend.run(qobj)
+        with self.assertRaises(IBMQJobFailureError):
+            job.result()
+
+        message = job.error_message()
+        print(message)
+
+    @requires_provider
     def test_refresh(self, provider):
         """Test refreshing job data."""
         backend = provider.get_backend('ibmq_qasm_simulator')

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -152,7 +152,7 @@ class TestIBMQJobAttributes(JobTestCase):
             job.result()
 
         message = job.error_message()
-        print(message)
+        self.assertNotIn("Unknown", message)
 
     @requires_provider
     def test_refresh(self, provider):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #405 
Ignore errors when fetching results for a failed job, since result may not be available. Use `error` or `status` from job get response instead, if available.


### Details and comments


