### PR TITLE
Job scheduling mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog].
 - You can now set the logging level and specify a log file using the environment 
   variables `QSIKIT_IBMQ_PROVIDER_LOG_LEVEL` and `QISKIT_IBMQ_PROVIDER_LOG_FILE`, 
   respectively. Note that the name of the logger is `qiskit.providers.ibmq`. (\#579)
+- `IBMQJob` now has a new method `scheduling_mode()` that returns the scheduling
+  mode the job is in. (\#593)
 
 ## [0.5.0] - 2020-02-26
 

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -136,6 +136,8 @@ class IBMQJob(BaseModel, BaseJob):
         self._queue_info = None     # type: Optional[QueueInfo]
         self._status, self._queue_info = self._get_status_position(
             _api_status, kwargs.pop('info_queue', None))
+        if self._run_mode is None:
+            self._run_mode = "fairshare"  # Default to fair share.
 
         # Properties used for caching.
         self._cancelled = False
@@ -475,6 +477,14 @@ class IBMQJob(BaseModel, BaseJob):
         if not self._time_per_step or self._status not in JOB_FINAL_STATES:
             self.refresh()
         return self._time_per_step
+
+    def run_mode(self):
+        """Return the scheduling mode the job runs in.
+
+        Returns:
+            The scheduling mode the job runs in.
+        """
+        return self._run_mode
 
     def submit(self) -> None:
         """Submit this job to an IBM Quantum Experience backend.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -482,9 +482,9 @@ class IBMQJob(BaseModel, BaseJob):
         """Return the scheduling mode the job is in.
 
         The scheduling mode indicates how the job is scheduled to run. For example,
-        `fairshare` indicates the job is scheduled using a fairshare algorithm.
+        ``fairshare`` indicates the job is scheduled using a fairshare algorithm.
 
-        This information is only available if the job status is RUNNING or DONE.
+        This information is only available if the job status is ``RUNNING`` or ``DONE``.
 
         Returns:
             The scheduling mode the job is in or ``None`` if the information
@@ -492,8 +492,7 @@ class IBMQJob(BaseModel, BaseJob):
         """
         # pylint: disable=access-member-before-definition,attribute-defined-outside-init
         if self._run_mode is None:
-            if self._status not in JOB_FINAL_STATES:
-                self.refresh()
+            self.refresh()
             if self._status in [JobStatus.RUNNING, JobStatus.DONE] and self._run_mode is None:
                 self._run_mode = "fairshare"  # type: Optional[str]
 

--- a/qiskit/providers/ibmq/job/schema.py
+++ b/qiskit/providers/ibmq/job/schema.py
@@ -37,7 +37,8 @@ FIELDS_MAP = {
     'name': '_name',
     'timePerStep': '_time_per_step',
     'shots': '_api_shots',
-    'tags': '_tags'
+    'tags': '_tags',
+    'runMode': '_run_mode'
 }
 
 
@@ -93,6 +94,7 @@ class JobResponseSchema(BaseSchema):
     _qobj = Raw(missing=None)
     _error = Nested(JobResponseErrorSchema, missing=None)
     _tags = List(String, missing=[])
+    _run_mode = String(missing=None)
 
     # Optional properties
     _backend_info = Nested(JobResponseBackendSchema)

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -365,6 +365,10 @@ class TestIBMQJobAttributes(JobTestCase):
         self.assertEqual(job.scheduling_mode(), "fairshare", "Job {} scheduling mode is {}".format(
             job.job_id(), job.scheduling_mode()))
 
+        rjob = backend.retrieve_job(job.job_id())
+        self.assertEqual(rjob.scheduling_mode(), "fairshare", "Job {} scheduling mode is {}".format(
+            rjob.job_id(), rjob.scheduling_mode()))
+
 
 def _bell_circuit():
     """Return a bell state circuit."""

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -367,8 +367,9 @@ class TestIBMQJobAttributes(JobTestCase):
         backend = provider.get_backend('ibmq_qasm_simulator')
         qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
         job = backend.run(qobj, validate_qobj=True)
-        self.assertEqual(job.run_mode(), "fairshare", "Job {} run mode is {}".format(
-            job.job_id(), job.run_mode()))
+        job.wait_for_final_state()
+        self.assertEqual(job.scheduling_mode(), "fairshare", "Job {} scheduling mode is {}".format(
+            job.job_id(), job.scheduling_mode()))
 
 
 def _bell_circuit():

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -361,6 +361,15 @@ class TestIBMQJobAttributes(JobTestCase):
         self.assertRaises(IBMQBackendValueError, backend.run, qobj, job_tags={'foo'})
         self.assertRaises(IBMQBackendValueError, backend.jobs, job_tags=[1, 2, 3])
 
+    @requires_provider
+    def test_run_mode(self, provider):
+        """Test job run mode."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        qobj = assemble(transpile(self._qc, backend=backend), backend=backend)
+        job = backend.run(qobj, validate_qobj=True)
+        self.assertEqual(job.run_mode(), "fairshare", "Job {} run mode is {}".format(
+            job.job_id(), job.run_mode()))
+
 
 def _bell_circuit():
     """Return a bell state circuit."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Close #235 . The "mode" a job runs in is now returned via `job.scheduling_mod()`.


### Details and comments


