### PR TITLE
Fix test_wait_for_final_state

### DIFF
--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -677,7 +677,7 @@ class TestIBMQJob(JobTestCase):
         # The first is whether the callback function is invoked. The second
         # is last called time. They're put in a list to be mutable.
         callback_info = [False, None]
-        wait_time = 0.5
+        wait_time = 1
         backend = provider.get_backend('ibmq_qasm_simulator')
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         job = backend.run(qobj, validate_qobj=True)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix `test_wait_for_final_state`.


### Details and comments
`test_wait_for_final_state` occasionally fails because the `wait_time` is so short that the job status may not yet be available when it's time to invoke the callback function. In this case the callback function is not invoked during the first iteration since there's nothing to report. This caused the assert to fail since the callback is not invoked within `wait_time`.

