### PR TITLE
Add qiskit version to result

### DIFF
--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -24,9 +24,10 @@ from requests.auth import AuthBase
 from urllib3.util.retry import Retry
 
 from qiskit.providers.ibmq.utils.utils import filter_data
+from qiskit.version import __qiskit_version__
+
 from .exceptions import RequestsApiError
 from ..version import __version__ as ibmq_provider_version
-from qiskit.version import __qiskit_version__
 
 STATUS_FORCELIST = (
     502,  # Bad Gateway

--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -26,6 +26,7 @@ from urllib3.util.retry import Retry
 from qiskit.providers.ibmq.utils.utils import filter_data
 from .exceptions import RequestsApiError
 from ..version import __version__ as ibmq_provider_version
+from qiskit.version import __qiskit_version__
 
 STATUS_FORCELIST = (
     502,  # Bad Gateway
@@ -33,7 +34,6 @@ STATUS_FORCELIST = (
     504,  # Gateway Timeout
     524,  # Cloudflare Timeout
 )
-CLIENT_APPLICATION = 'ibmqprovider/' + ibmq_provider_version
 CUSTOM_HEADER_ENV_VAR = 'QE_CUSTOM_CLIENT_APP_HEADER'
 logger = logging.getLogger(__name__)
 # Regex used to match the `/devices` endpoint, capturing the device name as group(2).
@@ -41,6 +41,22 @@ logger = logging.getLogger(__name__)
 # the `/devices/v/1` endpoint.
 # Capture groups: (/devices/)(<device_name>)(</optional rest of the url>)
 RE_DEVICES_ENDPOINT = re.compile(r'^(/devices/)([^/}]{2,})(.*)$', re.IGNORECASE)
+
+
+def _get_client_header() -> str:
+    """Return the client version."""
+    if __qiskit_version__.get('qiskit', None):
+        client_header = 'qiskit/' + __qiskit_version__['qiskit']
+    else:
+        known_versions = dict(
+            filter(lambda item: item[1] is not None, __qiskit_version__.items()))
+        # Always include provider version.
+        known_versions['qiskit-ibmq-provider'] = ibmq_provider_version
+        client_header = ','.join(known_versions.keys()) + '/' + ','.join(known_versions.values())
+    return client_header
+
+
+CLIENT_APPLICATION = _get_client_header()
 
 
 class PostForcelistRetry(Retry):

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -118,6 +118,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
             tags: Optional[List[str]] = None,
             run_mode: Optional[str] = None,
             share_level: Optional[str] = None,
+            client_info: Optional[Dict[str, str]] = None,
             **kwargs: Any
     ) -> None:
         """IBMQJob constructor.
@@ -137,6 +138,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
             tags: Job tags.
             run_mode: Scheduling mode the job runs in.
             share_level: Level the job can be shared with.
+            client_info: Client (Qiskit) version.
             kwargs: Additional job attributes.
         """
         self._backend = backend
@@ -147,7 +149,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
         self._kind = ApiJobKind(kind) if kind else None
         self._name = name
         self._time_per_step = time_per_step
-        self._result = Result.from_dict(result) if result else None
         if isinstance(qobj, dict):
             qobj = dict_to_qobj(qobj)
         self._qobj = qobj
@@ -158,6 +159,8 @@ class IBMQJob(SimpleNamespace, BaseJob):
             self._get_status_position(status, kwargs.pop('info_queue', None))
         self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
         self._share_level = share_level
+        self.client_info = client_info
+        self._set_result(result)
 
         for key, value in kwargs.items():
             # Append suffix to key to avoid conflicts.
@@ -673,6 +676,26 @@ class IBMQJob(SimpleNamespace, BaseJob):
 
         return self._run_mode
 
+    @property
+    def client_info(self) -> Optional[Dict[str, str]]:
+        """Return information on the client used for this job."""
+        if self._client_info is None:
+            self.refresh()
+        return self._client_info
+
+    @client_info.setter
+    def client_info(self, data: Dict[str, str]) -> None:
+        """Set client information.
+
+        Args:
+            data: Client information.
+        """
+        print(f"data is {data}")
+        if data:
+            self._client_info = dict(zip(data['name'].split(','), data['version'].split(',')))
+        else:
+            self._client_info = None
+
     def submit(self) -> None:
         """Submit this job to an IBM Quantum Experience backend.
 
@@ -710,8 +733,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
             self._api_status = api_response.pop('status')
             if 'kind' in api_response:
                 self._kind = ApiJobKind(api_response.pop('kind'))
-            if 'result' in api_response:
-                self._result = Result.from_dict(api_response.pop('result'))
             if 'qobj' in api_response:
                 self._qobj = dict_to_qobj(api_response.pop('qobj'))
         except (KeyError, TypeError) as err:
@@ -727,6 +748,8 @@ class IBMQJob(SimpleNamespace, BaseJob):
         self._status, self._queue_info = \
             self._get_status_position(self._api_status, api_response.pop('info_queue', None))
         self._share_level = api_response.pop('share_level', 'none')
+        self.client_info = api_response.pop('client_info', None)
+        self._set_result(api_response.pop('result', None))
 
         for key, value in api_response.items():
             self.__dict__[key + '_'] = value
@@ -877,16 +900,12 @@ class IBMQJob(SimpleNamespace, BaseJob):
         if not self._result or refresh:  # type: ignore[has-type]
             try:
                 result_response = self._api.job_result(self.job_id(), self._use_object_storage)
-                self._result = Result.from_dict(result_response)
-            except (ApiError, TypeError) as err:
+                self._set_result(result_response)
+            except ApiError as err:
                 if self._status is JobStatus.ERROR:
                     raise IBMQJobFailureError(
                         'Unable to retrieve result for job {}. Job has failed. Use '
                         'job.error_message() to get more details.'.format(self.job_id())) from err
-                if not self._kind:
-                    raise IBMQJobInvalidStateError(
-                        'Unable to retrieve result for job {}. Job result '
-                        'is in an unsupported format.'.format(self.job_id())) from err
                 raise IBMQJobApiError(
                     'Unable to retrieve result for '
                     'job {}: {}'.format(self.job_id(), str(err))) from err
@@ -901,6 +920,25 @@ class IBMQJob(SimpleNamespace, BaseJob):
                 'Use job.error_message() to get more details.'.format(self.job_id()))
 
         return self._result
+
+    def _set_result(self, raw_data) -> None:
+        """Set the job result.
+
+        Args:
+            raw_data: Raw result data.
+        """
+        if raw_data is None:
+            self._result = None
+            return
+        raw_data['client_info'] = self.client_info
+        try:
+            self._result = Result.from_dict(raw_data)
+        except (KeyError, TypeError) as err:
+            if not self._kind:
+                raise IBMQJobInvalidStateError(
+                    'Unable to retrieve result for job {}. Job result '
+                    'is in an unsupported format.'.format(self.job_id())) from err
+            raise
 
     def _check_for_error_message(self, result_response: Dict[str, Any]) -> None:
         """Retrieves the error message from the result response.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -696,7 +696,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
             data: Client information.
         """
         if data:
-            if data['name'].startswith('qiskit'):
+            if data.get('name', '').startswith('qiskit'):
                 self._client_info = dict(zip(data['name'].split(','), data['version'].split(',')))
             else:
                 self._client_info = {data.get('name', 'unknown'): data.get('version', 'unknown')}

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -138,7 +138,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
             tags: Job tags.
             run_mode: Scheduling mode the job runs in.
             share_level: Level the job can be shared with.
-            client_info: Client (Qiskit) version.
+            client_info: Client version.
             kwargs: Additional job attributes.
         """
         self._backend = backend
@@ -678,7 +678,12 @@ class IBMQJob(SimpleNamespace, BaseJob):
 
     @property
     def client_info(self) -> Optional[Dict[str, str]]:
-        """Return information on the client used for this job."""
+        """Return information on the client used for this job.
+
+        Returns:
+            Client information in dictionary format, where the key is the name
+                of the client and the value is the version.
+        """
         if self._client_info is None:
             self.refresh()
         return self._client_info
@@ -691,7 +696,10 @@ class IBMQJob(SimpleNamespace, BaseJob):
             data: Client information.
         """
         if data:
-            self._client_info = dict(zip(data['name'].split(','), data['version'].split(',')))
+            if data['name'].startswith('qiskit'):
+                self._client_info = dict(zip(data['name'].split(','), data['version'].split(',')))
+            else:
+                self._client_info = {data.get('name', 'unknown'): data.get('version', 'unknown')}
         else:
             self._client_info = None
 

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -677,23 +677,23 @@ class IBMQJob(SimpleNamespace, BaseJob):
         return self._run_mode
 
     @property
-    def client_version(self) -> Optional[Dict[str, str]]:
-        """Return information on the client used for this job.
+    def client_version(self) -> Dict[str, str]:
+        """Return version of the client used for this job.
 
         Returns:
-            Client information in dictionary format, where the key is the name
+            Client version in dictionary format, where the key is the name
                 of the client and the value is the version.
         """
-        if self._client_version is None:
+        if not self._client_version:
             self.refresh()
         return self._client_version
 
     @client_version.setter
     def client_version(self, data: Dict[str, str]) -> None:
-        """Set client information.
+        """Set client version.
 
         Args:
-            data: Client information.
+            data: Client version.
         """
         if data:
             if data.get('name', '').startswith('qiskit'):
@@ -703,7 +703,7 @@ class IBMQJob(SimpleNamespace, BaseJob):
                 self._client_version = \
                     {data.get('name', 'unknown'): data.get('version', 'unknown')}
         else:
-            self._client_version = None
+            self._client_version = {}
 
     def submit(self) -> None:
         """Submit this job to an IBM Quantum Experience backend.

--- a/releasenotes/notes/job-client-info-4ebded509a1e09eb.yaml
+++ b/releasenotes/notes/job-client-info-4ebded509a1e09eb.yaml
@@ -1,9 +1,10 @@
 ---
 features:
   - |
-    :class:`~qiskit.providers.ibmq.job.IBMQJob` now has a new attribute
-    ``client_version`` that contains version information of the client used
-    to submit the job, such as Qiskit version. The version information is
-    also available as the ``client_version`` attribute of the
+    A new attribute ``client_version`` was added to
+    :class:`~qiskit.providers.ibmq.job.IBMQJob` and
     :class:`qiskit.result.Result` object retrieved via
     :meth:`qiskit.providers.ibmq.job.IBMQJob.result`.
+    ``client_version`` is a dictionary with the key being the name
+    and the value being the version of the client used to submit
+    the job, such as Qiskit.

--- a/releasenotes/notes/job-client-info-4ebded509a1e09eb.yaml
+++ b/releasenotes/notes/job-client-info-4ebded509a1e09eb.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    :class:`~qiskit.providers.ibmq.job.IBMQJob` now has a new attribute
+    ``client_version`` that contains version information of the client used
+    to submit the job, such as Qiskit version. The version information is
+    also available as the ``client_version`` attribute of the
+    :class:`qiskit.result.Result` object retrieved via
+    :meth:`qiskit.providers.ibmq.job.IBMQJob.result`.

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -15,11 +15,10 @@
 """Test IBMQJob attributes."""
 
 import time
-from unittest import mock
+from unittest import mock, skip
 from datetime import datetime
 import re
 import uuid
-from unittest import skip
 
 from dateutil import tz
 

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -19,6 +19,7 @@ from unittest import mock
 from datetime import datetime
 import re
 import uuid
+from unittest import skip
 
 from dateutil import tz
 
@@ -478,3 +479,9 @@ class TestIBMQJobAttributes(JobTestCase):
             self.assertRaises(IBMQBackendApiProtocolError, self.sim_backend.run, self.qobj)
         finally:
             self.sim_backend._api = saved_api
+
+    @skip('Skip until feature is available')
+    def test_client_info(self):
+        """Test job client information."""
+        self.assertIsNotNone(self.sim_job.result().client_info)
+        self.assertIsNotNone(self.sim_job.client_info)

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -479,7 +479,7 @@ class TestIBMQJobAttributes(JobTestCase):
         finally:
             self.sim_backend._api = saved_api
 
-    def test_client_info(self):
-        """Test job client information."""
-        self.assertIsNotNone(self.sim_job.result().client_info)
-        self.assertIsNotNone(self.sim_job.client_info)
+    def test_client_version(self):
+        """Test job client version information."""
+        self.assertIsNotNone(self.sim_job.result().client_version)
+        self.assertIsNotNone(self.sim_job.client_version)

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -15,7 +15,7 @@
 """Test IBMQJob attributes."""
 
 import time
-from unittest import mock, skip
+from unittest import mock
 from datetime import datetime
 import re
 import uuid
@@ -479,7 +479,6 @@ class TestIBMQJobAttributes(JobTestCase):
         finally:
             self.sim_backend._api = saved_api
 
-    @skip('Skip until feature is available')
     def test_client_info(self):
         """Test job client information."""
         self.assertIsNotNone(self.sim_job.result().client_info)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #692.
This PR adds a new `client_version` attribute to `IBMQJob` and results retrieved via `IBMQJob.result()`. `client_version` is a dictionary with the key being the name and the value being the version of the client used to submit the job.


### Details and comments
`job.client_version` can return Qiskit meta version (e.g. `{'qiskit': '0.19.6'}`) or Qiskit element versions if meta version is not available (e.g. `{'qiskit-terra': '0.14.1', 'qiskit-ibmq-provider': '0.8.0'}`) or `composer-job` (`{'composer-job': 'unknown'}`) if the composer was used.
