### PR TITLE
Move the other job methods to ManagedJob

### DIFF
--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -26,7 +26,7 @@ from qiskit.compiler import assemble
 from qiskit.qobj import Qobj
 from qiskit.result import Result
 from qiskit.providers.jobstatus import JobStatus
-from qiskit.providers.exceptions import JobError, JobTimeoutError
+from qiskit.providers.exceptions import JobTimeoutError
 
 from .managedjob import ManagedJob
 from .utils import requires_submit, format_status_counts, format_job_details
@@ -203,8 +203,8 @@ class ManagedJobSet:
         """Return the Qobj for the jobs.
 
         Returns:
-            A list of Qobj for the jobs. The entry is ``None`` if the job
-                submit failed.
+            A list of Qobj for the jobs. The entry is ``None`` if the Qobj
+                could not be retrieved.
         """
         return [mjob.qobj() for mjob in self._managed_jobs]
 

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -160,6 +160,8 @@ class ManagedJobSet:
     def error_messages(self) -> Optional[str]:
         """Provide details about job failures.
 
+        This call will block until all job results become available.
+
         Returns:
             An error report if one or more jobs failed or ``None`` otherwise.
         """
@@ -168,18 +170,12 @@ class ManagedJobSet:
 
         report = []  # type: List[str]
         for i, mjob in enumerate(self._managed_jobs):
-            if mjob.job is None:
-                continue
-            if mjob.job.status() is not JobStatus.ERROR:
+            msg_list = mjob.error_message()
+            if not msg_list:
                 continue
             report.append("Experiments {}-{}, job index={}, job ID={}:".format(
                 mjob.start_index, mjob.end_index, i, mjob.job.job_id()))
-            try:
-                msg_list = mjob.job.error_message().split('\n')
-            except JobError:
-                msg_list = ["Unknown error."]
-
-            for msg in msg_list:
+            for msg in msg_list.split('\n'):
                 report.append(msg.rjust(len(msg)+2))
 
         if not report:
@@ -189,12 +185,8 @@ class ManagedJobSet:
     @requires_submit
     def cancel(self) -> None:
         """Cancel all managed jobs."""
-        for job in self.jobs():
-            if job is not None:
-                try:
-                    job.cancel()
-                except JobError as err:
-                    logger.warning("Unable to cancel job %s: %s", job.job_id(), str(err))
+        for mjob in self._managed_jobs:
+            mjob.cancel()
 
     @requires_submit
     def jobs(self) -> List[Union[IBMQJob, None]]:
@@ -211,9 +203,10 @@ class ManagedJobSet:
         """Return the Qobj for the jobs.
 
         Returns:
-            A list of Qobj for the jobs.
+            A list of Qobj for the jobs. The entry is ``None`` if the job
+                submit failed.
         """
-        return [mjob.job.qobj() for mjob in self._managed_jobs]
+        return [mjob.qobj() for mjob in self._managed_jobs]
 
     def name(self) -> str:
         """Return the name of this set of jobs.

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -166,7 +166,7 @@ class TestIBMQJobAttributes(JobTestCase):
 
         job = backend.run(qobj)
         with self.assertRaises(IBMQJobFailureError):
-            job.result(timeout=180, partial=True)
+            job.result(timeout=300, partial=True)
 
         message = job.error_message()
         self.assertTrue(message)

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -196,7 +196,7 @@ class TestIBMQJobManager(IBMQTestCase):
         job_set = self._jm.run(circs, backend=backend, max_experiments_per_job=1)
 
         jobs = job_set.jobs()
-        results = job_set.results(timeout=180)
+        results = job_set.results(timeout=300)
         self.assertIsNone(results[1])
 
         error_report = job_set.error_messages()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Related to #333 . 

Some of the job methods (e.g. `status()` and `result()`) are already in `ManagedJob`. This PR moves the rest to it to keep things consistent and `ManagedJobSet` cleaner.


### Details and comments


