### PR TITLE
Update test_filter_backends

### DIFF
--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -17,19 +17,26 @@
 from qiskit.providers.ibmq import least_busy
 
 from ..ibmqtestcase import IBMQTestCase
-from ..decorators import requires_provider
+from ..decorators import requires_provider, requires_device
 
 
 class TestBackendFilters(IBMQTestCase):
     """Qiskit Backend Filtering Tests."""
 
-    @requires_provider
-    def test_filter_config_properties(self, provider):
+    @requires_device
+    def test_filter_config_properties(self, backend):
         """Test filtering by configuration properties"""
-        n_qubits = 20 if self.using_ibmq_credentials else 5
+        # Use the default backend as a reference for the filter.
+        provider = backend._provider
+        n_qubits = backend.configuration().n_qubits
 
         filtered_backends = provider.backends(n_qubits=n_qubits, local=False)
+
         self.assertTrue(filtered_backends)
+        for filtered_backend in filtered_backends:
+            with self.subTest(backend=filtered_backend):
+                self.assertEqual(n_qubits, backend.configuration().n_qubits)
+                self.assertFalse(backend.configuration().local)
 
     @requires_provider
     def test_filter_status_dict(self, provider):
@@ -39,6 +46,11 @@ class TestBackendFilters(IBMQTestCase):
             local=False, simulator=True)  # from configuration
 
         self.assertTrue(filtered_backends)
+        for backend in filtered_backends:
+            with self.subTest(backend=backend):
+                self.assertTrue(backend.status().operational)
+                self.assertFalse(backend.configuration().local)
+                self.assertTrue(backend.configuration().simulator)
 
     @requires_provider
     def test_filter_config_callable(self, provider):
@@ -46,7 +58,12 @@ class TestBackendFilters(IBMQTestCase):
         filtered_backends = provider.backends(
             filters=lambda x: (not x.configuration().simulator
                                and x.configuration().n_qubits >= 5))
+
         self.assertTrue(filtered_backends)
+        for backend in filtered_backends:
+            with self.subTest(backend=backend):
+                self.assertFalse(backend.configuration().simulator)
+                self.assertGreaterEqual(backend.configuration().n_qubits, 5)
 
     @requires_provider
     def test_filter_least_busy(self, provider):

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -34,9 +34,9 @@ class TestBackendFilters(IBMQTestCase):
 
         self.assertTrue(filtered_backends)
         for filtered_backend in filtered_backends:
-            with self.subTest(backend=filtered_backend):
-                self.assertEqual(n_qubits, backend.configuration().n_qubits)
-                self.assertFalse(backend.configuration().local)
+            with self.subTest(filtered_backend=filtered_backend):
+                self.assertEqual(n_qubits, filtered_backend.configuration().n_qubits)
+                self.assertFalse(filtered_backend.configuration().local)
 
     @requires_provider
     def test_filter_status_dict(self, provider):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Coming from the API team, fix the `test_filter_config_properties` for avoid it failing in staging: the test was hard-coded for a number of qubits and in some (common/default) `staging` configuration it was unable to find a backend with the specified requisites. This PR makes the tests depend on the backend chosen for other tests, hopefully making it more robust.

In the process, extended the asserts of other the tests in the file to provide stronger guarantees that the filtering is being done correctly.

### Details and comments


