### PR TITLE
Add content type in REST requests

### DIFF
--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -170,6 +170,7 @@ class RetrySession(Session):
             client_app_header += "/" + custom_header
 
         self.headers.update({'X-Qx-Client-Application': client_app_header})
+        self.headers['Content-Type'] = 'application/json'
 
         self.auth = auth
         self.proxies = proxies or {}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
PR #556 sends payload in `str` format instead of `dict`. This requires the content type to be defined in the request header or some requests (like POST to `/Jobs`) will fail.


### Details and comments


