### PR TITLE
Don't use pending jobs in jupyter test

### DIFF
--- a/test/ibmq/test_jupyter.py
+++ b/test/ibmq/test_jupyter.py
@@ -49,7 +49,7 @@ class TestBackendInfo(IBMQTestCase):
                 config = backend.configuration()
                 status = backend.status()
                 self.assertIn(config.backend_name, tab_str)
-                self.assertIn(str(status.pending_jobs), tab_str)
+                self.assertIn(str(status.status_msg), tab_str)
 
     def test_qubits_tab(self):
         """Test qubits tab."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
An Azure run failed because `test_config_tab` verifies that `pending_jobs` is in the backend configuration tab, but the `pending_jobs` value changed in between. Changing the verification to `status_msg` as it's much unlikely to change.


### Details and comments


