### PR TITLE
Define custom json encoder for qobj payloads

### DIFF
--- a/qiskit/providers/ibmq/api/rest/job.py
+++ b/qiskit/providers/ibmq/api/rest/job.py
@@ -15,10 +15,13 @@
 """Job REST adapter for the IBM Q Experience API."""
 
 import pprint
+import json
 from json.decoder import JSONDecodeError
 
 from typing import Dict, Any
 from marshmallow.exceptions import ValidationError
+
+from qiskit.providers.ibmq.utils import json_encoder
 
 from .base import RestAdapterBase
 from .validation import StatusResponseSchema
@@ -137,7 +140,8 @@ class Job(RestAdapterBase):
         Returns:
             text response, that will be empty if the request was successful.
         """
-        response = self.session.put(url, json=qobj_dict, bare=True)
+        data = json.dumps(qobj_dict, cls=json_encoder.IQXJsonEconder)
+        response = self.session.put(url, data=data, bare=True)
         return response.text
 
     def get_object_storage(self, url: str) -> Dict[str, Any]:

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -18,6 +18,8 @@ import json
 
 from typing import Dict, List, Optional, Any
 
+from qiskit.providers.ibmq.utils import json_encoder
+
 from .base import RestAdapterBase
 from .backend import Backend
 from .job import Job
@@ -140,7 +142,8 @@ class Api(RestAdapterBase):
         if job_tags:
             payload['tags'] = job_tags
 
-        return self.session.post(url, json=payload).json()
+        data = json.dumps(payload, cls=json_encoder.IQXJsonEconder)
+        return self.session.post(url, data=data).json()
 
     def submit_job_object_storage(
             self,

--- a/qiskit/providers/ibmq/utils/json_encoder.py
+++ b/qiskit/providers/ibmq/utils/json_encoder.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=method-hidden
+
+"""Custom JSON encoders."""
+
+import json
+from typing import Any
+
+
+class IQXJsonEconder(json.JSONEncoder):
+    """A json encoder for qobj"""
+
+    def default(self, o: Any) -> Any:
+        # Convert numpy arrays:
+        if hasattr(o, 'tolist'):
+            return o.tolist()
+        # Use Qobj complex json format:
+        if isinstance(o, complex):
+            return (o.real, o.imag)
+        return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The qobj payload has a couple of quirks related to how qobj objects can
be constructed (and will be constructed after Qiskit/qiskit-terra#3383
merges) that aren't handled by the default json encoder. The first is
that complex numbers are converted to the form "(real, imaginary)", and
the second is that numpy arrays are sometimes part of the payload.
Instead of relying on a layer outside of the provider coercing these
objects to the expected format this commit changes how we push qobj
payloads to the iqx api so that we run it through a json encoder that
understands how to do this. After this commit qiskit-ibmq-provider owns
it's own payload format and the generation of the expected json payload
format instead of relying on an external library to handle it for us.

### Details and comments

Related to #553