### PR TITLE
Use job creation date for pagination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 	pylint -rn qiskit/providers/ibmq test
 
 mypy:
-	mypy --module qiskit.providers.ibmq
+	mypy --module qiskit.providers.ibmq --show-error-codes
 
 style:
 	pycodestyle qiskit test

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -225,7 +225,7 @@ class IBMQBackendService(SimpleNamespace):
                     return input_dt.isoformat()
                 return None
 
-            api_filter['creationDate'] = self._get_creation_date_filter(
+            api_filter['creationDate'] = self._update_creation_date_filter(
                 cur_dt_filter={}, gte_dt=_to_utc_str(start_datetime),
                 lte_dt=_to_utc_str(end_datetime))
 
@@ -286,10 +286,10 @@ class IBMQBackendService(SimpleNamespace):
             api_filter = copy.deepcopy(initial_filter)
             cur_dt_filter = api_filter.pop('creationDate', {})
             if descending:
-                new_dt_filter = self._get_creation_date_filter(
+                new_dt_filter = self._update_creation_date_filter(
                     cur_dt_filter=cur_dt_filter, lte_dt=last_job['creation_date'])
             else:
-                new_dt_filter = self._get_creation_date_filter(
+                new_dt_filter = self._update_creation_date_filter(
                     cur_dt_filter=cur_dt_filter, gte_dt=last_job['creation_date'])
             if not cur_dt_filter:
                 api_filter['creationDate'] = new_dt_filter
@@ -344,18 +344,18 @@ class IBMQBackendService(SimpleNamespace):
                 else:
                     cur_filter[key] = new_filter[key]
 
-    def _get_creation_date_filter(
+    def _update_creation_date_filter(
             self,
             cur_dt_filter: Dict[str, Any],
             gte_dt: Optional[str] = None,
             lte_dt: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Return the filter to use when retrieving jobs based on revised datetime.
+        """Use the new start and end datetime in the creation date filter.
 
         Args:
-            cur_dt_filter: Current datetime filter.
-            gte_dt: The start datetime.
-            lte_dt: The end datetime.
+            cur_dt_filter: Current creation date filter.
+            gte_dt: New start datetime.
+            lte_dt: New end datetime.
 
         Returns:
             Updated creation date filter.
@@ -371,7 +371,7 @@ class IBMQBackendService(SimpleNamespace):
                        if lt_op in cur_dt_filter]
             if 'between' in cur_dt_filter and len(cur_dt_filter['between']) > 1:
                 lt_list.append(cur_dt_filter.pop('between')[1])
-            lte_dt = max(lt_list) if lt_list else None
+            lte_dt = min(lt_list) if lt_list else None
 
         new_dt_filter = {}
         if gte_dt and lte_dt:

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -389,7 +389,7 @@ class TestIBMQJob(JobTestCase):
         past_month_tz_aware = past_month.replace(tzinfo=tz.tzlocal())
 
         job_list = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                               limit=10, start_datetime=past_month)
+                                               limit=2, start_datetime=past_month)
         self.assertTrue(job_list)
         for job in job_list:
             self.assertGreaterEqual(job.creation_date(), past_month_tz_aware,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #674 .

Use job creation date instead of `skip` to do pagination.


### Details and comments
`backend.jobs()` can timeout if there is a large number of jobs to be retrieved. The issue is due to several factors:
- there is no index for `creationDate DESC` in the database
- the database incorrectly returned more results than it should
- the larger the `skip` number is, the slower the query gets (database limit)

All these combined cause the request to timeout when querying for a large number of jobs. The first 2 are fixed in the database. This PR addresses the third one by using the `creationDate` for pagination instead of `skip`. 
