### PR TITLE
Fix job tags being None

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -433,7 +433,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
         # Tags prefix that denotes a job belongs to a jobset.
         ibmq_jobset_prefix = 'ibmq_jobset_'
 
-        tags_to_update = set(self._tags)  # Get the current job tags.
+        tags_to_update = set(self._tags or [])  # Get the current job tags.
         if isinstance(replacement_tags, list):  # `replacement_tags` could be an empty list.
             # Replace the current tags and re-add those associated with a job set.
             validate_job_tags(replacement_tags, IBMQJobInvalidStateError)
@@ -721,7 +721,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
         self._name = api_response.pop('name', None)
         self._time_per_step = api_response.pop('time_per_step', None)
         self._error = api_response.pop('error', None)
-        self._tags = api_response.pop('tags', None)
+        self._tags = api_response.pop('tags', [])
         self._run_mode = api_response.pop('run_mode', None)
         self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
         self._status, self._queue_info = \


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
A Travis [test](https://travis-ci.com/github/jyu00/qiskit-ibmq-provider/jobs/355392913) discovered an issue wherein a job's `_tags` can become `None`, causing a subsequent `set(self._tags)` statement to fail. This PR ensures `_tags` is not set to `None` and the `set()` can tolerate `None`. 


### Details and comments


