### PR TITLE
Convert time data in QueueInfo from string to datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog].
 
 - Fixed an issue where job status was incorrectly shown as `RUNNING` when it
   should be `QUEUED`. (\#663)
+- Fixed timestamp formats in `QueueInfo`. (\#668) 
 
 ## [0.7.0] - 2020-04-29
 

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -40,7 +40,7 @@ class QueueInfo(SimpleNamespace):
             self,
             position: Optional[int] = None,
             status: Optional[str] = None,
-            estimated_start_time: Optional[Union[str,datetime]] = None,
+            estimated_start_time: Optional[Union[str, datetime]] = None,
             estimated_complete_time: Optional[Union[str, datetime]] = None,
             hub_priority: Optional[float] = None,
             group_priority: Optional[float] = None,

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -14,9 +14,10 @@
 
 """Queue information for a job."""
 
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from datetime import datetime
 from types import SimpleNamespace
+import dateutil.parser
 
 from ..utils import utc_to_local, duration_difference
 from .utils import api_status_to_job_status
@@ -39,8 +40,8 @@ class QueueInfo(SimpleNamespace):
             self,
             position: Optional[int] = None,
             status: Optional[str] = None,
-            estimated_start_time: Optional[datetime] = None,
-            estimated_complete_time: Optional[datetime] = None,
+            estimated_start_time: Optional[Union[str,datetime]] = None,
+            estimated_complete_time: Optional[Union[str, datetime]] = None,
             hub_priority: Optional[float] = None,
             group_priority: Optional[float] = None,
             project_priority: Optional[float] = None,
@@ -62,6 +63,10 @@ class QueueInfo(SimpleNamespace):
         """
         self.position = position
         self._status = status
+        if isinstance(estimated_start_time, str):
+            estimated_start_time = dateutil.parser.isoparse(estimated_start_time)
+        if isinstance(estimated_complete_time, str):
+            estimated_complete_time = dateutil.parser.isoparse(estimated_complete_time)
         self.estimated_start_time = estimated_start_time
         self.estimated_complete_time = estimated_complete_time
         self.hub_priority = hub_priority


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#632 removed marshmallow, which used to do `str` to `datetime` conversion under the cover. That PR missed converting `estimated_start_time` and `estimated_complete_time` in `QueueInfo`. 


### Details and comments


