### PR TITLE
Disable jsonschema validation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,12 @@ The format is based on [Keep a Changelog].
   as `IBMQAccountError`). Also, the exception class `IBMQApiUrlError` 
   has been replaced by `IBMQAccountCredentialsInvalidUrl` and 
   `IBMQAccountCredentialsInvalidToken`. (\#480)
-  
+- JSON schema validation is no longer run by default on qobj objects passed
+  to `IBMQBackend.run()`. This siginficantly speeds up the execution of the
+  `run` method and the API server will return 400 if the qobj is invalid. If
+  you would like to still run the validation you can set the `validate_qobj`
+  kwarg to `True` which will enable the JSON schema validation. (\#554)
+
 ### Deprecated
 
 - The use of proxy urls without a protocol (e.g. `http://`) is deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The format is based on [Keep a Changelog].
 
 ## [UNRELEASED]
 
+### Changed
+
+- JSON schema validation is no longer run by default on qobj objects passed
+  to `IBMQBackend.run()`. This siginficantly speeds up the execution of the
+  `run` method and the API server will return 400 if the qobj is invalid. If
+  you would like to still run the validation you can set the `validate_qobj`
+  kwarg to `True` which will enable the JSON schema validation. (\#554)
+
 ## [0.4.6] - 2020-02-05
 
 ### Added
@@ -55,11 +63,6 @@ The format is based on [Keep a Changelog].
   as `IBMQAccountError`). Also, the exception class `IBMQApiUrlError` 
   has been replaced by `IBMQAccountCredentialsInvalidUrl` and 
   `IBMQAccountCredentialsInvalidToken`. (\#480)
-- JSON schema validation is no longer run by default on qobj objects passed
-  to `IBMQBackend.run()`. This siginficantly speeds up the execution of the
-  `run` method and the API server will return 400 if the qobj is invalid. If
-  you would like to still run the validation you can set the `validate_qobj`
-  kwarg to `True` which will enable the JSON schema validation. (\#554)
 
 ### Deprecated
 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -79,7 +79,8 @@ class IBMQBackend(BaseBackend):
             qobj: Qobj,
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
-            job_tags: Optional[List[str]] = None
+            job_tags: Optional[List[str]] = None,
+            validate_qobj: bool = False
     ) -> IBMQJob:
         """Run a Qobj asynchronously.
 
@@ -103,6 +104,8 @@ class IBMQBackend(BaseBackend):
             job_tags: tags to be assigned to the job. The tags can
                 subsequently be used as a filter in the ``jobs()`` function call.
                 Default: None.
+            validate_qobj: When set true run jsonschema validation against the
+                submitted payload
 
         Returns:
             an instance derived from BaseJob
@@ -128,7 +131,8 @@ class IBMQBackend(BaseBackend):
             api_job_share_level = ApiJobShareLevel.NONE
 
         validate_job_tags(job_tags, IBMQBackendValueError)
-        validate_qobj_against_schema(qobj)
+        if validate_qobj:
+            validate_qobj_against_schema(qobj)
         return self._submit_job(qobj, job_name, api_job_share_level, job_tags)
 
     def _submit_job(

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -493,8 +493,8 @@ class IBMQSimulator(IBMQBackend):
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
-            backend_options: Optional[Dict] = None,
             validate_qobj: bool = False,
+            backend_options: Optional[Dict] = None,
             noise_model: Any = None
     ) -> IBMQJob:
         """Run qobj asynchronously.

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -494,7 +494,8 @@ class IBMQSimulator(IBMQBackend):
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
             backend_options: Optional[Dict] = None,
-            noise_model: Any = None
+            noise_model: Any = None,
+            validate_qobj: bool = False
     ) -> IBMQJob:
         """Run qobj asynchronously.
 
@@ -508,6 +509,8 @@ class IBMQSimulator(IBMQBackend):
             job_tags: tags to be assigned to the job. The tags can
                 subsequently be used as a filter in the ``jobs()`` function call.
                 Default: None.
+            validate_qobj: When set true run jsonschema validation against the
+                  submitted payload
 
         Returns:
             an instance derived from BaseJob
@@ -576,7 +579,8 @@ class IBMQRetiredBackend(IBMQBackend):
             qobj: Qobj,
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
-            job_tags: Optional[List[str]] = None
+            job_tags: Optional[List[str]] = None,
+            validate_qobj: bool = False
     ) -> None:
         """Run a Qobj."""
         raise IBMQBackendError('This backend is no longer available.')

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -104,7 +104,7 @@ class IBMQBackend(BaseBackend):
             job_tags: tags to be assigned to the job. The tags can
                 subsequently be used as a filter in the ``jobs()`` function call.
                 Default: None.
-            validate_qobj: When set true run jsonschema validation against the
+            validate_qobj: If ``True``, run JSON schema validation against the
                 submitted payload
 
         Returns:
@@ -509,15 +509,16 @@ class IBMQSimulator(IBMQBackend):
             job_tags: tags to be assigned to the job. The tags can
                 subsequently be used as a filter in the ``jobs()`` function call.
                 Default: None.
-            validate_qobj: When set true run jsonschema validation against the
-                  submitted payload
+            validate_qobj: If ``True``, run JSON schema validation against the
+                submitted payload
 
         Returns:
             an instance derived from BaseJob
         """
         # pylint: disable=arguments-differ
         qobj = update_qobj_config(qobj, backend_options, noise_model)
-        return super(IBMQSimulator, self).run(qobj, job_name, job_share_level, job_tags)
+        return super(IBMQSimulator, self).run(qobj, job_name, job_share_level, job_tags,
+                                              validate_qobj)
 
 
 class IBMQRetiredBackend(IBMQBackend):

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -494,8 +494,8 @@ class IBMQSimulator(IBMQBackend):
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
             backend_options: Optional[Dict] = None,
-            noise_model: Any = None,
-            validate_qobj: bool = False
+            validate_qobj: bool = False,
+            noise_model: Any = None
     ) -> IBMQJob:
         """Run qobj asynchronously.
 

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -242,7 +242,7 @@ class TestAccountClient(IBMQTestCase):
         qobj = assemble(circuit, backend, shots=1)
 
         api = backend._api
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         job_id = job.job_id()
 
         max_retry = 2

--- a/test/ibmq/test_ibmq_backends.py
+++ b/test/ibmq/test_ibmq_backends.py
@@ -53,13 +53,13 @@ class TestIBMQBackends(IBMQTestCase):
         circuit.measure(qr[0], cr[0])
 
         qobj = assemble(transpile(circuit, backend=self._local_backend))
-        result_local = self._local_backend.run(qobj).result()
+        result_local = self._local_backend.run(qobj, validate_qobj=True).result()
 
         for remote_backend in self._remote_backends:
             if not remote_backend.status().operational:
                 continue
             with self.subTest(backend=remote_backend):
-                result_remote = remote_backend.run(qobj).result()
+                result_remote = remote_backend.run(qobj, validate_qobj=True).result()
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
@@ -72,11 +72,11 @@ class TestIBMQBackends(IBMQTestCase):
         circuit.measure(qr[0], cr[0])
 
         qobj = assemble(transpile(circuit, backend=self._local_backend))
-        result_local = self._local_backend.run(qobj).result()
+        result_local = self._local_backend.run(qobj, validate_qobj=True).result()
 
         for remote_backend in self._remote_backends:
             with self.subTest(backend=remote_backend):
-                result_remote = remote_backend.run(qobj).result()
+                result_remote = remote_backend.run(qobj, validate_qobj=True).result()
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
@@ -93,11 +93,11 @@ class TestIBMQBackends(IBMQTestCase):
         circuit.measure(qr[3], cr[3])
 
         qobj = assemble(transpile(circuit, backend=self._local_backend))
-        result_local = self._local_backend.run(qobj).result()
+        result_local = self._local_backend.run(qobj, validate_qobj=True).result()
 
         for remote_backend in self._remote_backends:
             with self.subTest(backend=remote_backend):
-                result_remote = remote_backend.run(qobj).result()
+                result_remote = remote_backend.run(qobj, validate_qobj=True).result()
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
@@ -115,12 +115,12 @@ class TestIBMQBackends(IBMQTestCase):
         circuit.measure(qr[3], cr[3])
 
         qobj_local = assemble(transpile(circuit, backend=self._local_backend))
-        result_local = self._local_backend.run(qobj_local).result()
+        result_local = self._local_backend.run(qobj_local, validate_qobj=True).result()
 
         for remote_backend in self._remote_backends:
             with self.subTest(backend=remote_backend):
                 qobj_remote = assemble(transpile(circuit, backend=remote_backend))
-                result_remote = remote_backend.run(qobj_remote).result()
+                result_remote = remote_backend.run(qobj_remote, validate_qobj=True).result()
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
@@ -144,11 +144,11 @@ class TestIBMQBackends(IBMQTestCase):
         circuit.measure(qr2[1], cr1[1])
 
         qobj = assemble(transpile(circuit, backend=self._local_backend))
-        result_local = self._local_backend.run(qobj).result()
+        result_local = self._local_backend.run(qobj, validate_qobj=True).result()
 
         for remote_backend in self._remote_backends:
             with self.subTest(backend=remote_backend):
-                result_remote = remote_backend.run(qobj).result()
+                result_remote = remote_backend.run(qobj, validate_qobj=True).result()
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit),
                                            result_local.get_counts(circuit), delta=50)
 
@@ -181,11 +181,11 @@ class TestIBMQBackends(IBMQTestCase):
         circuit2.measure(qr2[1], cr1[2])
 
         qobj = assemble(transpile([circuit1, circuit2], backend=self._local_backend))
-        result_local = self._local_backend.run(qobj).result()
+        result_local = self._local_backend.run(qobj, validate_qobj=True).result()
 
         for remote_backend in self._remote_backends:
             with self.subTest(backend=remote_backend):
-                result_remote = remote_backend.run(qobj).result()
+                result_remote = remote_backend.run(qobj, validate_qobj=True).result()
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit1),
                                            result_local.get_counts(circuit1), delta=50)
                 self.assertDictAlmostEqual(result_remote.get_counts(circuit2),

--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -87,7 +87,7 @@ class TestIBMQIntegration(IBMQTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qobj = assemble(transpile(qc, backend=backend, seed_transpiler=self.seed),
                         backend=backend)
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         result = job.result(timeout=20)
         self.assertIsInstance(result, Result)
 
@@ -106,7 +106,7 @@ class TestIBMQIntegration(IBMQTestCase):
         qc_extra.measure(qubit_reg, clbit_reg)
         qobj = assemble(transpile([qc, qc_extra], backend=backend, seed_transpiler=self.seed),
                         backend=backend)
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         result = job.result()
         self.assertIsInstance(result, Result)
 

--- a/test/ibmq/test_ibmq_job_model.py
+++ b/test/ibmq/test_ibmq_job_model.py
@@ -55,7 +55,7 @@ class TestIBMQJobModel(JobTestCase):
 
         delattr(qobj, 'qobj_id')
         with self.assertRaises(SchemaValidationError):
-            backend.run(qobj)
+            backend.run(qobj, validate_qobj=True)
 
     def test_valid_job(self):
         """Test the model can be created from a response."""

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -363,7 +363,7 @@ class TestIBMQJobStates(JobTestCase):
         """Creates a new ``IBMQJob`` running with the provided API object."""
         backend = IBMQBackend(mock.Mock(), mock.Mock(), mock.Mock(), api=api)
         self._current_api = api
-        self._current_qjob = backend.run(qobj=FakeQobj())
+        self._current_qjob = backend.run(qobj=FakeQobj(), validate_qobj=True)
         self._current_qjob.refresh = mock.Mock()
         return self._current_qjob
 

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -144,7 +144,7 @@ class TestIBMQJobManager(IBMQTestCase):
         qc_new = transpile(self._qc, backend)
         qobj = assemble([qc_new, qc_new], backend=backend)
         qobj.experiments[1].instructions[1].name = 'bad_instruction'
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
 
         circs = []
         for _ in range(4):

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -112,7 +112,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
                 qobj.header = QobjHeader.from_dict(custom_qobj_header)
                 qobj.experiments[0].header.some_field = 'extra info'
 
-                result = backend.run(qobj).result()
+                result = backend.run(qobj, validate_qobj=True).result()
                 self.assertEqual(result.header.to_dict(), custom_qobj_header)
                 self.assertEqual(result.results[0].header.some_field,
                                  'extra info')
@@ -131,7 +131,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
         # Update the Qobj.experiment header.
         qobj.experiments[0].header.some_field = 'extra info'
 
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         job.wait_for_final_state(wait=300, callback=self.simple_job_callback)
         result = job.result()
         self.assertEqual(result.header.to_dict(), custom_qobj_header)

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -37,7 +37,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         qobj = assemble(transpile(qc, backend=backend, seed_transpiler=73846087),
                         backend=backend)
         shots = qobj.config.shots
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         result = job.result()
         counts = result.get_counts(qc)
         target = {'0': shots / 2, '1': shots / 2}
@@ -63,7 +63,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         shots = 1024
         qobj = assemble(transpile([qcr1, qcr2], backend=backend, seed_transpiler=73846087),
                         backend=backend, shots=shots)
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         result = job.result()
         counts1 = result.get_counts(qcr1)
         counts2 = result.get_counts(qcr2)
@@ -97,7 +97,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         qcr2.measure(qr2[1], cr2[1])
         qobj = assemble(transpile([qcr1, qcr2], backend, seed_transpiler=8458),
                         backend=backend, shots=1024)
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         result = job.result()
         result1 = result.get_counts(qcr1)
         result2 = result.get_counts(qcr2)
@@ -118,6 +118,6 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         circuit.x(qr[0]).c_if(cr, 1)
 
         qobj = assemble(transpile(circuit, backend=backend))
-        result = backend.run(qobj).result()
+        result = backend.run(qobj, validate_qobj=True).result()
 
         self.assertEqual(result.get_counts(circuit), {'0001': 1024})

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -52,7 +52,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
     def test_websockets_simulator(self):
         """Test checking status of a job via websockets for a simulator."""
-        job = self.sim_backend.run(self.qobj)
+        job = self.sim_backend.run(self.qobj, validate_qobj=True)
 
         # Manually disable the non-websocket polling.
         job._api._job_final_status_polling = None
@@ -67,7 +67,7 @@ class TestWebsocketIntegration(IBMQTestCase):
         qc = transpile(self.qc1, backend=backend)
         qobj = assemble(qc, backend=backend)
 
-        job = backend.run(qobj)
+        job = backend.run(qobj, validate_qobj=True)
         # Manually disable the non-websocket polling.
         job._api._job_final_status_polling = None
         job.wait_for_final_state(wait=300, callback=self.simple_job_callback)
@@ -77,7 +77,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
     def test_websockets_job_final_state(self):
         """Test checking status of a job in a final state via websockets."""
-        job = self.sim_backend.run(self.qobj)
+        job = self.sim_backend.run(self.qobj, validate_qobj=True)
 
         job._wait_for_completion()
 
@@ -92,7 +92,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
     def test_websockets_retry_bad_url(self):
         """Test http retry after websocket error due to an invalid URL."""
-        job = self.sim_backend.run(self.qobj)
+        job = self.sim_backend.run(self.qobj, validate_qobj=True)
 
         saved_websocket_url = job._api.client_ws.websocket_url
         try:
@@ -112,7 +112,7 @@ class TestWebsocketIntegration(IBMQTestCase):
                            type_='authentication', data='phantom_token'))
     def test_websockets_retry_bad_auth(self, _):
         """Test http retry after websocket error due to a failed authentication."""
-        job = self.sim_backend.run(self.qobj)
+        job = self.sim_backend.run(self.qobj, validate_qobj=True)
 
         with mock.patch.object(AccountClient, 'job_status',
                                side_effect=job._api.job_status) as mocked_wait:
@@ -129,7 +129,7 @@ class TestWebsocketIntegration(IBMQTestCase):
             job._job_id = saved_job_id
             return saved_job_status(saved_job_id)
 
-        job = self.sim_backend.run(self.qobj)
+        job = self.sim_backend.run(self.qobj, validate_qobj=True)
 
         # Save the originals.
         saved_job_id = job._job_id
@@ -147,7 +147,7 @@ class TestWebsocketIntegration(IBMQTestCase):
         """Test timeout checking status of a job via websockets."""
         qc = transpile(self.qc1, backend=self.sim_backend)
         qobj = assemble(qc, backend=self.sim_backend, shots=2048)
-        job = self.sim_backend.run(qobj)
+        job = self.sim_backend.run(qobj, validate_qobj=True)
 
         with self.assertRaises(JobTimeoutError):
             job.result(timeout=0.1)
@@ -156,7 +156,7 @@ class TestWebsocketIntegration(IBMQTestCase):
         """Test checking status of multiple jobs in parallel via websockets."""
 
         def _run_job_get_result(q):
-            job = self.sim_backend.run(self.qobj)
+            job = self.sim_backend.run(self.qobj, validate_qobj=True)
             # Manually disable the non-websocket polling.
             job._api._job_final_status_polling = None
             job._wait_for_completion()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Running jsonschema validation is exceedingly slow, especially for large
payloads. It also provides no functional benefit since the api service
will validate the input already. If a structurally invalid request is
sent to the api it will reject it with a 400 response. This commit adds
a new option to the run method on the backend() to disable running
validation by default. This option is then used in testing so we run
validation in tests where speed doesn't matter.

### Details and comments