### PR TITLE
Fix bad backend visualization

### DIFF
--- a/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py
@@ -137,7 +137,10 @@ def make_backend_widget(backend_item: BackendWithProviders) -> wid.HBox:
                         if param['value'] != 1.0:
                             sum_cx_err += param['value']
                             num_cx += 1
-        avg_cx_err = round(sum_cx_err/(num_cx)*100, 2)
+        if num_cx:
+            avg_cx_err = round(sum_cx_err/(num_cx)*100, 2)
+        else:
+            avg_cx_err = 100.0
 
     avg_meas_err = 0
     for qub in props['qubits']:

--- a/test/ibmq/test_jupyter.py
+++ b/test/ibmq/test_jupyter.py
@@ -101,10 +101,11 @@ class TestIQXDashboard(IBMQTestCase):
     def test_backend_widget(self):
         """Test devices tab."""
         for backend in self.backends:
-            cred = backend.provider().credentials
-            provider_str = "{}/{}/{}".format(cred.hub, cred.group, cred.project)
-            b_w_p = BackendWithProviders(backend=backend, providers=[provider_str])
-            make_backend_widget(b_w_p)
+            with self.subTest(backend=backend):
+                cred = backend.provider().credentials
+                provider_str = "{}/{}/{}".format(cred.hub, cred.group, cred.project)
+                b_w_p = BackendWithProviders(backend=backend, providers=[provider_str])
+                make_backend_widget(b_w_p)
 
     def test_job_widget(self):
         """Test jobs tab."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #706 . 

The error map for a backend with all cx errors being 100% will show no connecting lines. This makes the graph a bit odd but is consistent with the default of not showing "bad" edges. 


### Details and comments


