### PR TITLE
Remove safety cancel

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -39,7 +39,8 @@ from .exceptions import (IBMQJobApiError, IBMQJobFailureError,
                          IBMQJobTimeoutError, IBMQJobInvalidStateError)
 from .queueinfo import QueueInfo
 from .schema import JobResponseSchema
-from .utils import build_error_report, api_status_to_job_status, api_to_job_error
+from .utils import (build_error_report, api_status_to_job_status,
+                    api_to_job_error, get_cancel_status)
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +268,7 @@ class IBMQJob(BaseModel, BaseJob):
         """
         try:
             response = self._api.job_cancel(self.job_id())
-            self._cancelled = 'error' not in response and response.get('cancelled', False)
+            self._cancelled = get_cancel_status(response)
             return self._cancelled
         except ApiError as error:
             self._cancelled = False

--- a/qiskit/providers/ibmq/job/utils.py
+++ b/qiskit/providers/ibmq/job/utils.py
@@ -70,6 +70,19 @@ def api_status_to_job_status(api_status: ApiJobStatus) -> JobStatus:
     return API_TO_JOB_STATUS[api_status]
 
 
+def get_cancel_status(cancel_response: Dict[str, Any]) -> bool:
+    """Return whether the cancel response represents a successful job cancel.
+
+    Args:
+        cancel_response: The response received from the server after
+            cancelling a job.
+
+    Returns:
+        Whether the job cancel is successful.
+    """
+    return 'error' not in cancel_response and cancel_response.get('cancelled', False)
+
+
 @contextmanager
 def api_to_job_error() -> Generator[None, None, None]:
     """Convert an ``ApiError`` to an ``IBMQJobApiError``."""

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -258,7 +258,7 @@ class TestAccountClient(IBMQTestCase):
                     self.assertEqual(status, JobStatus.CANCELLED,
                                      'cancel() was successful for job {} but its status is {}.'
                                      .format(job.job_id(), status))
-                break
+                    break
             except RequestsApiError as ex:
                 if 'JOB_NOT_RUNNING' in str(ex):
                     self.assertEqual(job.status(), JobStatus.DONE)

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -251,14 +251,11 @@ class TestAccountClient(IBMQTestCase):
         for _ in range(max_retry):
             try:
                 api.job_cancel(job_id)
-                # TODO Change the warning back to assert once API is fixed
-                # self.assertEqual(job.status(), JobStatus.CANCELLED)
                 status = job.status()
-                if status is not JobStatus.CANCELLED:
-                    self.log.warning("cancel() was successful for job %s but its status is %s.",
-                                     job.job_id(), status)
-                else:
-                    break
+                self.assertEqual(status, JobStatus.CANCELLED,
+                                 'cancel() was successful for job {} but its status is {}.'
+                                 .format(job.job_id(), status))
+                break
             except RequestsApiError as ex:
                 if 'JOB_NOT_RUNNING' in str(ex):
                     self.assertEqual(job.status(), JobStatus.DONE)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -215,9 +215,10 @@ class TestIBMQJob(JobTestCase):
             try:
                 if job.cancel():
                     status = job.status()
-                    self.assertTrue(status is JobStatus.CANCELLED,
-                                    'cancel() was successful for job {} but its status is {}.'
-                                    .format(job.job_id(), status))
+                    self.assertEqual(status, JobStatus.CANCELLED,
+                                     'cancel() was successful for job {} but its status is {}.'
+                                     .format(job.job_id(), status))
+                    break
             except JobError:
                 pass
 
@@ -330,10 +331,10 @@ class TestIBMQJob(JobTestCase):
             try:
                 if job_to_cancel.cancel():
                     status = job_to_cancel.status()
-                    # TODO Change the warning to assert once API is fixed
-                    if status is not JobStatus.CANCELLED:
-                        self.log.warning("cancel() was successful for job %s but its status is %s.",
-                                         job_to_cancel.job_id(), status)
+                    self.assertEqual(status, JobStatus.CANCELLED,
+                                     'cancel() was successful for job {} but its status is {}.'
+                                     .format(job_to_cancel.job_id(), status))
+                    break
             except JobError:
                 pass
 

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -215,10 +215,9 @@ class TestIBMQJob(JobTestCase):
             try:
                 if job.cancel():
                     status = job.status()
-                    # TODO Change the warning to assert once API is fixed
-                    if status is not JobStatus.CANCELLED:
-                        self.log.warning("cancel() was successful for job %s but its status is %s.",
-                                         job.job_id(), status)
+                    self.assertTrue(status is JobStatus.CANCELLED,
+                                    'cancel() was successful for job {} but its status is {}.'
+                                    .format(job.job_id(), status))
             except JobError:
                 pass
 

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -373,22 +373,17 @@ class TestResultManager(IBMQTestCase):
         job_set = self._jm.run(circs, backend=backend)
         jobs = job_set.jobs()
         cjob = jobs[1]
-        cancelled = False
+        status = None
         for _ in range(2):
             # Try twice in case job is not in a cancellable state
             try:
                 if cjob.cancel():
-                    # TODO skip checking for status when API is fixed.
-                    time.sleep(0.5)
-                    cjob.refresh()
-                    if cjob.cancelled():
-                        cancelled = True
-                        break
+                    status = cjob.status()
             except JobError:
                 pass
 
         result_manager = job_set.results()
-        if cancelled:
+        if status is JobStatus.CANCELLED:
             with self.assertRaises(IBMQManagedResultDataNotAvailable,
                                    msg="IBMQManagedResultDataNotAvailable not "
                                        "raised for job {}".format(cjob.job_id())):

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -373,17 +373,18 @@ class TestResultManager(IBMQTestCase):
         job_set = self._jm.run(circs, backend=backend)
         jobs = job_set.jobs()
         cjob = jobs[1]
-        status = None
+        cancelled = False
         for _ in range(2):
             # Try twice in case job is not in a cancellable state
             try:
-                if cjob.cancel():
-                    status = cjob.status()
+                cancelled = cjob.cancel()
+                if cancelled:
+                    break
             except JobError:
                 pass
 
         result_manager = job_set.results()
-        if status is JobStatus.CANCELLED:
+        if cancelled:
             with self.assertRaises(IBMQManagedResultDataNotAvailable,
                                    msg="IBMQManagedResultDataNotAvailable not "
                                        "raised for job {}".format(cjob.job_id())):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Addresses #499

### Details and comments

If a job was successfully cancelled while running, its status may become `CANCELLED` and then transition to `COMPLETED` after it finished running. This is no longer the case, since the api does not overwrite the job if it is in a final state (e.g. `CANCELLED`). So, the "todos" could be addressed by removing the safeties that were set in place.