### PR TITLE
Make share level and status enums case insensitive

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -111,7 +111,7 @@ class IBMQBackend(BaseBackend):
         api_job_share_level = None
         if job_share_level:
             try:
-                api_job_share_level = ApiJobShareLevel(job_share_level)
+                api_job_share_level = ApiJobShareLevel(job_share_level.lower())
             except ValueError:
                 raise IBMQBackendValueError(
                     '"{}" is not a valid job share level. '

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -108,7 +108,6 @@ class IBMQBackend(BaseBackend):
             IBMQBackendValueError: If the specified job share level is not valid.
         """
         # pylint: disable=arguments-differ
-        api_job_share_level = None
         if job_share_level:
             try:
                 api_job_share_level = ApiJobShareLevel(job_share_level.lower())
@@ -117,6 +116,8 @@ class IBMQBackend(BaseBackend):
                     '"{}" is not a valid job share level. '
                     'Valid job share levels are: {}'
                     .format(job_share_level, ', '.join(level.value for level in ApiJobShareLevel)))
+        else:
+            api_job_share_level = ApiJobShareLevel.NONE
 
         validate_qobj_against_schema(qobj)
         return self._submit_job(qobj, job_name, api_job_share_level)

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -157,7 +157,8 @@ class IBMQBackendService(SimpleNamespace):
 
         if status:
             if isinstance(status, str):
-                status = JobStatus[status]
+                status = JobStatus[status.upper()]
+
             if status == JobStatus.RUNNING:
                 this_filter = {'status': ApiJobStatus.RUNNING.value,
                                'infoQueue': {'exists': False}}

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -281,7 +281,7 @@ class IBMQJob(BaseModel, BaseJob):
 
         with api_to_job_error():
             api_response = self._api.job_status(self.job_id())
-            self._update_status_position(ApiJobStatus(api_response['status']),
+            self._update_status_position(ApiJobStatus(api_response['status'].upper()),
                                          api_response.get('infoQueue', None))
 
         # Get all job attributes if the job is done.
@@ -555,7 +555,7 @@ class IBMQJob(BaseModel, BaseJob):
             except UserTimeoutExceededError:
                 raise IBMQJobTimeoutError(
                     'Timeout while waiting for job {}'.format(self._job_id))
-        self._update_status_position(ApiJobStatus(status_response['status']),
+        self._update_status_position(ApiJobStatus(status_response['status'].upper()),
                                      status_response.get('infoQueue', None))
         # Get all job attributes if the job is done.
         if self._status in JOB_FINAL_STATES:

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -281,7 +281,7 @@ class IBMQJob(BaseModel, BaseJob):
 
         with api_to_job_error():
             api_response = self._api.job_status(self.job_id())
-            self._update_status_position(ApiJobStatus(api_response['status'].upper()),
+            self._update_status_position(ApiJobStatus(api_response['status']),
                                          api_response.get('infoQueue', None))
 
         # Get all job attributes if the job is done.
@@ -555,7 +555,7 @@ class IBMQJob(BaseModel, BaseJob):
             except UserTimeoutExceededError:
                 raise IBMQJobTimeoutError(
                     'Timeout while waiting for job {}'.format(self._job_id))
-        self._update_status_position(ApiJobStatus(status_response['status'].upper()),
+        self._update_status_position(ApiJobStatus(status_response['status']),
                                      status_response.get('infoQueue', None))
         # Get all job attributes if the job is done.
         if self._status in JOB_FINAL_STATES:

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -263,7 +263,8 @@ class TestIBMQJobAttributes(JobTestCase):
         job = backend.run(qobj, job_share_level='project')
 
         retrieved_job = backend.retrieve_job(job.job_id())
-        self.assertEqual(getattr(retrieved_job, 'share_level'), 'project')
+        self.assertEqual(getattr(retrieved_job, 'share_level'), 'project',
+                         "Job {} has incorrect share level".format(job.job_id()))
 
 
 def _bell_circuit():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Converts the strings passed to `ApiJobShareLevel` and `ApiJobStatus` to lowercase and uppercase, respectively.
