### PR TITLE
Don't wait for job to finish when getting qobj

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -154,7 +154,6 @@ class IBMQJob(BaseModel, BaseJob):
 
         # pylint: disable=access-member-before-definition,attribute-defined-outside-init
         if not self._qobj:  # type: ignore[has-type]
-            self._wait_for_completion()
             with api_to_job_error():
                 qobj = self._api.job_download_qobj(
                     self.job_id(), self._use_object_storage)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -240,8 +240,9 @@ class TestIBMQJob(JobTestCase):
 
         retrieved_job = provider.backends.retrieve_job(job.job_id())
         self.assertEqual(job.job_id(), retrieved_job.job_id())
-        self.assertEqual(job.result().get_counts(), retrieved_job.result().get_counts())
+        self.assertEqual(retrieved_job.qobj().to_dict(), qobj.to_dict())
         self.assertEqual(job.qobj().to_dict(), qobj.to_dict())
+        self.assertEqual(job.result().get_counts(), retrieved_job.result().get_counts())
 
     @requires_device
     def test_retrieve_job_uses_appropriate_backend(self, backend):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #571 . `job.qobj()` doesn't need to wait for the job to finish before getting its qobj. 


### Details and comments


