### PR TITLE
Make it easier to run slow tests on staging or production

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -90,9 +90,8 @@ def requires_provider(func):
 def requires_device(func):
     """Decorator that retrieves the appropriate backend to use for testing.
 
-    This decorator delegates into the `requires_provider` decorator, which
-    adds a `provider` argument to the decorated function. It also adds
-    a `backend` argument to the decorated function.
+    This decorator delegates into the `requires_provider` decorator, but instead of the
+    provider it appends a `backend` argument to the decorated function.
 
     It involves:
         * If the `QE_DEVICE` environment variable is set, the test is to be

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2017, 2019.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -36,7 +36,7 @@ from qiskit.result import Result
 
 from ..jobtestcase import JobTestCase
 from ..decorators import (requires_provider, requires_qe_access,
-                          run_on_staging, requires_device)
+                          run_on_device, requires_device)
 
 
 class TestIBMQJob(JobTestCase):
@@ -153,11 +153,9 @@ class TestIBMQJob(JobTestCase):
         job_ids = [job.job_id() for job in job_array]
         self.assertEqual(sorted(job_ids), sorted(list(set(job_ids))))
 
-    @run_on_staging
-    def test_run_async_device(self, provider):
+    @run_on_device
+    def test_run_async_device(self, provider, backend):  # pylint: disable=unused-argument
         """Test running in a real device asynchronously."""
-        backend = least_busy(provider.backends(simulator=False))
-
         self.log.info('submitting to backend %s', backend.name())
         num_qubits = 5
         qr = QuantumRegister(num_qubits, 'qr')
@@ -417,11 +415,9 @@ class TestIBMQJob(JobTestCase):
         message = new_job.error_message()
         self.assertIn('Experiment 1: ERROR', message)
 
-    @run_on_staging
-    def test_retrieve_failed_job_device(self, provider):
+    @run_on_device
+    def test_retrieve_failed_job_device(self, provider, backend):
         """Test retrieving a failed job from a device backend."""
-        backend = least_busy(provider.backends(simulator=False))
-
         qc_new = transpile(self._qc, backend)
         qobj = assemble([qc_new, qc_new], backend=backend)
         qobj.experiments[1].instructions[1].name = 'bad_instruction'

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -19,13 +19,12 @@ from unittest import mock
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers import JobStatus
-from qiskit.providers.ibmq import least_busy
 from qiskit.providers.ibmq.job.exceptions import IBMQJobFailureError, JobError
 from qiskit.providers.ibmq.api.clients.account import AccountClient
 from qiskit.compiler import assemble, transpile
 
 from ..jobtestcase import JobTestCase
-from ..decorators import requires_provider, run_on_staging
+from ..decorators import requires_provider, run_on_device
 
 
 class TestIBMQJobAttributes(JobTestCase):
@@ -54,11 +53,9 @@ class TestIBMQJobAttributes(JobTestCase):
         job = backend.run(qobj)
         self.assertTrue(job.backend().name() == backend.name())
 
-    @run_on_staging
-    def test_running_job_properties(self, provider):
+    @run_on_device
+    def test_running_job_properties(self, provider, backend):  # pylint: disable=unused-argument
         """Test fetching properties of a running job."""
-        backend = least_busy(provider.backends(simulator=False))
-
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         job = backend.run(qobj)
         _ = job.properties()
@@ -155,11 +152,9 @@ class TestIBMQJobAttributes(JobTestCase):
         for job in retrieved_jobs:
             self.assertEqual(job.name(), job_name)
 
-    @run_on_staging
-    def test_error_message_device(self, provider):
+    @run_on_device
+    def test_error_message_device(self, provider, backend):  # pylint: disable=unused-argument
         """Test retrieving job error messages from a device backend."""
-        backend = least_busy(provider.backends(simulator=False))
-
         qc_new = transpile(self._qc, backend)
         qobj = assemble([qc_new, qc_new], backend=backend)
         qobj.experiments[1].instructions[1].name = 'bad_instruction'

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -21,7 +21,6 @@ from queue import Queue
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import assemble, transpile
 from qiskit.providers import JobTimeoutError
-from qiskit.providers.ibmq import least_busy
 from qiskit.providers.ibmq.api.clients.websocket import (
     WebsocketClient, WebsocketAuthenticationMessage)
 from qiskit.providers.ibmq.api.clients import AccountClient
@@ -29,7 +28,7 @@ from qiskit.providers.ibmq.ibmqfactory import IBMQFactory
 from qiskit.providers.jobstatus import JobStatus
 
 from ...ibmqtestcase import IBMQTestCase
-from ...decorators import requires_qe_access, run_on_staging
+from ...decorators import requires_qe_access, run_on_device
 
 
 class TestWebsocketIntegration(IBMQTestCase):
@@ -67,11 +66,9 @@ class TestWebsocketIntegration(IBMQTestCase):
 
         self.assertEqual(result.status, 'COMPLETED')
 
-    @run_on_staging
-    def test_websockets_device(self, provider):
+    @run_on_device
+    def test_websockets_device(self, provider, backend):  # pylint: disable=unused-argument
         """Test checking status of a job via websockets for a device."""
-        backend = least_busy(provider.backends(simulator=False))
-
         qc = transpile(self.qc1, backend=backend)
         qobj = assemble(qc, backend=backend)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #374 . 

Main changes:
- introduces a new environment variable `USE_STAGING_CREDENTIALS` and `QE_STAGING_DEVICE`
- removes `QE_STG_HUB` (to reduce the number of env vars, we can add it back if needed)
- renames `run_on_staging` to `run_on_device`
- renames `QE_STG_TOKEN` and `QE_STG_URL` to `QE_STAGING_TOKEN` and `QE_STAGING_URL`
- if `USE_STAGING_CREDENTIALS` is specified, `run_on_device` uses the staging credentials and `QE_STAGING_DEVICE`. Otherwise it uses regular credentials if slow tests are allowed. 


### Details and comments


