### PR TITLE
Use local time for backend properties

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -41,7 +41,7 @@ from .exceptions import (IBMQBackendError, IBMQBackendValueError,
                          IBMQBackendJobLimitError)
 from .job import IBMQJob
 from .utils import update_qobj_config, validate_job_tags
-from .utils.converters import utc_to_local_all
+from .utils.converters import utc_to_local_all, local_to_utc
 from .utils.json_decoder import decode_pulse_defaults, decode_backend_properties
 
 logger = logging.getLogger(__name__)
@@ -255,12 +255,13 @@ class IBMQBackend(BaseBackend):
             The backend properties or ``None`` if the backend properties are not
             currently available.
         """
-        warnings.warn('Unless a UTC timezone information is present, the parameter `datetime`'
-                      'is now expected to be in local time instead of UTC.', stacklevel=2)
+        # pylint: disable=arguments-differ
+        if datetime:
+            warnings.warn('Unless a UTC timezone information is present, the parameter `datetime`'
+                          'is now expected to be in local time instead of UTC.', stacklevel=2)
+            datetime = local_to_utc(datetime)
         warnings.warn('All timestamps in the backend properties are now in local time '
                       'instead of UTC.', stacklevel=2)
-        # pylint: disable=arguments-differ
-        # TODO convert input datetime
 
         if datetime or refresh or self._properties is None:
             api_properties = self._api.backend_properties(self.name(), datetime=datetime)

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -41,6 +41,7 @@ from .exceptions import (IBMQBackendError, IBMQBackendValueError,
                          IBMQBackendJobLimitError)
 from .job import IBMQJob
 from .utils import update_qobj_config, validate_job_tags
+from .utils.converters import utc_to_local_all
 from .utils.json_decoder import decode_pulse_defaults, decode_backend_properties
 
 logger = logging.getLogger(__name__)
@@ -254,20 +255,23 @@ class IBMQBackend(BaseBackend):
             The backend properties or ``None`` if the backend properties are not
             currently available.
         """
+        warnings.warn('Unless a UTC timezone information is present, the parameter `datetime`'
+                      'is now expected to be in local time instead of UTC.', stacklevel=2)
+        warnings.warn('All timestamps in the backend properties are now in local time '
+                      'instead of UTC.', stacklevel=2)
         # pylint: disable=arguments-differ
-        if datetime:
-            # Do not use cache for specific datetime properties.
+        # TODO convert input datetime
+
+        if datetime or refresh or self._properties is None:
             api_properties = self._api.backend_properties(self.name(), datetime=datetime)
             if not api_properties:
                 return None
             decode_backend_properties(api_properties)
-            return BackendProperties.from_dict(api_properties)
-
-        if refresh or self._properties is None:
-            api_properties = self._api.backend_properties(self.name())
-            decode_backend_properties(api_properties)
-            self._properties = BackendProperties.from_dict(api_properties)
-
+            api_properties = utc_to_local_all(api_properties)
+            backend_properties = BackendProperties.from_dict(api_properties)
+            if datetime:    # Don't cache result.
+                return backend_properties
+            self._properties = backend_properties
         return self._properties
 
     def status(self) -> BackendStatus:

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -260,14 +260,14 @@ class IBMQBackend(BaseBackend):
             warnings.warn('Unless a UTC timezone information is present, the parameter `datetime`'
                           'is now expected to be in local time instead of UTC.', stacklevel=2)
             datetime = local_to_utc(datetime)
-        warnings.warn('All timestamps in the backend properties are now in local time '
-                      'instead of UTC.', stacklevel=2)
 
         if datetime or refresh or self._properties is None:
             api_properties = self._api.backend_properties(self.name(), datetime=datetime)
             if not api_properties:
                 return None
             decode_backend_properties(api_properties)
+            warnings.warn('All timestamps in backend properties are now in local time '
+                          'instead of UTC.', stacklevel=2)
             api_properties = utc_to_local_all(api_properties)
             backend_properties = BackendProperties.from_dict(api_properties)
             if datetime:    # Don't cache result.

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -20,7 +20,7 @@ import copy
 
 from typing import Dict, List, Callable, Optional, Any, Union
 from types import SimpleNamespace
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from qiskit.providers import JobStatus, QiskitBackendNotFoundError  # type: ignore[attr-defined]
 from qiskit.providers.providerutils import filter_backends
@@ -209,25 +209,10 @@ class IBMQBackendService(SimpleNamespace):
                           '`start_datetime` and `end_datetime` are now expected to be in '
                           'local time instead of UTC.', stacklevel=2)
 
-            def _to_utc_str(input_dt: Optional[datetime]) -> Optional[str]:
-                """Convert the input ``datetime`` to UTC and return its ISO format.
-
-                Args:
-                    input_dt: Datetime to be processed.
-
-                Returns:
-                    UTC in ISO format string.
-                """
-                if input_dt:
-                    # Input is considered local if it's ``utcoffset()`` is ``None`` or none-zero.
-                    if input_dt.utcoffset() is None or input_dt.utcoffset() != timedelta(0):
-                        input_dt = local_to_utc(input_dt)
-                    return input_dt.isoformat()
-                return None
-
             api_filter['creationDate'] = self._update_creation_date_filter(
-                cur_dt_filter={}, gte_dt=_to_utc_str(start_datetime),
-                lte_dt=_to_utc_str(end_datetime))
+                cur_dt_filter={},
+                gte_dt=local_to_utc(start_datetime).isoformat() if start_datetime else None,
+                lte_dt=local_to_utc(end_datetime).isoformat() if end_datetime else None)
 
         if job_tags:
             validate_job_tags(job_tags, IBMQBackendValueError)

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -38,6 +38,7 @@ from ..utils.utils import RefreshQueue, validate_job_tags
 from ..utils import utc_to_local
 from ..utils.qobj_utils import dict_to_qobj
 from ..utils.json_decoder import decode_backend_properties
+from ..utils.converters import utc_to_local_all
 from .exceptions import (IBMQJobApiError, IBMQJobFailureError,
                          IBMQJobTimeoutError, IBMQJobInvalidStateError)
 from .queueinfo import QueueInfo
@@ -201,6 +202,8 @@ class IBMQJob(SimpleNamespace, BaseJob):
             IBMQJobApiError: If an unexpected error occurred when communicating
                 with the server.
         """
+        warnings.warn('All timestamps in the backend properties are now in local time '
+                      'instead of UTC.', stacklevel=2)
         with api_to_job_error():
             properties = self._api.job_properties(job_id=self.job_id())
 
@@ -208,6 +211,8 @@ class IBMQJob(SimpleNamespace, BaseJob):
             return None
 
         decode_backend_properties(properties)
+        properties = utc_to_local_all(properties)
+        # TODO cache properties
         return BackendProperties.from_dict(properties)
 
     def result(

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -35,10 +35,9 @@ from ..apiconstants import ApiJobStatus, ApiJobKind
 from ..api.clients import AccountClient
 from ..api.exceptions import ApiError, UserTimeoutExceededError
 from ..utils.utils import RefreshQueue, validate_job_tags
-from ..utils import utc_to_local
 from ..utils.qobj_utils import dict_to_qobj
 from ..utils.json_decoder import decode_backend_properties
-from ..utils.converters import utc_to_local_all
+from ..utils.converters import utc_to_local, utc_to_local_all
 from .exceptions import (IBMQJobApiError, IBMQJobFailureError,
                          IBMQJobTimeoutError, IBMQJobInvalidStateError)
 from .queueinfo import QueueInfo
@@ -212,7 +211,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
 
         decode_backend_properties(properties)
         properties = utc_to_local_all(properties)
-        # TODO cache properties
         return BackendProperties.from_dict(properties)
 
     def result(

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -201,14 +201,14 @@ class IBMQJob(SimpleNamespace, BaseJob):
             IBMQJobApiError: If an unexpected error occurred when communicating
                 with the server.
         """
-        warnings.warn('All timestamps in the backend properties are now in local time '
-                      'instead of UTC.', stacklevel=2)
         with api_to_job_error():
             properties = self._api.job_properties(job_id=self.job_id())
 
         if not properties:
             return None
 
+        warnings.warn('All timestamps in backend properties are now in '
+                      'local time instead of UTC.', stacklevel=2)
         decode_backend_properties(properties)
         properties = utc_to_local_all(properties)
         return BackendProperties.from_dict(properties)

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -94,10 +94,15 @@ class QueueInfo(SimpleNamespace):
         """
         status = api_status_to_job_status(self._status).name \
             if self._status else self._get_value(self._status)
-        est_start_time = self.estimated_start_time.isoformat() \
-            if self.estimated_start_time else None
-        est_complete_time = self.estimated_complete_time.isoformat() \
-            if self.estimated_complete_time else None
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            est_start_time = self.estimated_start_time.isoformat() \
+                if self.estimated_start_time else None
+            est_complete_time = self.estimated_complete_time.isoformat() \
+                if self.estimated_complete_time else None
+        if est_start_time or est_complete_time:
+            warnings.warn('The estimated start and completion time is now returned '
+                          'in local time instead of UTC.', stacklevel=2)
 
         queue_info = [
             "job_id='{}'".format(self.job_id),
@@ -120,10 +125,17 @@ class QueueInfo(SimpleNamespace):
         """
         status = api_status_to_job_status(self._status).value \
             if self._status else self._get_value(self._status)
-        est_start_time = duration_difference(self.estimated_start_time) \
-            if self.estimated_start_time else self._get_value(self.estimated_start_time)
-        est_complete_time = duration_difference(self.estimated_complete_time) \
-            if self.estimated_complete_time else self._get_value(self.estimated_complete_time)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            est_start_time = duration_difference(self.estimated_start_time) \
+                if self.estimated_start_time else self._get_value(self.estimated_start_time)
+            est_complete_time = duration_difference(self.estimated_complete_time) \
+                if self.estimated_complete_time else self._get_value(self.estimated_complete_time)
+
+        if est_start_time or est_complete_time:
+            warnings.warn('The estimated start and completion time is now returned '
+                          'in local time instead of UTC.', stacklevel=2)
 
         queue_info = [
             "Job {} queue information:".format(self._get_value(self.job_id)),
@@ -149,17 +161,17 @@ class QueueInfo(SimpleNamespace):
     @property
     def estimated_start_time(self) -> Optional[datetime]:
         """Return estimated start time in local time."""
-        warnings.warn('The estimated start time is now returned in local time instead of UTC.',
-                      stacklevel=2)
         if self._estimated_start_time_utc is None:
             return None
+        warnings.warn('The estimated start time is now returned in local time instead of UTC.',
+                      stacklevel=2)
         return utc_to_local(self._estimated_start_time_utc)
 
     @property
     def estimated_complete_time(self) -> Optional[datetime]:
         """Return estimated complete time in local time."""
-        warnings.warn('The estimated complete time is now returned in local time instead of UTC.',
-                      stacklevel=2)
         if self._estimated_complete_time_utc is None:
             return None
+        warnings.warn('The estimated complete time is now returned in local time instead of UTC.',
+                      stacklevel=2)
         return utc_to_local(self._estimated_complete_time_utc)

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -26,17 +26,7 @@ from .utils import api_status_to_job_status
 
 
 class QueueInfo(SimpleNamespace):
-    """Queue information for a job.
-
-    Attributes:
-        position: Job position in the queue within the scope of the provider.
-        estimated_start_time: Estimated start time for the job, in UTC.
-        estimated_complete_time: Estimated completion time for the job, in UTC.
-        hub_priority: Dynamic priority for the hub the job is in.
-        group_priority: Dynamic priority for the group the job is in.
-        project_priority: Dynamic priority for the project the job is in.
-        job_id: Job ID.
-    """
+    """Queue information for a job."""
 
     def __init__(
             self,

--- a/qiskit/providers/ibmq/jupyter/dashboard/job_widgets.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/job_widgets.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2017, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,7 +20,6 @@ from datetime import datetime
 import ipywidgets as widgets
 
 from qiskit.providers.ibmq.job.ibmqjob import IBMQJob
-from qiskit.providers.ibmq.utils.converters import utc_to_local
 
 
 def make_clear_button(watcher: 'IQXDashboard') -> widgets.GridBox:
@@ -106,7 +105,7 @@ def create_job_widget(watcher: 'IQXDashboard',
     status_label = widgets.HTML(value="{}{}".format(status, queue_str),
                                 layout=widgets.Layout(width='125px'))
 
-    est_time = utc_to_local(est_start_time).strftime("%H:%M %Z (%m/%d)") if est_start_time else '-'
+    est_time = est_start_time.strftime("%H:%M %Z (%m/%d)") if est_start_time else '-'
     est_time_label = widgets.HTML(value="{}".format(est_time),
                                   layout=widgets.Layout(width='125px'))
 

--- a/qiskit/providers/ibmq/jupyter/gates_widget.py
+++ b/qiskit/providers/ibmq/jupyter/gates_widget.py
@@ -22,8 +22,6 @@ import ipywidgets as wid
 from qiskit.test.mock.fake_backend import FakeBackend
 from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
 
-from ..utils.converters import utc_to_local
-
 
 def gates_tab(backend: Union[IBMQBackend, FakeBackend]) -> wid.GridBox:
     """Construct the multiple qubit gate error widget.
@@ -35,7 +33,7 @@ def gates_tab(backend: Union[IBMQBackend, FakeBackend]) -> wid.GridBox:
         A widget with gate information.
     """
     props = backend.properties().to_dict()
-    update_date = utc_to_local(props['last_update_date'])
+    update_date = props['last_update_date']
     date_str = update_date.strftime("%a %d %B %Y at %H:%M %Z")
 
     multi_qubit_gates = [g for g in props['gates'] if len(g['qubits']) > 1]

--- a/qiskit/providers/ibmq/jupyter/qubits_widget.py
+++ b/qiskit/providers/ibmq/jupyter/qubits_widget.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2017, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,8 +21,6 @@ import ipywidgets as wid
 from qiskit.test.mock.fake_backend import FakeBackend
 from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
 
-from ..utils.converters import utc_to_local
-
 
 def qubits_tab(backend: Union[IBMQBackend, FakeBackend]) -> wid.VBox:
     """The qubit properties widget.
@@ -35,7 +33,7 @@ def qubits_tab(backend: Union[IBMQBackend, FakeBackend]) -> wid.VBox:
     """
     props = backend.properties().to_dict()
 
-    update_date = utc_to_local(props['last_update_date'])
+    update_date = props['last_update_date']
     date_str = update_date.strftime("%a %d %B %Y at %H:%M %Z")
     header_html = "<div><font style='font-weight:bold'>{key}</font>: {value}</div>"
     header_html = header_html.format(key='last_update_date',

--- a/qiskit/providers/ibmq/utils/converters.py
+++ b/qiskit/providers/ibmq/utils/converters.py
@@ -15,14 +15,14 @@
 """Utilities related to conversion."""
 
 from typing import Union, Tuple, Any
-import datetime
+from datetime import datetime, timedelta, timezone
 from math import ceil
 
 import dateutil.parser
 from dateutil import tz
 
 
-def utc_to_local(utc_dt: Union[datetime.datetime, str]) -> datetime.datetime:
+def utc_to_local(utc_dt: Union[datetime, str]) -> datetime:
     """Convert a UTC ``datetime`` object or string to a local timezone ``datetime``.
 
     Args:
@@ -36,14 +36,14 @@ def utc_to_local(utc_dt: Union[datetime.datetime, str]) -> datetime.datetime:
     """
     if isinstance(utc_dt, str):
         utc_dt = dateutil.parser.parse(utc_dt)
-    if not isinstance(utc_dt, datetime.datetime):
+    if not isinstance(utc_dt, datetime):
         raise TypeError('Input `utc_dt` is not string or datetime.')
-    utc_dt = utc_dt.replace(tzinfo=datetime.timezone.utc)  # type: ignore[arg-type]
+    utc_dt = utc_dt.replace(tzinfo=timezone.utc)  # type: ignore[arg-type]
     local_dt = utc_dt.astimezone(tz.tzlocal())  # type: ignore[attr-defined]
     return local_dt
 
 
-def local_to_utc(local_dt: Union[datetime.datetime, str]) -> datetime.datetime:
+def local_to_utc(local_dt: Union[datetime, str]) -> datetime:
     """Convert a local ``datetime`` object or string to a UTC ``datetime``.
 
     Args:
@@ -57,11 +57,14 @@ def local_to_utc(local_dt: Union[datetime.datetime, str]) -> datetime.datetime:
     """
     if isinstance(local_dt, str):
         local_dt = dateutil.parser.parse(local_dt)
-    if not isinstance(local_dt, datetime.datetime):
+    if not isinstance(local_dt, datetime):
         raise TypeError('Input `local_dt` is not string or datetime.')
-    local_dt = local_dt.replace(tzinfo=tz.tzlocal())
-    utc_dt = local_dt.astimezone(tz.UTC)
-    return utc_dt
+
+    # Input is considered local if it's ``utcoffset()`` is ``None`` or none-zero.
+    if local_dt.utcoffset() is None or local_dt.utcoffset() != timedelta(0):
+        local_dt = local_dt.replace(tzinfo=tz.tzlocal())
+        return local_dt.astimezone(tz.UTC)
+    return local_dt  # Already in UTC.
 
 
 def utc_to_local_all(data: Any) -> Any:
@@ -73,7 +76,7 @@ def utc_to_local_all(data: Any) -> Any:
     Returns:
         Converted data.
     """
-    if isinstance(data, datetime.datetime):
+    if isinstance(data, datetime):
         return utc_to_local(data)
     elif isinstance(data, list):
         return [utc_to_local_all(elem) for elem in data]
@@ -105,7 +108,7 @@ def seconds_to_duration(seconds: float) -> Tuple[int, int, int, int, int]:
     return days, hours, minutes, seconds, millisec
 
 
-def duration_difference(date_time_utc: datetime.datetime) -> str:
+def duration_difference(date_time_utc: datetime) -> str:
     """Compute the estimated duration until the given datetime.
 
     Args:
@@ -114,7 +117,7 @@ def duration_difference(date_time_utc: datetime.datetime) -> str:
     Returns:
         String giving the estimated duration.
     """
-    time_delta = date_time_utc.replace(tzinfo=None) - datetime.datetime.utcnow()
+    time_delta = date_time_utc.replace(tzinfo=None) - datetime.utcnow()
     time_tuple = seconds_to_duration(time_delta.total_seconds())
     # The returned tuple contains the duration in terms of
     # days, hours, minutes, seconds, and milliseconds.

--- a/qiskit/providers/ibmq/utils/converters.py
+++ b/qiskit/providers/ibmq/utils/converters.py
@@ -14,9 +14,10 @@
 
 """Utilities related to conversion."""
 
-from typing import Union, Tuple
+from typing import Union, Tuple, Any
 import datetime
 from math import ceil
+
 import dateutil.parser
 from dateutil import tz
 
@@ -61,6 +62,24 @@ def local_to_utc(local_dt: Union[datetime.datetime, str]) -> datetime.datetime:
     local_dt = local_dt.replace(tzinfo=tz.tzlocal())
     utc_dt = local_dt.astimezone(tz.UTC)
     return utc_dt
+
+
+def utc_to_local_all(data: Any) -> Any:
+    """Recursively convert all ``datetime`` in the input data from local time to UTC.
+
+    Args:
+        data: Data to be converted.
+
+    Returns:
+        Converted data.
+    """
+    if isinstance(data, datetime.datetime):
+        return utc_to_local(data)
+    elif isinstance(data, list):
+        return [utc_to_local_all(elem) for elem in data]
+    elif isinstance(data, dict):
+        return {key: utc_to_local_all(elem) for key, elem in data.items()}
+    return data
 
 
 def seconds_to_duration(seconds: float) -> Tuple[int, int, int, int, int]:

--- a/qiskit/providers/ibmq/utils/converters.py
+++ b/qiskit/providers/ibmq/utils/converters.py
@@ -70,6 +70,9 @@ def local_to_utc(local_dt: Union[datetime, str]) -> datetime:
 def utc_to_local_all(data: Any) -> Any:
     """Recursively convert all ``datetime`` in the input data from local time to UTC.
 
+    Note:
+        Only lists and dictionaries are traversed.
+
     Args:
         data: Data to be converted.
 
@@ -108,16 +111,16 @@ def seconds_to_duration(seconds: float) -> Tuple[int, int, int, int, int]:
     return days, hours, minutes, seconds, millisec
 
 
-def duration_difference(date_time_utc: datetime) -> str:
+def duration_difference(date_time: datetime) -> str:
     """Compute the estimated duration until the given datetime.
 
     Args:
-        date_time_utc: The input datetime, in UTC.
+        date_time: The input local datetime.
 
     Returns:
         String giving the estimated duration.
     """
-    time_delta = date_time_utc.replace(tzinfo=None) - datetime.utcnow()
+    time_delta = date_time.replace(tzinfo=None) - datetime.now()
     time_tuple = seconds_to_duration(time_delta.total_seconds())
     # The returned tuple contains the duration in terms of
     # days, hours, minutes, seconds, and milliseconds.

--- a/releasenotes/notes/properties-local-time-c54dc119cdea6474.yaml
+++ b/releasenotes/notes/properties-local-time-c54dc119cdea6474.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    Timestamps in backend properties returned by
+    :meth:`qiskit.providers.ibmq.IBMQBackend.properties`
+    and :meth:`qiskit.providers.ibmq.job.IBMQJob.properties` are now in local
+    time instead of UTC. The ``datetime`` parameter for
+    :meth:`qiskit.providers.ibmq.IBMQBackend.properties` is also expected to be
+    in local time unless it has UTC timezone information.
+    ``estimated_start_time`` and ``estimated_complete_time`` in
+    :class:`~qiskit.providers.ibmq.job.QueueInfo`, returned by
+    :meth:`qiskit.providers.ibmq.job.IBMQJob.queue_info`, are also in local
+    time instead of UTC.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #684.
Convert timestamps in backend properties from UTC to local time. This includes
- `backend.properties()`
- `datetime` parameter for `backend.properties()`
- `job.properties()`
- `estimated_start_time` and `estimated_complete_time` in `QueueInfo`. 


### Details and comments


