### PR TITLE
Use Linux for cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,17 +197,16 @@ jobs:
 
     # "conditional tests" stage
     ###########################################################################
-    # slow tests using OSX, Python 3.6.5
+    # slow tests using Linux, Python 3.6
     - stage: conditional tests
-      <<: *stage_osx
       if: type = cron
+      <<: *stage_linux
+      python: 3.6
+      name: slow test
       env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.6.5
         - QISKIT_TESTS=run_slow
       script:
-        # effectively increases timeout to 1h.
-        - travis_wait 60 make test
+        - make test
     # test with terra master, using GNU/Linux, Python 3.8
     - if: type = cron
       <<: *stage_linux
@@ -217,7 +216,7 @@ jobs:
       env:
         - QISKIT_TESTS=run_slow
       script:
-        - travis_wait 60 make test
+        - make test
     # additional Windows tests
     # Windows, Python 3.7
     - if: type = cron

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -75,6 +75,7 @@ class TestIBMQJobManager(IBMQTestCase):
                 = BaseFakeAccountClient()
             self._fake_api_backend._provider = self._fake_api_provider
             self._fake_api_provider.backends._provider = self._fake_api_provider
+            self._fake_api_backend._configuration.max_experiments = 10
         return self._fake_api_backend
 
     @property


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The nightly cron jobs that run slow tests have been failing with 137, indicating not enough resources. While some investigation didn't show any spike in memory usage, switching to Linux (which gets more resources) may help solving this issue.

Another minor change is to reduce the number of circuits being transpiled in parallel in some test cases from 300 to 10, with the hope to also reduce memory usage. 


### Details and comments


