### PR TITLE
Handle parameterized circuits

### DIFF
--- a/qiskit/providers/ibmq/utils/json_encoder.py
+++ b/qiskit/providers/ibmq/utils/json_encoder.py
@@ -19,6 +19,8 @@
 import json
 from typing import Any
 
+from qiskit.circuit.parameterexpression import ParameterExpression
+
 
 class IQXJsonEconder(json.JSONEncoder):
     """A json encoder for qobj"""
@@ -30,4 +32,6 @@ class IQXJsonEconder(json.JSONEncoder):
         # Use Qobj complex json format:
         if isinstance(o, complex):
             return (o.real, o.imag)
+        if isinstance(o, ParameterExpression):
+            return float(o)
         return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After Qiskit/qiskit-terra#3383 the conversion of types outside the
standard set of types understood by the standard json encoder is the
responsibility of the ibmq provider. However, there was one type missing
from the custom encoder class added to handle this, ParameterExpression.
For bound parameterized circuit the ParameterExpression class will be
castable to a float to get the bound numeric value that should be sent
on the wire with the job. However, the encoder doesn't have handling for
this. Qiskit/qiskit-terra#3959 is adding conversion for the to_dict()
qobj method so that floats are output, but this a stop gap workaround
while a better solution is being developed. We should have handling
in qiskit-ibmq-provider if/when ParameterExpression objects get passed
in via qobj object.

### Details and comments