### PR TITLE
Deprecate Qconfig.py

### DIFF
--- a/qiskit/providers/ibmq/credentials/qconfig.py
+++ b/qiskit/providers/ibmq/credentials/qconfig.py
@@ -15,8 +15,9 @@
 """Utilities for reading credentials from the deprecated ``Qconfig.py`` file."""
 
 import os
+import warnings
 from collections import OrderedDict
-from typing import Dict, Tuple
+from typing import Dict
 from importlib.util import module_from_spec, spec_from_file_location
 
 from .credentials import Credentials
@@ -42,14 +43,11 @@ def read_credentials_from_qconfig() -> Dict[HubGroupProject, Credentials]:
     if not os.path.isfile(DEFAULT_QCONFIG_FILE):
         return OrderedDict()
     else:
-        # Note this is nested inside the else to prevent some tools marking
-        # the whole method as deprecated.
-        pass
-        # TODO: reintroduce when we decide on deprecating
-        # warnings.warn(
-        #     "Using 'Qconfig.py' for storing the credentials will be deprecated in"
-        #     "upcoming versions (>0.6.0). Using .qiskitrc is recommended",
-        #     DeprecationWarning)
+        # TODO: remove in 0.9.
+        warnings.warn(
+            "Using 'Qconfig.py' for storing credentials is deprecated and will "
+            "be removed in the next release. Please use .qiskitrc instead.",
+            category=DeprecationWarning, stacklevel=4)
 
     try:
         spec = spec_from_file_location('Qconfig', DEFAULT_QCONFIG_FILE)

--- a/releasenotes/notes/deprecate-qconfig-4ab8cd1f988b5624.yaml
+++ b/releasenotes/notes/deprecate-qconfig-4ab8cd1f988b5624.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    Use of `Qconfig.py` to save IBM Quantum Experience credentials is deprecated
+    and will be removed in the next release. You should use `qiskitrc`
+    (the default) instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #616 .
`qiskitrc` replaced `Qconfig.py` 2 years ago, but the latter was never deprecated. This PR deprecates `Qconfig.py` so it can be removed in the next release. 


### Details and comments


