### PR TITLE
Add ability to run tests on staging locally

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -140,8 +140,8 @@ def run_on_staging(func):
             environment variables.
         * if the first three variables are set, then their values are used as the
             credentials, unless the `QE_STG_LOCAL` environment variable is set.
-            The `QE_STG_LOCAL` environment variable signals that tests are to
-            be run locally on staging, so tests with this decorator should be skipped.
+            The `QE_STG_LOCAL` environment variable signals that the tests are to be
+            run locally on staging, so tests with this decorator should be skipped.
         * if the test is not skipped, enables the staging account and
             appends it as the `provider` argument to the test function.
 

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -95,9 +95,9 @@ def requires_device(func):
     provider it appends a `backend` argument to the decorated function.
 
     It involves:
-        * If the `QE_STG_LOCAL` environment variable is set, the test is to be
-            run locally against staging, so a staging `backend` is appended.
-        * If the `QE_STG_LOCAL` environment variable is not set, the test is to
+        * If the `QE_STG_DEVICE` environment variable is set, the test is to be
+            run locally against staging with the backend specified by `QE_STG_DEVICE`.
+        * If the `QE_STG_DEVICE` environment variable is not set, the test is to
             be run against production, so a production backend is appended.
 
     Args:
@@ -112,7 +112,7 @@ def requires_device(func):
         provider = kwargs.pop('provider')
 
         _backend = None
-        if os.getenv('QE_STG_LOCAL'):
+        if os.getenv('QE_STG_DEVICE'):
             stg_token = os.getenv('QE_STG_TOKEN')
             stg_url = os.getenv('QE_STG_URL')
             stg_hub = os.getenv('QE_STG_HUB')
@@ -136,12 +136,13 @@ def run_on_staging(func):
     """Decorator that signals that the test runs on the staging system.
 
     It involves:
-        * reads the `QE_STG_TOKEN`, `QE_STG_URL`, `QE_STG_HUB` and `QE_STG_LOCAL`
+        * reads the `QE_STG_TOKEN`, `QE_STG_URL`, `QE_STG_HUB` and `QE_STG_DEVICE`
             environment variables.
         * if the first three variables are set, then their values are used as the
-            credentials, unless the `QE_STG_LOCAL` environment variable is set.
-            The `QE_STG_LOCAL` environment variable signals that the tests are to be
-            run locally on staging, so tests with this decorator should be skipped.
+            credentials, unless the `QE_STG_DEVICE` environment variable is set.
+            The `QE_STG_DEVICE` environment variable signals that the tests are to be
+            run locally on staging, on a specific device, so tests with this decorator
+            should be skipped.
         * if the test is not skipped, enables the staging account and
             appends it as the `provider` argument to the test function.
 
@@ -156,9 +157,9 @@ def run_on_staging(func):
         stg_token = os.getenv('QE_STG_TOKEN')
         stg_url = os.getenv('QE_STG_URL')
         stg_hub = os.getenv('QE_STG_HUB')
-        stg_is_local = os.getenv('QE_STG_LOCAL')
+        stg_device = os.getenv('QE_STG_DEVICE')
 
-        if not (stg_token and stg_url and stg_hub) or stg_is_local:
+        if not (stg_token and stg_url and stg_hub) or stg_device:
             raise SkipTest('Skipping staging tests')
 
         credentials = Credentials(stg_token, stg_url)

--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -15,13 +15,12 @@
 """IBMQ provider integration tests (compile and run)."""
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers.ibmq import least_busy
 from qiskit.result import Result
 from qiskit.execute import execute
 from qiskit.compiler import assemble, transpile
 
 from ..ibmqtestcase import IBMQTestCase
-from ..decorators import requires_provider
+from ..decorators import requires_provider, requires_device
 
 
 class TestIBMQIntegration(IBMQTestCase):
@@ -48,11 +47,9 @@ class TestIBMQIntegration(IBMQTestCase):
         self.assertEqual(remote_result.status, 'COMPLETED')
         self.assertEqual(remote_result.results[0].status, 'DONE')
 
-    @requires_provider
-    def test_compile_remote(self, provider):
+    @requires_device
+    def test_compile_remote(self, backend):
         """Test Compiler remote."""
-        backend = least_busy(provider.backends())
-
         qubit_reg = QuantumRegister(2, name='q')
         clbit_reg = ClassicalRegister(2, name='c')
         qc = QuantumCircuit(qubit_reg, clbit_reg, name="bell")
@@ -63,11 +60,9 @@ class TestIBMQIntegration(IBMQTestCase):
         circuits = transpile(qc, backend=backend)
         self.assertIsInstance(circuits, QuantumCircuit)
 
-    @requires_provider
-    def test_compile_two_remote(self, provider):
+    @requires_device
+    def test_compile_two_remote(self, backend):
         """Test Compiler remote on two circuits."""
-        backend = least_busy(provider.backends())
-
         qubit_reg = QuantumRegister(2, name='q')
         clbit_reg = ClassicalRegister(2, name='c')
         qc = QuantumCircuit(qubit_reg, clbit_reg, name="bell")

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -83,9 +83,10 @@ class TestIBMQJob(JobTestCase):
         self.assertGreater(contingency2[1], 0.01)
 
     @slow_test
-    @requires_device
-    def test_run_device(self, backend):
+    @requires_provider
+    def test_run_device(self, provider):
         """Test running in a real device."""
+        backend = least_busy(provider.backends(simulator=False))
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         shots = qobj.config.shots
         job = backend.run(qobj)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -36,7 +36,7 @@ from qiskit.result import Result
 
 from ..jobtestcase import JobTestCase
 from ..decorators import (requires_provider, requires_qe_access,
-                          run_on_staging)
+                          run_on_staging, requires_device)
 
 
 class TestIBMQJob(JobTestCase):
@@ -83,11 +83,9 @@ class TestIBMQJob(JobTestCase):
         self.assertGreater(contingency2[1], 0.01)
 
     @slow_test
-    @requires_provider
-    def test_run_device(self, provider):
+    @requires_device
+    def test_run_device(self, backend):
         """Test running in a real device."""
-        backend = least_busy(provider.backends(simulator=False))
-
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         shots = qobj.config.shots
         job = backend.run(qobj)
@@ -218,11 +216,9 @@ class TestIBMQJob(JobTestCase):
         self.assertTrue(can_cancel)
         self.assertTrue(job.status() is JobStatus.CANCELLED)
 
-    @requires_provider
-    def test_get_jobs_from_backend(self, provider):
+    @requires_device
+    def test_get_jobs_from_backend(self, backend):
         """Test retrieving jobs from a backend."""
-        backend = least_busy(provider.backends())
-
         job_list = backend.jobs(limit=5, skip=0)
         for job in job_list:
             self.assertTrue(isinstance(job.job_id(), str))
@@ -293,12 +289,9 @@ class TestIBMQJob(JobTestCase):
                               real_backend.retrieve_job, job_sim.job_id())
         self.assertIn('belongs to', str(context_manager.warning))
 
-    @requires_provider
-    def test_retrieve_job_error_backend(self, provider):
+    @requires_device
+    def test_retrieve_job_error_backend(self, backend):
         """Test retrieving an invalid job from a backend."""
-        backends = provider.backends(simulator=False)
-        backend = least_busy(backends)
-
         self.assertRaises(IBMQBackendError, backend.retrieve_job, 'BAD_JOB_ID')
 
     @requires_provider
@@ -306,12 +299,9 @@ class TestIBMQJob(JobTestCase):
         """Test retrieving an invalid job from backend service."""
         self.assertRaises(IBMQBackendError, provider.backends.retrieve_job, 'BAD_JOB_ID')
 
-    @requires_provider
-    def test_get_jobs_filter_job_status_backend(self, provider):
+    @requires_device
+    def test_get_jobs_filter_job_status_backend(self, backend):
         """Test retrieving jobs from a backend filtered by status."""
-        backends = provider.backends(simulator=False)
-        backend = least_busy(backends)
-
         job_list = backend.jobs(limit=5, skip=0, status=JobStatus.DONE)
         for job in job_list:
             self.assertTrue(job.status() is JobStatus.DONE)
@@ -379,12 +369,9 @@ class TestIBMQJob(JobTestCase):
             self.assertTrue(any(cresult.data.counts.to_dict()['0x0'] < 500
                                 for cresult in result.results))
 
-    @requires_provider
-    def test_get_jobs_filter_date_backend(self, provider):
+    @requires_device
+    def test_get_jobs_filter_date_backend(self, backend):
         """Test retrieving jobs from a backend filtered by date."""
-        backends = provider.backends(simulator=False)
-        backend = least_busy(backends)
-
         my_filter = {'creationDate': {'lt': '2017-01-01T00:00:00.00'}}
         job_list = backend.jobs(limit=5, db_filter=my_filter)
 

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -465,22 +465,21 @@ class TestIBMQJob(JobTestCase):
                 backend = least_busy(backends)
                 break
 
-        if backend:
-            self.assertIsNotNone(backend)
-            config = backend.configuration()
-            defaults = backend.defaults()
-            cmd_def = defaults.build_cmd_def()
+        self.assertIsNotNone(backend)
+        config = backend.configuration()
+        defaults = backend.defaults()
+        cmd_def = defaults.build_cmd_def()
 
-            # Run 2 experiments - 1 with x pulse and 1 without
-            x = cmd_def.get('x', 0)
-            measure = cmd_def.get('measure', range(config.n_qubits)) << x.duration
-            ground_sched = measure
-            excited_sched = x | measure
-            schedules = [ground_sched, excited_sched]
+        # Run 2 experiments - 1 with x pulse and 1 without
+        x = cmd_def.get('x', 0)
+        measure = cmd_def.get('measure', range(config.n_qubits)) << x.duration
+        ground_sched = measure
+        excited_sched = x | measure
+        schedules = [ground_sched, excited_sched]
 
-            qobj = assemble(schedules, backend, meas_level=1, shots=256)
-            job = backend.run(qobj)
-            _ = job.result()
+        qobj = assemble(schedules, backend, meas_level=1, shots=256)
+        job = backend.run(qobj)
+        _ = job.result()
 
 
 def _bell_circuit():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary


### Details and comments

This PR addresses being able to **optionally** run some of the tests on staging locally by introducing a new `requires_device` decorator. The `requires_device` decorator replaces the `requires_provider` in some tests, specifically those that meet the use the pattern:
- `backend = least_busy(provider.backends(simulator=False))` to retrieve a backend (i.e. the test is meant to be run on a real device).

To accomplish this, it requires the introduction of one new environment variable `QE_DEVICE`, which is meant to store the name of the device to test on. Therefore, when tests are to be run locally (and targeting a specific device), this environment variable could be set. If the environment variable is not set locally, then the tests use the default behavior; they use the least busy open backend.

