### PR TITLE
Fix setup.py to require terra 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
-- `backend.jobs(status='RUNNING')` now returns the correct jobs. (\#669) 
+- `backend.jobs(status='RUNNING')` now returns the correct jobs. (\#669)
+- Fixed `setup.py` to match `requirements.txt`. (\#677)  
 
 ## [0.7.1] - 2020-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog].
 ### Fixed
 
 - `backend.jobs(status='RUNNING')` now returns the correct jobs. (\#669)
-- Fixed `setup.py` to match `requirements.txt`. (\#677)  
+- Fixed `setup.py` to match `requirements.txt`. (\#678)  
 
 ## [0.7.1] - 2020-05-13
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 REQUIREMENTS = [
     "nest-asyncio>=1.0.0,!=1.1.0",
-    "qiskit-terra>=0.13",
+    "qiskit-terra>=0.14",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",
     "websockets>=7,<8",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #677. 
Update `setup.py` to require `qiskit-terra` 0.14. 



### Details and comments


