### PR TITLE
Remove shots from job submit

### DIFF
--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -110,7 +110,6 @@ class Api(RestAdapterBase):
     def create_remote_job(
             self,
             backend_name: str,
-            shots: int = 1,
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None
@@ -119,7 +118,6 @@ class Api(RestAdapterBase):
 
         Args:
             backend_name: The name of the backend.
-            shots: Number of shots.
             job_name: Custom name to be assigned to the job.
             job_share_level: Level the job should be shared at.
             job_tags: Tags to be assigned to the job.
@@ -129,10 +127,8 @@ class Api(RestAdapterBase):
         """
         url = self.get_url('jobs')
 
-        # TODO: "shots" is currently required by the API.
         payload = {
             'backend': {'name': backend_name},
-            'shots': shots,
             'allowObjectStorage': True
         }
 

--- a/qiskit/providers/ibmq/api/rest/schemas/root.py
+++ b/qiskit/providers/ibmq/api/rest/schemas/root.py
@@ -132,7 +132,6 @@ class JobsRequestSchema(BaseSchema):
     # Required properties
     qObject = Dict(required=True, description="the Qobj to be executed, as a dictionary.")
     backend = Nested(BackendRequestSchema, required=True)
-    shots = Number(required=True)
 
 
 class JobsResponseSchema(BaseSchema):

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -36,7 +36,6 @@ FIELDS_MAP = {
     'error': '_error',
     'name': '_name',
     'timePerStep': '_time_per_step',
-    'shots': '_api_shots',
     'tags': '_tags'
 }
 

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -36,6 +36,7 @@ FIELDS_MAP = {
     'error': '_error',
     'name': '_name',
     'timePerStep': '_time_per_step',
+    'shots': '_api_shots',
     'tags': '_tags'
 }
 

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -81,6 +81,7 @@ class TestAccountClient(IBMQTestCase):
 
         job = api.job_submit(backend_name, qobj.to_dict())
         job_id = job['id']
+        self.assertNotIn('shots', job)
         self.assertEqual(job['kind'], 'q-object-external-storage')
 
         # Wait for completion.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Addresses #549 

### Details and comments

Removes shots from `create_remote_jobs` and other accompanying places.

Rather than writing another test, an extra assert was added to `test_job_submit_object_storage`. It asserts that the `shots` attribute is not returned by the server in the job submit info.
