### PR TITLE
Revert "don't build wheels (#454)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,5 +170,5 @@ jobs:
         - TWINE_USERNAME=qiskit
       install: pip install -U twine
       script:
-        - python3 setup.py sdist
+        - python3 setup.py sdist bdist_wheel
         - twine upload dist/qiskit*

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -541,7 +541,7 @@ class IBMQJob(BaseModel, BaseJob):
             IBMQJobApiError: If there was some unexpected failure in the server.
         """
         try:
-            return "{}. Error code {}.".format(error['message'], error['code'])
+            return "{}. Error code: {}.".format(error['message'], error['code'])
         except KeyError:
             raise IBMQJobApiError('Failed to get job error message. Invalid error data received: {}'
                                   .format(error))

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -541,7 +541,7 @@ class IBMQJob(BaseModel, BaseJob):
             IBMQJobApiError: If there was some unexpected failure in the server.
         """
         try:
-            return "{}. Error code: {}.".format(error['message'], error['code'])
+            return "{}. Error code {}.".format(error['message'], error['code'])
         except KeyError:
             raise IBMQJobApiError('Failed to get job error message. Invalid error data received: {}'
                                   .format(error))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Wheels are useful because they're more efficient they're not just
about binaries. Wheels are a distribution format and are just unzipped
when installed, while sdists require running the setup.py and building
the package to be installed locally. While wheels are very useful for
compiled python extensions because it lets us distribute pre-compiled
binaries the benefits extend beyond just that. We should still build
and publish a wheel even if it's just python code. This is why there is
a separate definition for both universal and pure python wheels. [1]

### Details and comments

This reverts commit 8d0d8df88f681d29cb00e596c2e05a39024a12c5.

[1] https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project