### PR TITLE
Fix IBMQBackend pickling by removing SimpleNamespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,6 +198,8 @@ jobs:
       python: 3.8
       name: with terra master
       before_script: pip install -U git+https://github.com/Qiskit/qiskit-terra.git
+      env:
+        - QISKIT_TESTS=run_slow
     - if: tag IS present
       language: python
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -216,6 +216,8 @@ jobs:
       before_script: pip install -U git+https://github.com/Qiskit/qiskit-terra.git
       env:
         - QISKIT_TESTS=run_slow
+      script:
+        - travis_wait 60 make test
     # additional Windows tests
     # Windows, Python 3.7
     - if: type = cron

--- a/qiskit/providers/ibmq/backendjoblimit.py
+++ b/qiskit/providers/ibmq/backendjoblimit.py
@@ -15,10 +15,9 @@
 """Job limit information related to a backend."""
 
 from typing import Any
-from types import SimpleNamespace
 
 
-class BackendJobLimit(SimpleNamespace):
+class BackendJobLimit:
     """Job limit for a backend.
 
     Represent the job limit for a backend on a specific provider. This
@@ -44,5 +43,12 @@ class BackendJobLimit(SimpleNamespace):
         """
         self.maximum_jobs = maximum_jobs
         self.active_jobs = running_jobs
+        self._data = {}
 
         super().__init__(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute {} is not defined.'.format(name))

--- a/qiskit/providers/ibmq/backendjoblimit.py
+++ b/qiskit/providers/ibmq/backendjoblimit.py
@@ -31,6 +31,8 @@ class BackendJobLimit:
             this provider.
     """
 
+    _data = {}
+
     def __init__(self, maximum_jobs: int, running_jobs: int, **kwargs: Any) -> None:
         """BackendJobLimit constructor.
 
@@ -51,4 +53,4 @@ class BackendJobLimit:
         try:
             return self._data[name]
         except KeyError:
-            raise AttributeError('Attribute {} is not defined.'.format(name))
+            raise AttributeError('Attribute {} is not defined.'.format(name)) from None

--- a/qiskit/providers/ibmq/backendjoblimit.py
+++ b/qiskit/providers/ibmq/backendjoblimit.py
@@ -45,9 +45,7 @@ class BackendJobLimit:
         """
         self.maximum_jobs = maximum_jobs
         self.active_jobs = running_jobs
-        self._data = {}
-
-        super().__init__(**kwargs)
+        self._data = kwargs
 
     def __getattr__(self, name: str) -> Any:
         try:

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -19,7 +19,6 @@ import warnings
 import copy
 
 from typing import Dict, List, Callable, Optional, Any, Union
-from types import SimpleNamespace
 from datetime import datetime
 
 from qiskit.providers import JobStatus, QiskitBackendNotFoundError  # type: ignore[attr-defined]
@@ -37,7 +36,7 @@ from .utils.converters import local_to_utc
 logger = logging.getLogger(__name__)
 
 
-class IBMQBackendService(SimpleNamespace):
+class IBMQBackendService:
     """Backend namespace for an IBM Quantum Experience account provider.
 
     Represent a namespace that provides backend related services for the IBM

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -98,6 +98,8 @@ class IBMQJob(BaseJob):
     which is a supported attribute.
     """
 
+    _data = {}
+
     _executor = futures.ThreadPoolExecutor()
     """Threads used for asynchronous processing."""
 
@@ -1077,4 +1079,4 @@ class IBMQJob(BaseJob):
         try:
             return self._data[name]
         except KeyError:
-            raise AttributeError('Attribute {} is not defined.'.format(name))
+            raise AttributeError('Attribute {} is not defined.'.format(name)) from None

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -16,7 +16,6 @@
 
 from typing import Any, Optional, Union
 from datetime import datetime
-from types import SimpleNamespace
 import warnings
 
 import dateutil.parser
@@ -25,7 +24,7 @@ from ..utils import utc_to_local, duration_difference
 from .utils import api_status_to_job_status
 
 
-class QueueInfo(SimpleNamespace):
+class QueueInfo:
     """Queue information for a job."""
 
     def __init__(
@@ -66,7 +65,7 @@ class QueueInfo(SimpleNamespace):
         self.project_priority = project_priority
         self.job_id = job_id
 
-        super().__init__(**kwargs)
+        self._data = kwargs
 
     def __repr__(self) -> str:
         """Return the string representation of ``QueueInfo``.
@@ -106,6 +105,12 @@ class QueueInfo(SimpleNamespace):
         ]
 
         return "<{}({})>".format(self.__class__.__name__, ', '.join(queue_info))
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute {} is not defined.'.format(name))
 
     def format(self) -> str:
         """Build a user-friendly report for the job queue information.

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -27,6 +27,8 @@ from .utils import api_status_to_job_status
 class QueueInfo:
     """Queue information for a job."""
 
+    _data = {}
+
     def __init__(
             self,
             position: Optional[int] = None,
@@ -110,7 +112,7 @@ class QueueInfo:
         try:
             return self._data[name]
         except KeyError:
-            raise AttributeError('Attribute {} is not defined.'.format(name))
+            raise AttributeError('Attribute {} is not defined.'.format(name)) from None
 
     def format(self) -> str:
         """Build a user-friendly report for the job queue information.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #712. 

Remove inheritance of `SimpleNamespace`.


### Details and comments
`SimpleNamespace` was used in various classes to allow attribute access for arbitrary kwargs from the constructor. However, a recent change in terra requires `IBMQBackend` to be serializable with `pickle`, which is much more difficult with `SimpleNamespace`. Not only does it require the subclass to overwrite `__reduce__`, but it also calls the subclass's, in this case `IBMQBackendService`, `__init__` function during un-pickling without giving it the full state (i.e. an empty `provider` with no `_backends`, causing the `IBMQBackendService.__init__` to fail). 

For most classes, the extra kwargs are just stored in private dictionaries. For `IBMQBackendService`, `SimpleNamespace` was a carry-over from when backends were discovered lazily and is no longer required as the backends are added as attributes via `setattr`.
