### PR TITLE
Convert list to complex for pulse backends

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -27,7 +27,7 @@ from .api.clients import AccountClient
 from .ibmqbackend import IBMQBackend, IBMQSimulator
 from .credentials import Credentials
 from .ibmqbackendservice import IBMQBackendService
-from .utils.json_decoder import decode_pulse_backend_configuration
+from .utils.json_decoder import decode_pulse_backend_config
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class AccountProvider(BaseProvider):
 
             try:
                 if raw_config.get('open_pulse', False):
-                    decode_pulse_backend_configuration(raw_config)
+                    decode_pulse_backend_config(raw_config)
                     config = PulseBackendConfiguration.from_dict(raw_config)
                 else:
                     config = QasmBackendConfiguration.from_dict(raw_config)

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -27,6 +27,7 @@ from .api.clients import AccountClient
 from .ibmqbackend import IBMQBackend, IBMQSimulator
 from .credentials import Credentials
 from .ibmqbackendservice import IBMQBackendService
+from .utils.json_decoder import decode_pulse_backend_configuration
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,7 @@ class AccountProvider(BaseProvider):
 
             try:
                 if raw_config.get('open_pulse', False):
+                    decode_pulse_backend_configuration(raw_config)
                     config = PulseBackendConfiguration.from_dict(raw_config)
                 else:
                     config = QasmBackendConfiguration.from_dict(raw_config)

--- a/qiskit/providers/ibmq/utils/json_decoder.py
+++ b/qiskit/providers/ibmq/utils/json_decoder.py
@@ -33,7 +33,7 @@ def decode_pulse_qobj(pulse_qobj: Dict) -> None:
             _decode_pulse_qobj_instr(instr)
 
 
-def decode_pulse_backend_configuration(config: Dict) -> None:
+def decode_pulse_backend_config(config: Dict) -> None:
     """Decode pulse backend configuration data.
 
     Args:

--- a/qiskit/providers/ibmq/utils/json_decoder.py
+++ b/qiskit/providers/ibmq/utils/json_decoder.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=method-hidden
+
+"""Custom JSON decoder."""
+
+from typing import Dict, Union, List
+
+
+def decode_pulse_qobj(pulse_qobj: Dict) -> None:
+    """Decode a pulse Qobj.
+
+    Args:
+        pulse_qobj: Qobj to be decoded.
+    """
+    for item in pulse_qobj['config']['pulse_library']:
+        _decode_pulse_library_item(item)
+
+    for exp in pulse_qobj['experiments']:
+        for instr in exp['instructions']:
+            _decode_pulse_qobj_instr(instr)
+
+
+def decode_pulse_backend_configuration(config: Dict) -> None:
+    """Decode pulse backend configuration data.
+
+    Args:
+        config: A ``PulseBackendConfiguration`` in dictionary format.
+    """
+    for u_channle_list in config['u_channel_lo']:
+        for u_channle_lo in u_channle_list:
+            u_channle_lo['scale'] = _to_complex(u_channle_lo['scale'])
+
+
+def decode_pulse_defaults(defaults: Dict) -> None:
+    """Decode pulse defaults data.
+
+    Args:
+        defaults: A ``PulseDefaults`` in dictionary format.
+    """
+    for item in defaults['pulse_library']:
+        _decode_pulse_library_item(item)
+
+    for cmd in defaults['cmd_def']:
+        if 'sequence' in cmd:
+            for instr in cmd['sequence']:
+                _decode_pulse_qobj_instr(instr)
+
+
+def _to_complex(value: Union[List[float], complex]) -> complex:
+    """Convert the input value to type ``complex``.
+
+    Args:
+        value: Value to be converted.
+
+    Returns:
+        Input value in ``complex``.
+
+    Raises:
+        TypeError: If the input value is not in the expected format.
+    """
+    if isinstance(value, list) and len(value) == 2:
+        return complex(value[0], value[1])
+    elif isinstance(value, complex):
+        return value
+
+    raise TypeError("{} is not in a valid complex number format.".format(value))
+
+
+def _decode_pulse_library_item(pulse_library_item: Dict) -> None:
+    """Decode a pulse library item.
+
+    Args:
+        pulse_library_item: A ``PulseLibraryItem`` in dictionary format.
+    """
+    pulse_library_item['samples'] =\
+        [_to_complex(sample) for sample in pulse_library_item['samples']]
+
+
+def _decode_pulse_qobj_instr(pulse_qobj_instr: Dict) -> None:
+    """Decode a pulse Qobj instruction.
+
+    Args:
+        pulse_qobj_instr: A ``PulseQobjInstruction`` in dictionary format.
+    """
+    if 'val' in pulse_qobj_instr:
+        pulse_qobj_instr['val'] = _to_complex(pulse_qobj_instr['val'])
+    if 'parameters' in pulse_qobj_instr and 'amp' in pulse_qobj_instr['parameters']:
+        pulse_qobj_instr['parameters']['amp'] = _to_complex(pulse_qobj_instr['parameters']['amp'])

--- a/qiskit/providers/ibmq/utils/json_decoder.py
+++ b/qiskit/providers/ibmq/utils/json_decoder.py
@@ -12,8 +12,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=method-hidden
-
 """Custom JSON decoder."""
 
 from typing import Dict, Union, List

--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -41,7 +41,11 @@ class TestSerialization(IBMQTestCase):
     @requires_provider
     def test_pulse_qobj(self, provider):
         """Test serializing pulse qobj data."""
-        backend = provider.get_backend('ibmq_armonk')
+        backends = provider.backends(operational=True, open_pulse=True)
+        if not backends:
+            self.skipTest('Need pulse backends.')
+
+        backend = backends[0]
         config = backend.configuration()
         defaults = backend.defaults()
         inst_map = defaults.circuit_instruction_map

--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -15,6 +15,7 @@
 """Test serializing and deserializing data sent to the server."""
 
 from unittest import skipIf
+from typing import Any
 
 import qiskit
 from qiskit.compiler import assemble
@@ -111,7 +112,7 @@ class TestSerialization(IBMQTestCase):
                 self.assertFalse(complex_keys)
 
 
-def _find_potential_complex(data, c_key, tally):
+def _find_potential_complex(data: Any, c_key: str, tally: set) -> None:
     """Find data that looks like serialized complex numbers.
 
     Args:
@@ -123,11 +124,11 @@ def _find_potential_complex(data, c_key, tally):
         if len(data) == 2 and all(isinstance(x, (float, int)) for x in data):
             tally.add(c_key)
         for item in data:
-            if isinstance(item, dict) or isinstance(item, list):
+            if isinstance(item, (dict, list)):
                 _find_potential_complex(item, c_key, tally)
     elif isinstance(data, dict):
         for key, value in data.items():
-            if isinstance(value, dict) or isinstance(value, list):
+            if isinstance(value, (dict, list)):
                 full_key = c_key + '.' + key if c_key else key
                 _find_potential_complex(value, full_key, tally)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Related to #553 and #631. 
This PR converts specific fields in `PulseDefaults` and `PulseBackendConfiguration` from `list` to `complex`. 

Only fields that are known to be complex are converted, which is not the best solution as it's cumbersome and not future proof. Hopefully we will switch to a better serialization mechanism in the near future.

### Details and comments


