### PR TITLE
Consolidate timestamp in local time warning 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,10 +89,6 @@ autodoc_default_options = {
     'inherited-members': None,
 }
 
-# This value controls the behavior of sphinx-build -W during importing modules.
-# If False is given, autodoc forcedly suppresses the error if the imported
-# module emits warnings.
-autodoc_warningiserror = False
 
 # If true, figures, tables and code-blocks are automatically numbered if they
 # have a caption.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,10 @@ autodoc_default_options = {
     'inherited-members': None,
 }
 
+# This value controls the behavior of sphinx-build -W during importing modules.
+# If False is given, autodoc forcedly suppresses the error if the imported
+# module emits warnings.
+autodoc_warningiserror = False
 
 # If true, figures, tables and code-blocks are automatically numbered if they
 # have a caption.

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -266,8 +266,6 @@ class IBMQBackend(BaseBackend):
             if not api_properties:
                 return None
             decode_backend_properties(api_properties)
-            warnings.warn('All timestamps in backend properties are now in local time '
-                          'instead of UTC.', stacklevel=2)
             api_properties = utc_to_local_all(api_properties)
             backend_properties = BackendProperties.from_dict(api_properties)
             if datetime:    # Don't cache result.

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -15,6 +15,7 @@
 """Factory and Account manager for IBM Quantum Experience."""
 
 import logging
+import warnings
 from typing import Dict, List, Union, Callable, Optional, Any
 from collections import OrderedDict
 
@@ -38,6 +39,9 @@ QX_AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
 UPDATE_ACCOUNT_TEXT = "Please update your accounts and programs by following the " \
                       "instructions here: https://github.com/Qiskit/qiskit-ibmq-provider#" \
                       "updating-to-the-new-ibm-q-experience "
+
+warnings.warn('Timestamps in IBMQ backend properties, jobs, and job results '
+              'are all now in local time instead of UTC.')
 
 
 class IBMQFactory:

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -40,9 +40,6 @@ UPDATE_ACCOUNT_TEXT = "Please update your accounts and programs by following the
                       "instructions here: https://github.com/Qiskit/qiskit-ibmq-provider#" \
                       "updating-to-the-new-ibm-q-experience "
 
-warnings.warn('Timestamps in IBMQ backend properties, jobs, and job results '
-              'are all now in local time instead of UTC.')
-
 
 class IBMQFactory:
     """Factory and account manager for IBM Quantum Experience."""
@@ -107,6 +104,10 @@ class IBMQFactory:
             raise IBMQAccountCredentialsInvalidUrl(
                 'The URL specified ({}) is not an IBM Quantum Experience authentication '
                 'URL. Valid authentication URL: {}.'.format(credentials.url, QX_AUTH_URL))
+
+        # TODO Remove in the future.
+        warnings.warn('Timestamps in IBMQ backend properties, jobs, and job results '
+                      'are all now in local time instead of UTC.')
 
         # Initialize the providers.
         self._initialize_providers(credentials)
@@ -186,6 +187,10 @@ class IBMQFactory:
         if not version_info['new_api'] or 'api-auth' not in version_info:
             raise IBMQAccountCredentialsInvalidUrl(
                 'Invalid IBM Quantum Experience credentials found. ' + UPDATE_ACCOUNT_TEXT)
+
+        # TODO: Remove in the future.
+        warnings.warn('Timestamps in IBMQ backend properties, jobs, and job results '
+                      'are all now in local time instead of UTC.')
 
         # Initialize the providers.
         if self._credentials:

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -210,8 +210,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
         if not properties:
             return None
 
-        warnings.warn('All timestamps in backend properties are now in '
-                      'local time instead of UTC.', stacklevel=2)
         decode_backend_properties(properties)
         properties = utc_to_local_all(properties)
         return BackendProperties.from_dict(properties)
@@ -284,8 +282,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
                     'Unable to retrieve result for job {}. Job has failed. '
                     'Use job.error_message() to get more details.'.format(self.job_id()))
 
-        warnings.warn('The date in job Result object is now returned '
-                      'in local time instead of UTC.', stacklevel=2)
         return self._retrieve_result(refresh=refresh)
 
     def cancel(self) -> bool:
@@ -587,9 +583,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
             The job creation date as a datetime object, in local time.
         """
         creation_date_local_dt = utc_to_local(self._creation_date)
-        # TODO: Remove when decided the warning is no longer needed.
-        warnings.warn('The creation date is returned in local time now, '
-                      'rather than UTC.', stacklevel=2)
         return creation_date_local_dt
 
     def job_id(self) -> str:
@@ -651,8 +644,6 @@ class IBMQJob(SimpleNamespace, BaseJob):
         # Note: By default, `None` should be returned if no time per step info is available.
         time_per_step_local = None
         if self._time_per_step:
-            warnings.warn('The time per step date and time information is returned in '
-                          'local time now, rather than UTC.', stacklevel=2)
             time_per_step_local = {}
             for step_name, time_data_utc in self._time_per_step.items():
                 time_per_step_local[step_name] = utc_to_local(time_data_utc)

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -90,9 +90,6 @@ class QueueInfo(SimpleNamespace):
                 if self.estimated_start_time else None
             est_complete_time = self.estimated_complete_time.isoformat() \
                 if self.estimated_complete_time else None
-        if est_start_time or est_complete_time:
-            warnings.warn('The estimated start and completion time is now returned '
-                          'in local time instead of UTC.', stacklevel=2)
 
         queue_info = [
             "job_id='{}'".format(self.job_id),
@@ -123,10 +120,6 @@ class QueueInfo(SimpleNamespace):
             est_complete_time = duration_difference(self.estimated_complete_time) \
                 if self.estimated_complete_time else self._get_value(self.estimated_complete_time)
 
-        if est_start_time or est_complete_time:
-            warnings.warn('The estimated start and completion time is now returned '
-                          'in local time instead of UTC.', stacklevel=2)
-
         queue_info = [
             "Job {} queue information:".format(self._get_value(self.job_id)),
             "    queue position: {}".format(self._get_value(self.position)),
@@ -153,8 +146,6 @@ class QueueInfo(SimpleNamespace):
         """Return estimated start time in local time."""
         if self._estimated_start_time_utc is None:
             return None
-        warnings.warn('The estimated start time is now returned in local time instead of UTC.',
-                      stacklevel=2)
         return utc_to_local(self._estimated_start_time_utc)
 
     @property
@@ -162,6 +153,4 @@ class QueueInfo(SimpleNamespace):
         """Return estimated complete time in local time."""
         if self._estimated_complete_time_utc is None:
             return None
-        warnings.warn('The estimated complete time is now returned in local time instead of UTC.',
-                      stacklevel=2)
         return utc_to_local(self._estimated_complete_time_utc)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #708. Consolidate all the "xxx is now in local time" warnings into a single one that's displayed when IBMQ is loaded. 


### Details and comments


