### PR TITLE
Add error message in IBMQJobFailureError

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -281,7 +281,7 @@ class IBMQJob(BaseJob):
             # Job failed.
             if partial:
                 self._retrieve_result(refresh=refresh)
-            if not partial or not self._result:
+            if not partial or not self._result or not self._result.results:
                 error_message = self.error_message()
                 if '\n' in error_message:
                     error_message = ". Use job.error_message() to get more details"
@@ -500,8 +500,9 @@ class IBMQJob(BaseJob):
 
         with api_to_job_error():
             api_response = self._api.job_status(self.job_id())
+            self._api_status = api_response['status']
             self._status, self._queue_info = self._get_status_position(
-                api_response['status'], api_response.get('info_queue', None))
+                self._api_status, api_response.get('info_queue', None))
 
         # Get all job attributes if the job is done.
         if self._status in JOB_FINAL_STATES:
@@ -880,8 +881,9 @@ class IBMQJob(BaseJob):
             raise IBMQJobApiError('Error checking job status due to a network '
                                   'error: {}'.format(str(api_err))) from api_err
 
+        self._api_status = status_response['status']
         self._status, self._queue_info = self._get_status_position(
-            status_response['status'], status_response.get('info_queue', None))
+            self._api_status, status_response.get('info_queue', None))
 
         # Get all job attributes when the job is done.
         self.refresh()
@@ -899,6 +901,11 @@ class IBMQJob(BaseJob):
             IBMQJobApiError: If an unexpected error occurred when communicating
                 with the server.
         """
+        if self._api_status in (ApiJobStatus.ERROR_CREATING_JOB.value,
+                                ApiJobStatus.ERROR_VALIDATING_JOB.value):
+            # No results if job was never executed.
+            return
+
         if not self._result or refresh:  # type: ignore[has-type]
             try:
                 result_response = self._api.job_result(self.job_id(), self._use_object_storage)
@@ -907,11 +914,10 @@ class IBMQJob(BaseJob):
                     # Look for error message in result response.
                     self._check_for_error_message(result_response)
             except ApiError as err:
-                if self._status in [JobStatus.ERROR, JobStatus.CANCELLED]:
-                    pass
-                raise IBMQJobApiError(
-                    'Unable to retrieve result for '
-                    'job {}: {}'.format(self.job_id(), str(err))) from err
+                if self._status not in (JobStatus.ERROR, JobStatus.CANCELLED):
+                    raise IBMQJobApiError(
+                        'Unable to retrieve result for '
+                        'job {}: {}'.format(self.job_id(), str(err))) from err
 
     def _set_result(self, raw_data: Optional[Dict]) -> None:
         """Set the job result.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -278,13 +278,22 @@ class IBMQJob(BaseJob):
             if self._status is JobStatus.CANCELLED:
                 raise IBMQJobInvalidStateError('Unable to retrieve result for job {}. '
                                                'Job was cancelled.'.format(self.job_id()))
-
-            if self._status is JobStatus.ERROR and not partial:
+            # Job failed.
+            if partial:
+                self._retrieve_result(refresh=refresh)
+            if not partial or not self._result:
+                error_message = self.error_message()
+                if '\n' in error_message:
+                    error_message = ". Use job.error_message() to get more details"
+                else:
+                    error_message = ": " + error_message
                 raise IBMQJobFailureError(
-                    'Unable to retrieve result for job {}. Job has failed. '
-                    'Use job.error_message() to get more details.'.format(self.job_id()))
+                    'Unable to retrieve result for job {}. Job has failed{}'.format(
+                        self.job_id(), error_message))
+        else:
+            self._retrieve_result(refresh=refresh)
 
-        return self._retrieve_result(refresh=refresh)
+        return self._result
 
     def cancel(self) -> bool:
         """Attempt to cancel the job.
@@ -512,10 +521,7 @@ class IBMQJob(BaseJob):
 
         if not self._job_error_msg:
             # First try getting error messages from the result.
-            try:
-                self._retrieve_result()
-            except IBMQJobFailureError:
-                pass
+            self._retrieve_result()
 
         if not self._job_error_msg:
             # Then try refreshing the job
@@ -882,48 +888,30 @@ class IBMQJob(BaseJob):
 
         return self._status in required_status
 
-    def _retrieve_result(self, refresh: bool = False) -> Result:
+    def _retrieve_result(self, refresh: bool = False):
         """Retrieve the job result response.
 
         Args:
             refresh: If ``True``, re-query the server for the result.
                Otherwise return the cached value.
 
-        Returns:
-            The job result.
-
         Raises:
             IBMQJobApiError: If an unexpected error occurred when communicating
                 with the server.
-            IBMQJobFailureError: If the job failed and partial result could not
-                be retrieved.
-            IBMQJobInvalidStateError: If result is in an unsupported format.
         """
-        # pylint: disable=access-member-before-definition,attribute-defined-outside-init
-        result_response = None
         if not self._result or refresh:  # type: ignore[has-type]
             try:
                 result_response = self._api.job_result(self.job_id(), self._use_object_storage)
                 self._set_result(result_response)
-            except ApiError as err:
                 if self._status is JobStatus.ERROR:
-                    raise IBMQJobFailureError(
-                        'Unable to retrieve result for job {}. Job has failed. Use '
-                        'job.error_message() to get more details.'.format(self.job_id())) from err
+                    # Look for error message in result response.
+                    self._check_for_error_message(result_response)
+            except ApiError as err:
+                if self._status in [JobStatus.ERROR, JobStatus.CANCELLED]:
+                    pass
                 raise IBMQJobApiError(
                     'Unable to retrieve result for '
                     'job {}: {}'.format(self.job_id(), str(err))) from err
-            finally:
-                # In case partial results are returned or job failure, an error message is cached.
-                if result_response:
-                    self._check_for_error_message(result_response)
-
-        if self._status is JobStatus.ERROR and not self._result.results:
-            raise IBMQJobFailureError(
-                'Unable to retrieve result for job {}. Job has failed. '
-                'Use job.error_message() to get more details.'.format(self.job_id()))
-
-        return self._result
 
     def _set_result(self, raw_data: Optional[Dict]) -> None:
         """Set the job result.

--- a/releasenotes/notes/err-msg-in-exception-196b51c52539c8d4.yaml
+++ b/releasenotes/notes/err-msg-in-exception-196b51c52539c8d4.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    :meth:`qiskit.providers.ibmq.job.IBMQJob.result` raises an
+    :class:`~qiskit.providers.ibmq.job.IBMQJobFailureError` exception if
+    the job has failed. The exception message will now contain the reason
+    the job failed, if the entire job failed for a single reason.

--- a/test/utils.py
+++ b/test/utils.py
@@ -108,21 +108,35 @@ def cancel_job(job: IBMQJob, verify: bool = False) -> bool:
     return cancelled
 
 
-def submit_bad_job(backend: IBMQBackend) -> IBMQJob:
-    """Submit a job that is destined to fail.
+def submit_job_bad_shots(backend: IBMQBackend) -> IBMQJob:
+    """Submit a job that will fail due to too many shots.
 
     Args:
         backend: Backend to submit the job to.
 
     Returns:
-        Failed job.
+        Submitted job.
     """
-    # Submit a job that will fail.
     qobj = bell_in_qobj(backend=backend)
     qobj.config.shots = 10000  # Modify the number of shots to be an invalid amount.
     job_to_fail = backend.run(qobj, validate_qobj=True)
-    job_to_fail.wait_for_final_state()
     return job_to_fail
+
+
+def submit_job_one_bad_instr(backend: IBMQBackend) -> IBMQJob:
+    """Submit a job that contains one good and one bad instruction.
+
+    Args:
+        backend: Backend to submit the job to.
+
+    Returns:
+        Submitted job.
+    """
+    qc_new = transpile(ReferenceCircuits.bell(), backend)
+    qobj = assemble([qc_new]*2, backend=backend)
+    qobj.experiments[1].instructions[1].name = 'bad_instruction'
+    job = backend.run(qobj, validate_qobj=True)
+    return job
 
 
 def submit_and_cancel(backend: IBMQBackend) -> IBMQJob:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #710. This PR adds the actual reason for the job failure in the `IBMQJobFailureError` exception message, if the reason is a one-liner. If it has more than one liner (e.g. simulators return a reason for each experiment), then it continues to tell the user to use `job.error_message()`.


### Details and comments


