### PR TITLE
Catch backend configuration value error

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -132,13 +132,12 @@ class AccountProvider(BaseProvider):
                     provider=self,
                     credentials=self.credentials,
                     api=self._api)
-            except TypeError as ex:
+            except (TypeError, ValueError) as ex:
                 logger.warning(
                     'Remote backend "%s" could not be instantiated due to an '
-                    'invalid config: %s',
-                    raw_config.get('backend_name',
-                                   raw_config.get('name', 'unknown')),
-                    ex)
+                    'invalid config: %s: %s',
+                    raw_config.get('backend_name', raw_config.get('name', 'unknown')),
+                    type(ex).__name__, ex)
 
         return ret
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Backend discovery happens during provider initialization. If the configuration for a backend retrieved from the API is incorrect, the backend should be ignored and the provider initialization continues. The code used to catch only missing fields (`TypeError`). This PR adds invalid field values (`ValueError`). 


### Details and comments


