### PR TITLE
Downgrade websocket error message

### DIFF
--- a/qiskit/providers/ibmq/api/clients/account.py
+++ b/qiskit/providers/ibmq/api/clients/account.py
@@ -373,10 +373,10 @@ class AccountClient(BaseClient):
                 status_response = self._job_final_status_websocket(job_id, timeout)
             except WebsocketTimeoutError as ex:
                 logger.debug('Timeout checking job status using websocket, '
-                             'retrying using HTTP: {}'.format(ex))
+                             'retrying using HTTP: %s', ex)
             except (RuntimeError, WebsocketError) as ex:
                 logger.debug('Error checking job status using websocket, '
-                             'retrying using HTTP: {}'.format(ex))
+                             'retrying using HTTP: %s', ex)
 
             # Adjust timeout for HTTP retry.
             if timeout is not None:

--- a/qiskit/providers/ibmq/api/clients/account.py
+++ b/qiskit/providers/ibmq/api/clients/account.py
@@ -372,11 +372,11 @@ class AccountClient(BaseClient):
             try:
                 status_response = self._job_final_status_websocket(job_id, timeout)
             except WebsocketTimeoutError as ex:
-                logger.debug('Timeout checking job status using websocket, '
-                             'retrying using HTTP: %s', ex)
+                logger.info('Timeout checking job status using websocket, '
+                            'retrying using HTTP: %s', ex)
             except (RuntimeError, WebsocketError) as ex:
-                logger.debug('Error checking job status using websocket, '
-                             'retrying using HTTP: %s', ex)
+                logger.info('Error checking job status using websocket, '
+                            'retrying using HTTP: %s', ex)
 
             # Adjust timeout for HTTP retry.
             if timeout is not None:

--- a/qiskit/providers/ibmq/api/clients/account.py
+++ b/qiskit/providers/ibmq/api/clients/account.py
@@ -372,13 +372,11 @@ class AccountClient(BaseClient):
             try:
                 status_response = self._job_final_status_websocket(job_id, timeout)
             except WebsocketTimeoutError as ex:
-                logger.warning('Timeout checking job status using websocket, '
-                               'retrying using HTTP')
-                logger.debug(ex)
+                logger.debug('Timeout checking job status using websocket, '
+                             'retrying using HTTP: {}'.format(ex))
             except (RuntimeError, WebsocketError) as ex:
-                logger.warning('Error checking job status using websocket, '
-                               'retrying using HTTP.')
-                logger.debug(ex)
+                logger.debug('Error checking job status using websocket, '
+                             'retrying using HTTP: {}'.format(ex))
 
             # Adjust timeout for HTTP retry.
             if timeout is not None:

--- a/qiskit/providers/ibmq/api/clients/websocket.py
+++ b/qiskit/providers/ibmq/api/clients/websocket.py
@@ -278,7 +278,7 @@ class WebsocketClient(BaseClient):
                                              .format(message, ex.code)) from ex
 
             except WebsocketError as ex:
-                logger.warning('%s', ex)
+                logger.info('A websocket error occurred: %s', ex)
 
                 # Specific `WebsocketError` exceptions that are not worth retrying.
                 if isinstance(ex, (WebsocketTimeoutError, WebsocketIBMQProtocolError)):
@@ -290,8 +290,8 @@ class WebsocketClient(BaseClient):
 
                 # Sleep, and then `continue` with retrying.
                 backoff_time = self._backoff_time(backoff_factor, current_retry_attempt)
-                logger.warning('Retrying get_job_status after %s seconds: '
-                               'Attempt #%s.', backoff_time, current_retry_attempt)
+                logger.info('Retrying get_job_status via websocket after %s seconds: '
+                             'Attempt #%s.', backoff_time, current_retry_attempt)
                 yield from asyncio.sleep(backoff_time)  # Block asyncio loop for given backoff time.
 
                 continue  # Continues next iteration after `finally` block.

--- a/qiskit/providers/ibmq/api/clients/websocket.py
+++ b/qiskit/providers/ibmq/api/clients/websocket.py
@@ -291,7 +291,7 @@ class WebsocketClient(BaseClient):
                 # Sleep, and then `continue` with retrying.
                 backoff_time = self._backoff_time(backoff_factor, current_retry_attempt)
                 logger.info('Retrying get_job_status via websocket after %s seconds: '
-                             'Attempt #%s.', backoff_time, current_retry_attempt)
+                            'Attempt #%s.', backoff_time, current_retry_attempt)
                 yield from asyncio.sleep(backoff_time)  # Block asyncio loop for given backoff time.
 
                 continue  # Continues next iteration after `finally` block.

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -98,7 +98,6 @@ class JobResponseSchema(BaseSchema):
     # Optional properties
     _backend_info = Nested(JobResponseBackendSchema)
     allow_object_storage = Boolean()
-    error = String()
 
     @pre_load
     def preprocess_field_names(self, data, **_):  # type: ignore


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
There is really no need to issue a warning when websocket fails and the provider is retrying with http. There is nothing a user can do about the websocket failure, and the http retry usually works. It just causes confusion to users who think it's due to their code. The message, however, might be useful for developers to debug websocket issues, so it's downgraded to ~`debug`~ `info` level. `info` level is useful for getting more information without too much noise, and it's below the default level of `warning`.


### Details and comments


