### PR TITLE
Convert list to complex for Qobj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ The format is based on [Keep a Changelog].
 ### Fixed
 
 - Fixed an issue where `nest_asyncio.apply()` may raise an exception
-  if there is no asyncio loop due to threading. (\#595)  
+  if there is no asyncio loop due to threading. (\#595)
+- Increased timeout value to allow large Qobj to be uploaded. (\#626)
+- Added a JSON decoder to convert lists in Qobj to complex. (\#631)  
   
 ## [0.6.0] - 2020-03-26
 

--- a/qiskit/providers/ibmq/api/rest/job.py
+++ b/qiskit/providers/ibmq/api/rest/job.py
@@ -186,5 +186,5 @@ class Job(RestAdapterBase):
             JSON response.
         """
         logger.debug('Downloading Qobj from object storage.')
-        response = self.session.get(url, bare=True).json()
+        response = self.session.get(url, bare=True, timeout=600).json()
         return response

--- a/qiskit/providers/ibmq/utils/qobj_utils.py
+++ b/qiskit/providers/ibmq/utils/qobj_utils.py
@@ -122,11 +122,11 @@ def _to_complex(value: Union[List[float], complex]) -> complex:
         Input value in ``complex``.
 
     Raises:
-        ValueError: If the input value is not in the expected format.
+        TypeError: If the input value is not in the expected format.
     """
     if isinstance(value, list) and len(value) == 2:
         return complex(value[0], value[1])
     elif isinstance(value, complex):
         return value
 
-    raise ValueError("{} is not in a valid complex number format.".format(value))
+    raise TypeError("{} is not in a valid complex number format.".format(value))

--- a/qiskit/providers/ibmq/utils/qobj_utils.py
+++ b/qiskit/providers/ibmq/utils/qobj_utils.py
@@ -14,7 +14,7 @@
 
 """Utilities related to Qobj."""
 
-from typing import Dict, Any, Optional, Union
+from typing import Dict, Any, Optional, Union, List
 
 from qiskit.qobj import QobjHeader, QasmQobj, PulseQobj
 
@@ -89,5 +89,44 @@ def dict_to_qobj(qobj_dict: Dict) -> Union[QasmQobj, PulseQobj]:
         The corresponding QasmQobj or PulseQobj instance.
     """
     if qobj_dict['type'] == 'PULSE':
+        _decode_pulse_qobj(qobj_dict)   # Convert to proper types.
         return PulseQobj.from_dict(qobj_dict)
     return QasmQobj.from_dict(qobj_dict)
+
+
+def _decode_pulse_qobj(pulse_qobj: Dict) -> None:
+    """Decode a pulse Qobj.
+
+    Args:
+        pulse_qobj: Qobj to be decoded.
+    """
+    pulse_library = pulse_qobj['config']['pulse_library']
+    for lib in pulse_library:
+        lib['samples'] = [_to_complex(sample) for sample in lib['samples']]
+
+    for exp in pulse_qobj['experiments']:
+        for instr in exp['instructions']:
+            if 'val' in instr:
+                instr['val'] = _to_complex(instr['val'])
+            if 'parameters' in instr and 'amp' in instr['parameters']:
+                instr['parameters']['amp'] = _to_complex(instr['parameters']['amp'])
+
+
+def _to_complex(value: Union[List[float], complex]) -> complex:
+    """Convert the input value to type ``complex``.
+
+    Args:
+        value: Value to be converted.
+
+    Returns:
+        Input value in ``complex``.
+
+    Raises:
+        ValueError: If the input value is not in the expected format.
+    """
+    if isinstance(value, list) and len(value) == 2:
+        return complex(value[0], value[1])
+    elif isinstance(value, complex):
+        return value
+
+    raise ValueError("{} is not in a valid complex number format.".format(value))

--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test serializing and deserializing data sent to the server."""
+
+from qiskit.compiler import assemble
+
+from ..decorators import requires_provider
+from ..utils import bell_in_qobj, cancel_job
+from ..ibmqtestcase import IBMQTestCase
+
+
+class TestSerialization(IBMQTestCase):
+    """Test data serialization."""
+
+    @requires_provider
+    def test_qasm_qobj(self, provider):
+        """Test serializing qasm qobj data."""
+        backend = provider.get_backend('ibmq_qasm_simulator')
+        qobj = bell_in_qobj(backend=backend)
+        job = backend.run(qobj, validate_qobj=True)
+        rqobj = backend.retrieve_job(job.job_id()).qobj()
+
+        self.assertEqual(_array_to_list(qobj.to_dict()), rqobj.to_dict())
+
+    @requires_provider
+    def test_pulse_qobj(self, provider):
+        """Test serializing pulse qobj data."""
+        backend = provider.get_backend('ibmq_armonk')
+        config = backend.configuration()
+        defaults = backend.defaults()
+        inst_map = defaults.circuit_instruction_map
+
+        x = inst_map.get('x', 0)
+        measure = inst_map.get('measure', range(config.n_qubits)) << x.duration
+        schedules = x | measure
+
+        qobj = assemble(schedules, backend, meas_level=1, shots=256)
+        job = backend.run(qobj, validate_qobj=True)
+        rqobj = backend.retrieve_job(job.job_id()).qobj()
+
+        # Convert numpy arrays to lists since they now get converted right
+        # before being sent to the server.
+        self.assertEqual(_array_to_list(qobj.to_dict()), rqobj.to_dict())
+
+        cancel_job(job)
+
+
+def _array_to_list(data):
+    """Convert numpy arrays to lists."""
+    for key, value in data.items():
+        if hasattr(value, 'tolist'):
+            data[key] = value.tolist()
+        elif isinstance(value, dict):
+            _array_to_list(value)
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                if isinstance(item, dict):
+                    value[index] = _array_to_list(item)
+
+    return data


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Related to #553 .

Qiskit terra removed marshmallow from Qobj in Qiskit/qiskit-terra#3383. Marshmallow used to convert `complex` objects to lists and vice versa according to the schemas. PR #556 added a JSON encoder to convert complex to list, but there was no decoder to convert them back.


### Details and comments


