### PR TITLE
Return job creation date as str

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -20,6 +20,7 @@ This module is used for creating a job objects for the IBM Q Experience.
 import logging
 from typing import Dict, Optional, Tuple, Any
 import warnings
+from datetime import datetime
 
 from marshmallow import ValidationError
 
@@ -103,14 +104,13 @@ class IBMQJob(BaseModel, BaseJob):
         finished with errors. In that case, ``status()`` will simply return
         ``JobStatus.ERROR`` and you can call ``error_message()`` to get more
         info.
-
     """
 
     def __init__(self,
                  _backend: BaseBackend,
                  api: AccountClient,
                  _job_id: str,
-                 _creation_date: str,
+                 _creation_date: datetime,
                  kind: ApiJobKind,
                  _api_status: ApiJobStatus,
                  **kwargs: Any) -> None:
@@ -365,7 +365,7 @@ class IBMQJob(BaseModel, BaseJob):
         Returns:
             Job creation date.
         """
-        return self._creation_date
+        return str(self._creation_date)
 
     def job_id(self) -> str:
         """Return the job ID assigned by the API.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The job response schema defines job creation date as `DateTime`, but `job.creation_date()` is expected to return a `str`. This PR keeps the schema unchanged for validation but returns the date as a `str`. 

Closes #438.


### Details and comments


