### PR TITLE
Use v1 status endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog].
 > - **Security**: in case of vulnerabilities.
 
 
+## [UNRELEASED]
+
+### Fixed
+
+- `backend.jobs(status='RUNNING')` now returns the correct jobs. (\#669) 
+
 ## [0.7.1] - 2020-05-13
 
 ### Fixed
@@ -417,6 +423,7 @@ The format is based on [Keep a Changelog].
 - Support for non-qobj format has been removed. (\#26, \#28)
 
 
+[UNRELEASED]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.7.1...HEAD
 [0.7.1]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.6.1...0.7.0
 [0.6.1]: https://github.com/Qiskit/qiskit-ibmq-provider/compare/0.6.0...0.6.1

--- a/qiskit/providers/ibmq/api/clients/websocket.py
+++ b/qiskit/providers/ibmq/api/clients/websocket.py
@@ -251,7 +251,7 @@ class WebsocketClient(BaseClient):
             WebsocketError: If the websocket connection ended unexpectedly.
             WebsocketTimeoutError: If the timeout has been reached.
         """
-        url = '{}/jobs/{}/status'.format(self.websocket_url, job_id)
+        url = '{}/jobs/{}/status/v/1'.format(self.websocket_url, job_id)
 
         original_timeout = timeout
         start_time = time.time()

--- a/qiskit/providers/ibmq/api/rest/job.py
+++ b/qiskit/providers/ibmq/api/rest/job.py
@@ -38,8 +38,8 @@ class Job(RestAdapterBase):
         'callback_download': '/resultDownloaded',
         'cancel': '/cancel',
         'download_url': '/jobDownloadUrl',
-        'self': '',
-        'status': '/status',
+        'self': '/v/1',
+        'status': '/status/v/1',
         'properties': '/properties',
         'result_url': '/resultDownloadUrl',
         'upload_url': '/jobUploadUrl'

--- a/qiskit/providers/ibmq/api/rest/job.py
+++ b/qiskit/providers/ibmq/api/rest/job.py
@@ -39,6 +39,7 @@ class Job(RestAdapterBase):
         'cancel': '/cancel',
         'download_url': '/jobDownloadUrl',
         'self': '/v/1',
+        'self_update': '',
         'status': '/status/v/1',
         'properties': '/properties',
         'result_url': '/resultDownloadUrl',
@@ -86,7 +87,7 @@ class Job(RestAdapterBase):
             JSON response containing the name of the updated attribute and its
             corresponding value.
         """
-        url = self.get_url('self')
+        url = self.get_url('self_update')
         return self.session.put(url, data=json.dumps(job_attribute_info)).json()
 
     def callback_upload(self) -> Dict[str, Any]:

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -35,7 +35,7 @@ class Api(RestAdapterBase):
         'backends': '/devices/v/1',
         'hubs': '/Network',
         'jobs': '/Jobs',
-        'jobs_status': '/Jobs/status',
+        'jobs_status': '/Jobs/status/v/1',
         'circuit': '/qcircuit',
         'version': '/version'
     }

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -998,10 +998,8 @@ class IBMQJob(SimpleNamespace, BaseJob):
         """
         queue_info = None
         status = api_status_to_job_status(api_status)
-        if api_status == ApiJobStatus.RUNNING.value and api_info_queue:
+        if api_status == ApiJobStatus.QUEUED.value and api_info_queue:
             queue_info = QueueInfo(job_id=self.job_id(), **api_info_queue)
-            if queue_info._status == ApiJobStatus.PENDING_IN_QUEUE.value:
-                status = JobStatus.QUEUED
 
         if status is not JobStatus.QUEUED:
             queue_info = None

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -114,10 +114,12 @@ class ManagedJobSet:
             self._tags = job_tags.copy()
 
         exp_index = 0
+        total_jobs = len(experiment_list)
         for i, experiments in enumerate(experiment_list):
             qobj = assemble(experiments, backend=backend, **assemble_config)
             job_name = JOB_SET_NAME_FORMATTER.format(self._name, i)
             mjob = ManagedJob(experiments_count=len(experiments), start_index=exp_index)
+            logger.debug("Submitting job %s/%s for job set %s", i, total_jobs, self._name)
             mjob.submit(qobj=qobj, job_name=job_name, backend=backend,
                         executor=executor, job_share_level=job_share_level,
                         job_tags=self._tags+[self._id_long], submit_lock=self._job_submit_lock)

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -119,10 +119,11 @@ class ManagedJobSet:
             qobj = assemble(experiments, backend=backend, **assemble_config)
             job_name = JOB_SET_NAME_FORMATTER.format(self._name, i)
             mjob = ManagedJob(experiments_count=len(experiments), start_index=exp_index)
-            logger.debug("Submitting job %s/%s for job set %s", i, total_jobs, self._name)
+            logger.debug("Submitting job %s/%s for job set %s", i+1, total_jobs, self._name)
             mjob.submit(qobj=qobj, job_name=job_name, backend=backend,
                         executor=executor, job_share_level=job_share_level,
                         job_tags=self._tags+[self._id_long], submit_lock=self._job_submit_lock)
+            logger.debug("Job %s submitted", i+1)
             self._managed_jobs.append(mjob)
             exp_index += len(experiments)
 

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -347,19 +347,14 @@ class TestIBMQJob(JobTestCase):
         before_status = job._status
         job_list_queued = backend.jobs(status=JobStatus.QUEUED, limit=5)
         if before_status is JobStatus.QUEUED and job.status() is JobStatus.QUEUED:
-            # When retrieving jobs, the status of a recent job might be `RUNNING` when it is in fact
-            # `QUEUED`. This is due to queue info not being returned for the job. To ensure the job
-            # was retrieved, check whether the job id is in the list of queued jobs retrieved.
             self.assertIn(job.job_id(), [queued_job.job_id() for queued_job in job_list_queued],
                           "job {} is queued but not retrieved when filtering for queued jobs."
                           .format(job.job_id()))
 
-        # TODO: Uncomment when api fixes job statuses.
-        # for queued_job in job_list_queued:
-        #     self.assertTrue(queued_job._status == JobStatus.QUEUED,
-        #                     "status for job {} is '{}' but it should be {}"
-        #                     .format(queued_job.job_id(), queued_job._status,
-        #                             JobStatus.QUEUED))
+        for queued_job in job_list_queued:
+            self.assertTrue(queued_job._status == JobStatus.QUEUED,
+                            "status for job {} is '{}' but it should be {}"
+                            .format(queued_job.job_id(), queued_job._status, JobStatus.QUEUED))
 
         # Cancel job so it doesn't consume more resources.
         cancel_job(job)
@@ -540,9 +535,6 @@ class TestIBMQJob(JobTestCase):
             self.assertIn('queue_info', kwargs)
 
             queue_info = kwargs.pop('queue_info', None)
-            if c_status is JobStatus.QUEUED:
-                self.assertIsNotNone(
-                    queue_info, "queue_info not found for job {}".format(c_job_id))
             callback_info['called'] = True
 
             if wait_time is None:

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -324,8 +324,8 @@ class TestIBMQJobAttributes(JobTestCase):
         job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
         job = self.sim_backend.run(self.qobj, job_tags=job_tags, validate_qobj=True)
         # TODO No need to wait for job to run once api is fixed
-        # while job.status() not in JOB_FINAL_STATES + (JobStatus.RUNNING,):
-        #     time.sleep(0.5)
+        while job.status() not in JOB_FINAL_STATES + (JobStatus.RUNNING,):
+            time.sleep(0.5)
 
         rjobs = self.sim_backend.jobs(job_tags=['phantom_tag'])
         self.assertEqual(len(rjobs), 0,

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -275,13 +275,13 @@ class TestIBMQJobAttributes(JobTestCase):
         leave_states = list(JOB_FINAL_STATES) + [JobStatus.RUNNING]
         job = backend.run(qobj, validate_qobj=True)
         queue_info = None
-        for _ in range(10):
+        for _ in range(20):
             queue_info = job.queue_info()
             # Even if job status is queued, its queue info may not be immediately available.
             if (job._status is JobStatus.QUEUED and job.queue_position() is not None) or \
                     job._status in leave_states:
                 break
-            time.sleep(0.5)
+            time.sleep(1)
 
         if job._status is JobStatus.QUEUED and job.queue_position() is not None:
             self.log.debug("Job id=%s, queue info=%s, queue position=%s",
@@ -324,8 +324,8 @@ class TestIBMQJobAttributes(JobTestCase):
         job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
         job = self.sim_backend.run(self.qobj, job_tags=job_tags, validate_qobj=True)
         # TODO No need to wait for job to run once api is fixed
-        while job.status() not in JOB_FINAL_STATES + (JobStatus.RUNNING,):
-            time.sleep(0.5)
+        # while job.status() not in JOB_FINAL_STATES + (JobStatus.RUNNING,):
+        #     time.sleep(0.5)
 
         rjobs = self.sim_backend.jobs(job_tags=['phantom_tag'])
         self.assertEqual(len(rjobs), 0,

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -543,7 +543,7 @@ class QueuedAPI(BaseFakeAPI):
     """Class for emulating a successfully-completed queued API."""
 
     _job_status = [
-        {'status': 'RUNNING', 'info_queue': {'status': 'PENDING_IN_QUEUE'}},
+        {'status': 'QUEUED'},
         {'status': 'RUNNING'},
         {'status': 'COMPLETED'}
     ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #610 and closes #523 .
Use new endpoints that return raw job status (such as `QUEUED`) instead of mapped status. 


### Details and comments


