### PR TITLE
Update private job test

### DIFF
--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -21,7 +21,7 @@ from qiskit.result import Result
 from qiskit.execute import execute
 from qiskit.compiler import assemble, transpile
 from qiskit.test.reference_circuits import ReferenceCircuits
-from qiskit.providers.ibmq.exceptions import IBMQBackendApiError
+from qiskit.providers.ibmq.job.exceptions import IBMQJobApiError
 
 from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_provider, requires_device, requires_private_provider
@@ -124,7 +124,12 @@ class TestIBMQIntegration(IBMQTestCase):
 
         # Wait a bit for databases to update.
         time.sleep(2)
+        rjob = backend.retrieve_job(job.job_id())
 
-        with self.assertRaises(IBMQBackendApiError) as err_cm:
-            backend.retrieve_job(job.job_id())
-        self.assertIn('3250', str(err_cm.exception))
+        with self.assertRaises(IBMQJobApiError) as err_cm:
+            rjob.qobj()
+        self.assertIn('3202', str(err_cm.exception))
+
+        with self.assertRaises(IBMQJobApiError) as err_cm:
+            rjob.result()
+        self.assertIn('3202', str(err_cm.exception))

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -16,7 +16,7 @@
 
 import time
 from unittest import mock
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 import uuid
 
@@ -216,11 +216,11 @@ class TestIBMQJobAttributes(JobTestCase):
     def test_job_creation_date(self):
         """Test retrieving creation date, while ensuring it is in local time."""
         # datetime, before running the job, in local time.
-        start_datetime = datetime.now().replace(tzinfo=tz.tzlocal())
+        start_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) - timedelta(seconds=1)
         job = self.sim_backend.run(self.qobj, validate_qobj=True)
         job.result()
         # datetime, after the job is done running, in local time.
-        end_datetime = datetime.now().replace(tzinfo=tz.tzlocal())
+        end_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) + timedelta(seconds=1)
 
         self.assertTrue((start_datetime <= job.creation_date() <= end_datetime),
                         'job creation date {} is not '
@@ -230,11 +230,11 @@ class TestIBMQJobAttributes(JobTestCase):
     def test_time_per_step(self):
         """Test retrieving time per step, while ensuring the date times are in local time."""
         # datetime, before running the job, in local time.
-        start_datetime = datetime.now().replace(tzinfo=tz.tzlocal())
+        start_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) - timedelta(seconds=1)
         job = self.sim_backend.run(self.qobj, validate_qobj=True)
         job.result()
         # datetime, after the job is done running, in local time.
-        end_datetime = datetime.now().replace(tzinfo=tz.tzlocal())
+        end_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) + timedelta(seconds=1)
 
         self.assertTrue(job.time_per_step())
         for step, time_data in job.time_per_step().items():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR updates `test_private_job` for an API change - that private jobs can now be retrieved, just not their Qobj/results. 

It also adds a 1 second timedelta to `test_job_creation_date` and `test_time_per_step` more tolerant, since local and API don't have synchronized clocks. 

### Details and comments


