### PR TITLE
ManagedResult.combine_results() that returns combined Result

### DIFF
--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -162,13 +162,16 @@ class ManagedJob:
     def result(
             self,
             timeout: Optional[float] = None,
-            partial: bool = False
+            partial: bool = False,
+            refresh: bool = False
     ) -> Optional[Result]:
         """Return the result of the job.
 
         Args:
            timeout: Number of seconds to wait for job.
            partial: If ``True``, attempt to retrieve partial job results.
+           refresh: If ``True``, re-query the server for the result. Otherwise
+                return the cached value.
 
         Returns:
             Job result or ``None`` if result could not be retrieved.
@@ -180,7 +183,7 @@ class ManagedJob:
         result = None
         if self.job is not None:
             try:
-                result = self.job.result(timeout=timeout, partial=partial)
+                result = self.job.result(timeout=timeout, partial=partial, refresh=refresh)
             except IBMQJobTimeoutError:
                 raise
             except JobError as err:

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -232,7 +232,8 @@ class ManagedJobSet:
     def results(
             self,
             timeout: Optional[float] = None,
-            partial: bool = False
+            partial: bool = False,
+            refresh: bool = False
     ) -> ManagedResults:
         """Return the results of the jobs.
 
@@ -272,6 +273,8 @@ class ManagedJobSet:
         Args:
            timeout: Number of seconds to wait for job results.
            partial: If ``True``, attempt to retrieve partial job results.
+           refresh: If ``True``, re-query the server for the result. Otherwise
+                return the cached value.
 
         Returns:
             A :class:`ManagedResults`
@@ -282,7 +285,7 @@ class ManagedJobSet:
             IBMQJobManagerTimeoutError: if unable to retrieve all job results before the
                 specified timeout.
         """
-        if self._managed_results is not None:
+        if self._managed_results is not None and not refresh:
             return self._managed_results
 
         start_time = time.time()
@@ -292,7 +295,7 @@ class ManagedJobSet:
         # TODO We can potentially make this multithreaded
         for mjob in self._managed_jobs:
             try:
-                result = mjob.result(timeout=timeout, partial=partial)
+                result = mjob.result(timeout=timeout, partial=partial, refresh=refresh)
                 if result is None or not result.success:
                     success = False
             except IBMQJobTimeoutError as ex:

--- a/qiskit/providers/ibmq/managed/managedresults.py
+++ b/qiskit/providers/ibmq/managed/managedresults.py
@@ -15,10 +15,10 @@
 """Results managed by the Job Manager."""
 
 from typing import List, Optional, Union, Tuple, Dict
-# TODO Use TYPE_CHECKING instead of pylint disable after dropping python 3.5
-import numpy  # pylint: disable=unused-import
 import copy
 
+# TODO Use TYPE_CHECKING instead of pylint disable after dropping python 3.5
+import numpy  # pylint: disable=unused-import
 from qiskit.result import Result
 from qiskit.circuit import QuantumCircuit
 from qiskit.pulse import Schedule
@@ -57,7 +57,7 @@ class ManagedResults:
         self._job_set = job_set
         self.backend_name = backend_name
         self.success = success
-        self._combined_results = None  # Used for caching.
+        self._combined_results = None  # type: Result
 
     def data(self, experiment: Union[str, QuantumCircuit, Schedule, int]) -> Dict:
         """Get the raw data for an experiment.

--- a/qiskit/providers/ibmq/managed/managedresults.py
+++ b/qiskit/providers/ibmq/managed/managedresults.py
@@ -175,7 +175,7 @@ class ManagedResults:
         result, exp_index = self._get_result(experiment)
         return result.get_unitary(experiment=exp_index, decimals=decimals)
 
-    def to_result(self) -> Result:
+    def combine_results(self) -> Result:
         """Combine results from all jobs into a single `Result`.
 
         Note:

--- a/releasenotes/notes/managedresult-to-result-1bb684c23bca3734.yaml
+++ b/releasenotes/notes/managedresult-to-result-1bb684c23bca3734.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     :class:`~qiskit.providers.ibmq.managed.ManagedResults` now has a new
-    :meth:`~qiskit.providers.ibmq.managed.ManagedResults.to_result` method
+    :meth:`~qiskit.providers.ibmq.managed.ManagedResults.combine_results` method
     that combines results from all managed jobs and returns a single
     :class:`~qiskit.result.Result` object. This ``Result`` object can
     be used, for example, in ``qiskit-ignis`` fitter methods.

--- a/releasenotes/notes/managedresult-to-result-1bb684c23bca3734.yaml
+++ b/releasenotes/notes/managedresult-to-result-1bb684c23bca3734.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    :class:`~qiskit.providers.ibmq.managed.ManagedResults` now has a new
+    :meth:`~qiskit.providers.ibmq.managed.ManagedResults.to_result` method
+    that combines results from all managed jobs and returns a single
+    :class:`~qiskit.result.Result` object. This ``Result`` object can
+    be used, for example, in ``qiskit-ignis`` fitter methods.

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -397,6 +397,17 @@ class TestIBMQJobManager(IBMQTestCase):
         with self.assertRaises(IBMQManagedResultDataNotAvailable):
             result_manager.get_counts(1)
 
+    def test_to_result(self):
+        """Test converting ManagedResult to Result."""
+        max_per_job = 5
+        job_set = self._jm.run([self._qc]*max_per_job*2, backend=self.fake_api_backend,
+                               max_experiments_per_job=max_per_job)
+        result_manager = job_set.results()
+        combined_result = result_manager.to_result()
+
+        for i in range(max_per_job*2):
+            self.assertEqual(result_manager.get_counts(i), combined_result.get_counts(i))
+
     def test_ibmq_managed_results_signature(self):
         """Test ``ManagedResults`` and ``Result`` contain the same public methods.
 

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -421,6 +421,7 @@ class TestIBMQJobManager(IBMQTestCase):
 
         managed_results_methods = self._get_class_methods(ManagedResults)
         self.assertTrue(managed_results_methods)
+        del managed_results_methods['to_result']
 
         # Ensure both classes share the *exact* same public methods.
         self.assertEqual(result_methods.keys(), managed_results_methods.keys())

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -397,13 +397,13 @@ class TestIBMQJobManager(IBMQTestCase):
         with self.assertRaises(IBMQManagedResultDataNotAvailable):
             result_manager.get_counts(1)
 
-    def test_to_result(self):
+    def test_combine_results(self):
         """Test converting ManagedResult to Result."""
         max_per_job = 5
         job_set = self._jm.run([self._qc]*max_per_job*2, backend=self.fake_api_backend,
                                max_experiments_per_job=max_per_job)
         result_manager = job_set.results()
-        combined_result = result_manager.to_result()
+        combined_result = result_manager.combine_results()
 
         for i in range(max_per_job*2):
             self.assertEqual(result_manager.get_counts(i), combined_result.get_counts(i))
@@ -421,7 +421,7 @@ class TestIBMQJobManager(IBMQTestCase):
 
         managed_results_methods = self._get_class_methods(ManagedResults)
         self.assertTrue(managed_results_methods)
-        del managed_results_methods['to_result']
+        del managed_results_methods['combine_results']
 
         # Ensure both classes share the *exact* same public methods.
         self.assertEqual(result_methods.keys(), managed_results_methods.keys())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #681. 
This PR introduces a `ManagedResult.combine_results()` method that combines all job results and returns a single `Result` object. This allows users to use Job Manager for large experiments and still use ignis fitter methods that expect a `Result`:

```
job_manager = IBMQJobManager()
job_set = job_manager.run(lots_circuits, backend=backend)
combined_result = job_set.results().combine_results()
state_fit = StateTomographyFitter(combined_result, lots_circuits)
```

### Details and comments


