### PR TITLE
Normalize proxy urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,13 +120,7 @@ jobs:
     - stage: test
       <<: *stage_linux
       if: type != cron
-      # Compiling Python 3.7 requires an Ubuntu Xenial distribution
-      # and sudo set to true
-      # Fix when this is solved:
-      # https://github.com/travis-ci/travis-ci/issues/9815
-      dist: xenial
       python: 3.7
-      sudo: true
 
     # GNU/Linux, Python 3.8
     - stage: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog].
 
 ### Changed
 
+- The use of proxy urls without a protocol (e.g. `http://`) is deprecated
+  due to recent Python changes. (\#538)
 - The Exception hierarchy has been refined with more specialized classes. 
   You can, however, continue to catch their parent exceptions (such 
   as `IBMQAccountError`). Also, the exception class `IBMQApiUrlError` 

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -15,6 +15,7 @@
 """Model for representing IBM Q credentials."""
 
 import re
+import warnings
 
 from typing import Dict, Tuple, Optional, Any
 from requests_ntlm import HttpNtlmAuth
@@ -78,6 +79,9 @@ class Credentials:
         self.proxies = proxies or {}
         self.verify = verify
 
+        # Normalize proxy urls.
+        self._prepend_protocol_if_needed()
+
     def is_ibmq(self) -> bool:
         """Return whether the credentials represent a IBMQ account."""
         return all([self.hub, self.group, self.project])
@@ -118,6 +122,26 @@ class Credentials:
                 )
 
         return request_kwargs
+
+    def _prepend_protocol_if_needed(self) -> None:
+        """Prepend the proxy URLs with protocol if needed."""
+        if 'urls' not in self.proxies:
+            return
+
+        warning_issued = False
+        for key, url in self.proxies['urls'].items():
+            colon_pos = url.find(':')
+            if colon_pos < 0 or re.match(r'[0-9]*$', url[colon_pos+1:]):
+                # If colon not found OR everything after colon are digits (i.e. port number).
+                if not warning_issued:
+                    warnings.warn("Proxy URLs without protocols (e.g. 'http://') "
+                                  "will no longer be supported in the future release.",
+                                  DeprecationWarning, stacklevel=4)
+                    warning_issued = True
+                prepend_str = 'http:'
+                if url[:2] != '//':
+                    prepend_str += '//'
+                self.proxies['urls'][key] = prepend_str + url
 
 
 def _unify_ibmq_url(

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -26,6 +26,7 @@ from qiskit.providers.ibmq import IBMQFactory
 from qiskit.providers.ibmq.api.clients import (AuthClient,
                                                VersionClient)
 from qiskit.providers.ibmq.api.exceptions import RequestsApiError
+from qiskit.providers.ibmq.credentials import Credentials
 from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_qe_access
 
@@ -38,8 +39,8 @@ except ImportError:
 ADDRESS = '127.0.0.1'
 PORT = 8080
 VALID_PROXIES = {'https': 'http://{}:{}'.format(ADDRESS, PORT)}
-INVALID_PORT_PROXIES = {'https': '{}:{}'.format(ADDRESS, '6666')}
-INVALID_ADDRESS_PROXIES = {'https': '{}:{}'.format('invalid', PORT)}
+INVALID_PORT_PROXIES = {'https': 'http://{}:{}'.format(ADDRESS, '6666')}
+INVALID_ADDRESS_PROXIES = {'https': 'http://{}:{}'.format('invalid', PORT)}
 
 
 @skipIf((sys.version_info > (3, 5) and pproxy_version == '1.2.2') or
@@ -144,6 +145,24 @@ class TestProxies(IBMQTestCase):
             version_finder.version()
 
         self.assertIsInstance(context_manager.exception.__cause__, ProxyError)
+
+    @requires_qe_access
+    def test_proxy_urls(self, qe_token, qe_url):
+        """Test different forms of the proxy urls."""
+        test_urls = [
+            '{}:{}'.format(ADDRESS, PORT),
+            'http://{}:{}'.format(ADDRESS, PORT),
+            '//{}:{}'.format(ADDRESS, PORT),
+            'http:{}:{}'.format(ADDRESS, PORT),
+            'http://user:123@{}:{}'.format(ADDRESS, PORT)
+        ]
+        for proxy_url in test_urls:
+            with self.subTest(proxy_url=proxy_url):
+                credentials = Credentials(
+                    qe_token, qe_url, proxies={'urls': {'https': proxy_url}})
+                version_finder = VersionClient(credentials.base_url,
+                                               **credentials.connection_parameters())
+                version_finder.version()
 
 
 def pproxy_desired_access_log_line(url):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #528. 
It adds `http://` to proxy urls without one and issues a deprecation warning that it's no longer supported.

### Details and comments


