### PR TITLE
Add minimum quibits to most_busy_backend

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -28,6 +28,6 @@ def most_busy_backend(provider):
     Returns:
         IBMQBackend: the most busy backend.
     """
-
-    return max([b for b in provider.backends(simulator=False) if b.status().operational],
+    backends = provider.backends(simulator=False, operational=True)
+    return max([b for b in backends if b.configuration().n_qubits >= 5],
                key=lambda b: b.status().pending_jobs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Make sure the most busy backend returned has a minimum number of quilts, namely 5.