### PR TITLE
Move access token to request header

### DIFF
--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -112,9 +112,9 @@ class RetrySession(Session):
         """Set the session access token."""
         self._access_token = value
         if value:
-            self.params.update({'access_token': value})  # type: ignore[attr-defined]
+            self.headers.update({'X-Access-Token': value})  # type: ignore[attr-defined]
         else:
-            self.params.pop('access_token', None)  # type: ignore[attr-defined]
+            self.headers.pop('X-Access-Token', None)  # type: ignore[attr-defined]
 
     def _initialize_retry(
             self,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Thanks to @ sdague's suggestion, we can actually move the access token to the request header instead of param, so it doesn't show up in logs. 

We can probably remove the token obfuscation in traceback, but will leave it for now just in case. 


### Details and comments


