### PR TITLE
Add job limit exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog].
 
 ## [UNRELEASED]
 
+### Added
+
+- A new exception, `IBMQBackendJobLimitError`, is now raised if a job 
+  could not be submitted because the limit on active jobs has been reached. 
+
 ### Changed
 
 - `IBMQFactory.save_account()` and `IBMQFactory.enable_account()` now accept

--- a/qiskit/providers/ibmq/exceptions.py
+++ b/qiskit/providers/ibmq/exceptions.py
@@ -79,3 +79,8 @@ class IBMQBackendApiProtocolError(IBMQBackendApiError):
 class IBMQBackendValueError(IBMQBackendError, ValueError):
     """Value errors raised by the backend modules."""
     pass
+
+
+class IBMQBackendJobLimitError(IBMQBackendError):
+    """Errors raised when job limit is reached."""
+    pass

--- a/test/ibmq/test_basic_server_paths.py
+++ b/test/ibmq/test_basic_server_paths.py
@@ -14,9 +14,12 @@
 
 """Tests that hit all the basic server endpoints using both a public and premium provider."""
 
-from qiskit.test import slow_test
+import time
 
+from qiskit.test import slow_test
 from qiskit.providers.ibmq import least_busy
+from qiskit.providers.ibmq.exceptions import IBMQBackendJobLimitError
+
 from ..decorators import requires_providers
 from ..ibmqtestcase import IBMQTestCase
 from ..utils import cancel_job, bell_in_qobj
@@ -41,7 +44,7 @@ class TestBasicServerPaths(IBMQTestCase):
                 filters=lambda b: b.configuration().n_qubits >= 5))
             with self.subTest(desc=desc, backend=backend):
                 qobj = bell_in_qobj(backend)
-                job = backend.run(qobj, validate_qobj=True)
+                job = self._submit_job_with_retry(qobj, backend)
 
                 # Fetch the results.
                 result = job.result()
@@ -59,8 +62,7 @@ class TestBasicServerPaths(IBMQTestCase):
                 filters=lambda b: b.configuration().n_qubits >= 5)[0]
             with self.subTest(desc=desc, backend=backend):
                 qobj = bell_in_qobj(backend)
-                job = backend.run(qobj, validate_qobj=True)
-
+                job = self._submit_job_with_retry(qobj, backend)
                 self.assertIsNotNone(job.properties())
                 self.assertTrue(job.status())
                 # Cancel job so it doesn't consume more resources.
@@ -73,8 +75,7 @@ class TestBasicServerPaths(IBMQTestCase):
             backend = provider.get_backend(backend_name)
             with self.subTest(desc=desc, backend=backend):
                 qobj = bell_in_qobj(backend)
-
-                job = backend.run(qobj, validate_qobj=True)
+                job = self._submit_job_with_retry(qobj, backend)
                 job_id = job.job_id()
 
                 retrieved_jobs = provider.backends.jobs(backend_name=backend_name)
@@ -105,3 +106,16 @@ class TestBasicServerPaths(IBMQTestCase):
                 if desc == 'public_provider':
                     self.assertEqual(job_limit.maximum_jobs, 5)
                 self.assertTrue(job_limit)
+
+    def _submit_job_with_retry(self, qobj, backend, max_retry=5):
+        """Retry submitting a job if limit is reached."""
+        limit_error = None
+        for _ in range(max_retry):
+            try:
+                job = backend.run(qobj, validate_qobj=True)
+                return job
+            except IBMQBackendJobLimitError as err:
+                limit_error = err
+                time.sleep(1)
+
+        self.fail("Unable to submit job after {} retries: {}".format(max_retry, limit_error))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
PR #618 added additional tests for public provider. However, there's a limit on the number of pending jobs one can have with a public provider, and this could cause Travis builds to fail. 

Since a user can easily encounter the job limit error, which is also user actionable, this PR adds a new `IBMQBackendJobLimitError` exception for user to trap. It also updates the tests to trap that exception and retry job submit. 


### Details and comments


