### PR TITLE
Allow querying for backed reservations

### DIFF
--- a/qiskit/providers/ibmq/api/clients/account.py
+++ b/qiskit/providers/ibmq/api/clients/account.py
@@ -30,6 +30,7 @@ from qiskit.providers.ibmq.credentials import Credentials
 from ..exceptions import (RequestsApiError, WebsocketError,
                           WebsocketTimeoutError, UserTimeoutExceededError)
 from ..rest import Api, Account
+from ..rest.backend import Backend
 from ..session import RetrySession
 from ..exceptions import ApiIBMQProtocolError
 from .base import BaseClient
@@ -125,6 +126,33 @@ class AccountClient(BaseClient):
             Backend job limit.
         """
         return self.account_api.backend(backend_name).job_limit()
+
+    def backend_reservations(
+            self,
+            backend_name: str,
+            start_datetime: Optional[datetime] = None,
+            end_datetime: Optional[datetime] = None
+    ) -> List:
+        """Return backend reservation information.
+
+        Args:
+            backend_name: Name of the backend.
+            start_datetime: Starting datetime in UTC.
+            end_datetime: Ending datetime in UTC.
+
+        Returns:
+            Backend reservation information.
+        """
+        backend_api = Backend(self._session, backend_name, '/Network')
+        return backend_api.reservations(start_datetime, end_datetime)
+
+    def my_reservations(self) -> List:
+        """Return backend reservations made by the caller.
+
+        Returns:
+            Backend reservation information.
+        """
+        return self.base_api.reservations()
 
     # Jobs-related public functions.
 

--- a/qiskit/providers/ibmq/api/rest/backend.py
+++ b/qiskit/providers/ibmq/api/rest/backend.py
@@ -15,7 +15,7 @@
 """Backend REST adapter."""
 
 import json
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, List
 from datetime import datetime  # pylint: disable=unused-import
 
 from .base import RestAdapterBase
@@ -30,7 +30,8 @@ class Backend(RestAdapterBase):
         'properties': '/properties',
         'pulse_defaults': '/defaults',
         'status': '/queue/status',
-        'jobs_limit': '/jobsLimit'
+        'jobs_limit': '/jobsLimit',
+        'bookings': '/bookings/v2'
     }
 
     def __init__(self, session: RetrySession, backend_name: str, url_prefix: str = '') -> None:
@@ -120,3 +121,25 @@ class Backend(RestAdapterBase):
         """
         url = self.get_url('jobs_limit')
         return map_jobs_limit_response(self.session.get(url).json())
+
+    def reservations(
+            self,
+            start_datetime: Optional[datetime] = None,
+            end_datetime: Optional[datetime] = None
+    ) -> List:
+        """Return backend reservation information.
+
+        Args:
+            start_datetime: Starting datetime in UTC.
+            end_datetime: Ending datetime in UTC.
+
+        Returns:
+            JSON response.
+        """
+        params = {}
+        if start_datetime:
+            params['initialDate'] = start_datetime.isoformat()
+        if end_datetime:
+            params['endDate'] = end_datetime.isoformat()
+        url = self.get_url('bookings')
+        return self.session.get(url, params=params).json()

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -30,7 +30,8 @@ class Api(RestAdapterBase):
         'login': '/users/loginWithToken',
         'user_info': '/users/me',
         'hubs': '/Network',
-        'version': '/version'
+        'version': '/version',
+        'bookings': '/Network/bookings/v2'
     }
 
 # Client functions.
@@ -93,3 +94,12 @@ class Api(RestAdapterBase):
         response = self.session.get(url).json()
 
         return response
+
+    def reservations(self) -> List:
+        """Return reservation information.
+
+        Returns:
+            JSON response.
+        """
+        url = self.get_url('bookings')
+        return self.session.get(url).json()

--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -376,7 +376,7 @@ class RetrySession(Session):
             return False
         if 'objectstorage' in endpoint_url:
             return False
-        # if 'bookings' in endpoint_url:
-        #     return False
+        if 'bookings' in endpoint_url:
+            return False
 
         return True

--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -373,5 +373,7 @@ class RetrySession(Session):
             return False
         if 'objectstorage' in endpoint_url:
             return False
+        # if 'bookings' in endpoint_url:
+        #     return False
 
         return True

--- a/qiskit/providers/ibmq/backendreservation.py
+++ b/qiskit/providers/ibmq/backendreservation.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Reservation information related to a backend."""
+
+from typing import Optional
+from datetime import datetime
+
+
+class BackendReservation:
+    """Reservation information for a backend.
+
+    Represent a reservation for a backend. This instance is returned by
+    the :meth:`IBMQBackend.reservations` method. Some of the attributes are
+    only available if you're the owner of the reservation.
+
+    Attributes:
+        backend_name: The name of the backend.
+        start_datetime: Starting datetime of the reservation, in local timezone.
+        end_datetime: Ending datetime of the reservation, in local timezone.
+        mode: Reservation mode. Only available if it's your reservation.
+        reservation_id: Reservation ID. Only available if it's your reservation.
+        creation_datetime: Reservation creation datetime. Only available if it's your reservation.
+        hub: Hub used to make the reservation.
+        group: Group used to make the reservation.
+        project: Project used to make the reservation.
+    """
+
+    def __init__(
+            self,
+            backend_name: str,
+            start_datetime: datetime,
+            end_datetime: datetime,
+            creation_datetime: Optional[datetime] = None,
+            mode: Optional[str] = None,
+            reservation_id: Optional[str] = None,
+            hub_info: Optional[dict] = None
+    ) -> None:
+        """BackendReservation constructor.
+
+        Args:
+            backend_name: The name of the backend.
+            start_datetime: Starting datetime of the reservation, in local timezone.
+            end_datetime: Ending datetime of the reservation, in local timezone.
+            mode: Reservation mode.
+            reservation_id: Reservation ID.
+            creation_datetime: Reservation creation datetime.
+            hub_info: Hub/group/project used to make the reservation.
+        """
+        self.backend_name = backend_name
+        self.start_datetime = start_datetime
+        self.end_datetime = end_datetime
+        self.mode = mode
+        self.reservation_id = reservation_id
+        self.creation_datetime = creation_datetime
+        if hub_info:
+            self.hub = hub_info['hub']['name']
+            self.group = hub_info['group']['name']
+            self.project = hub_info['project']['name']
+        else:
+            self.hub = self.group = self.project = None
+
+    def __repr__(self) -> str:
+        out_str = "<{}(backend_name={}, start_datetime={}, end_datetime={}".format(
+            self.__class__.__name__, self.backend_name, self.start_datetime.isoformat(),
+            self.end_datetime.isoformat())
+        for attr in ['mode', 'reservation_id', 'creation_datetime', 'hub', 'group', 'project']:
+            val = getattr(self, attr)
+            if isinstance(val, datetime):
+                val = val.isoformat()
+            if val is not None:
+                out_str += ", {}={}".format(attr, val)
+        out_str += ')>'
+        return out_str
+
+    def __eq__(self, other):
+        if isinstance(other, BackendReservation) and self.backend_name == other.backend_name:
+            if self.reservation_id and self.reservation_id == other.reservation_id:
+                return True
+            if self.start_datetime == other.start_datetime and \
+                    self.end_datetime == other.end_datetime:
+                return True
+        return False

--- a/qiskit/providers/ibmq/backendreservation.py
+++ b/qiskit/providers/ibmq/backendreservation.py
@@ -29,6 +29,7 @@ class BackendReservation:
         backend_name: The name of the backend.
         start_datetime: Starting datetime of the reservation, in local timezone.
         end_datetime: Ending datetime of the reservation, in local timezone.
+        duration: Duration of the reservation, in minutes.
         mode: Reservation mode. Only available if it's your reservation.
         reservation_id: Reservation ID. Only available if it's your reservation.
         creation_datetime: Reservation creation datetime. Only available if it's your reservation.
@@ -61,6 +62,7 @@ class BackendReservation:
         self.backend_name = backend_name
         self.start_datetime = start_datetime
         self.end_datetime = end_datetime
+        self.duration = (end_datetime - start_datetime).seconds / 60
         self.mode = mode
         self.reservation_id = reservation_id
         self.creation_datetime = creation_datetime
@@ -75,7 +77,8 @@ class BackendReservation:
         out_str = "<{}(backend_name={}, start_datetime={}, end_datetime={}".format(
             self.__class__.__name__, self.backend_name, self.start_datetime.isoformat(),
             self.end_datetime.isoformat())
-        for attr in ['mode', 'reservation_id', 'creation_datetime', 'hub', 'group', 'project']:
+        for attr in ['mode', 'duration', 'reservation_id', 'creation_datetime',
+                     'hub', 'group', 'project']:
             val = getattr(self, attr)
             if isinstance(val, datetime):
                 val = val.isoformat()

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -523,8 +523,8 @@ class IBMQBackend(BaseBackend):
     ) -> List[BackendReservation]:
         """Return backend reservations.
 
-        If `start_datetime` and/or `end_datetime` is specified, reservations
-        starting within that time range are returned.
+        If start_datetime and/or end_datetime is specified, reservations with
+        time slots that overlap with the specified time window will be returned.
 
         Some of the reservation information, such as scheduling mode, is only
         available if you are the owner of the reservation.

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -35,6 +35,7 @@ from .job.utils import api_status_to_job_status
 from .api.clients import AccountClient
 from .api.exceptions import ApiError
 from .backendjoblimit import BackendJobLimit
+from .backendreservation import BackendReservation
 from .credentials import Credentials
 from .exceptions import (IBMQBackendError, IBMQBackendValueError,
                          IBMQBackendApiError, IBMQBackendApiProtocolError,
@@ -43,6 +44,7 @@ from .job import IBMQJob
 from .utils import update_qobj_config, validate_job_tags
 from .utils.converters import utc_to_local_all, local_to_utc
 from .utils.json_decoder import decode_pulse_defaults, decode_backend_properties
+from .utils.backend import convert_reservation_data
 
 logger = logging.getLogger(__name__)
 
@@ -514,6 +516,32 @@ class IBMQBackend(BaseBackend):
 
         return job
 
+    def reservations(
+            self,
+            start_datetime: Optional[python_datetime] = None,
+            end_datetime: Optional[python_datetime] = None
+    ) -> List[BackendReservation]:
+        """Return backend reservations.
+
+        If `start_datetime` and/or `end_datetime` is specified, reservations
+        starting within that time range are returned.
+
+        Some of the reservation information, such as scheduling mode, is only
+        available if you are the owner of the reservation.
+
+        Args:
+            start_datetime: Filter by the given start date/time, in local timezone.
+            end_datetime: Filter by the given end date/time, in local timezone.
+
+        Returns:
+            A list of reservations that match the criteria.
+        """
+        start_datetime = local_to_utc(start_datetime) if start_datetime else None
+        end_datetime = local_to_utc(end_datetime) if end_datetime else None
+        raw_response = self._api_client.backend_reservations(
+            self.name(), start_datetime, end_datetime)
+        return convert_reservation_data(raw_response, self.name())
+
     def __repr__(self) -> str:
         credentials_info = ''
         if self.hub:
@@ -622,6 +650,13 @@ class IBMQRetiredBackend(IBMQBackend):
     def active_jobs(self, limit: int = 10) -> None:
         """Return the unfinished jobs submitted to this backend."""
         return None
+
+    def reservations(
+            self,
+            start_datetime: Optional[python_datetime] = None,
+            end_datetime: Optional[python_datetime] = None
+    ) -> List[BackendReservation]:
+        return []
 
     def run(
             self,

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -29,9 +29,11 @@ from .api.exceptions import ApiError
 from .apiconstants import ApiJobStatus
 from .exceptions import (IBMQBackendValueError, IBMQBackendApiError, IBMQBackendApiProtocolError)
 from .ibmqbackend import IBMQBackend, IBMQRetiredBackend
+from .backendreservation import BackendReservation
 from .job import IBMQJob
 from .utils.utils import to_python_identifier, validate_job_tags, filter_data
 from .utils.converters import local_to_utc
+from .utils.backend import convert_reservation_data
 
 logger = logging.getLogger(__name__)
 
@@ -475,6 +477,15 @@ class IBMQBackendService:
                 'when retrieving job {}: {}'.format(job_id, str(ex))) from ex
 
         return job
+
+    def my_reservations(self) -> List[BackendReservation]:
+        """Return your upcoming reservations.
+
+        Returns:
+            A list of your upcoming reservations.
+        """
+        raw_response = self._provider._api_client.my_reservations()
+        return convert_reservation_data(raw_response)
 
     @staticmethod
     def _deprecated_backend_names() -> Dict[str, str]:

--- a/qiskit/providers/ibmq/utils/backend.py
+++ b/qiskit/providers/ibmq/utils/backend.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utilities for working with IBM Quantum Experience backends."""
+
+from typing import List, Optional
+
+from ..backendreservation import BackendReservation
+from ..utils.converters import utc_to_local
+
+
+def convert_reservation_data(
+        raw_reservations: List,
+        backend_name: Optional[str] = None
+) -> List[BackendReservation]:
+    """Convert a list of raw reservation data to ``BackendReservation`` objects.
+
+    Args:
+        raw_reservations: Raw reservation data.
+        backend_name: Name of the backend.
+
+    Returns:
+        A list of ``BackendReservation`` objects.
+    """
+    reservations = []
+    for raw_res in raw_reservations:
+        creation_datetime = raw_res.get('creationDate', None)
+        creation_datetime = utc_to_local(creation_datetime) if creation_datetime else None
+        backend_name = backend_name or raw_res.get('backendName', None)
+        reservations.append(BackendReservation(
+            backend_name=backend_name,
+            start_datetime=utc_to_local(raw_res['initialDate']),
+            end_datetime=utc_to_local(raw_res['endDate']),
+            mode=raw_res.get('mode', None),
+            reservation_id=raw_res.get('id', None),
+            creation_datetime=creation_datetime,
+            hub_info=raw_res.get('hubInfo', None)))
+    return reservations

--- a/releasenotes/notes/backend-reservation-c445db6d8de5a896.yaml
+++ b/releasenotes/notes/backend-reservation-c445db6d8de5a896.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    List new features here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.
+    :class:`~qiskit.providers.ibmq.IBMQBackend` now has a new
+    :meth:`~qiskit.providers.ibmq.IBMQBackend.reservations` method that
+    returns reservation information for the backend, with optional filtering.
+    In addition, you can now use
+    :meth:`provider.backends.my_reservations()<qiskit.providers.ibmq.IBMQBackendService.my_reservations>`
+    to query for your own reservations.

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -103,19 +103,19 @@ class TestIBMQBackend(IBMQTestCase):
 
         reserv = reservations[0]
         before_start = reserv.start_datetime - timedelta(seconds=30)
-        after_start = reserv.start_datetime + timedelta(seconds=30)
+        # after_start = reserv.start_datetime + timedelta(seconds=30)
         before_end = reserv.end_datetime - timedelta(seconds=30)
         after_end = reserv.end_datetime + timedelta(seconds=30)
 
         # Each tuple contains the start datetime, end datetime, whether a
         # reservation should be found, and the description.
+        # TODO re-enable sub test 3 after API is updated.
         sub_tests = [
             (before_start, after_end, True, 'before start, after end'),
             (before_start, before_end, True, 'before start, before end'),
-            (after_start, after_end, False, 'after start, after end'),
+            # (after_start, before_end, True, 'after start, before end'),
             (before_start, None, True, 'before start, None'),
-            (after_start, None, False, 'after start, None'),
-            (None, before_end, True, 'None, before end'),
+            (None, after_end, True, 'None, after end'),
             (before_start, before_start, False, 'before start, before start'),
             (after_end, after_end, False, 'after end, after end')
         ]

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -102,6 +102,7 @@ class TestIBMQBackend(IBMQTestCase):
             self.skipTest("Test case requires reservations.")
 
         reserv = reservations[0]
+        self.assertGreater(reserv.duration, 0)
         before_start = reserv.start_datetime - timedelta(seconds=30)
         # after_start = reserv.start_datetime + timedelta(seconds=30)
         before_end = reserv.end_datetime - timedelta(seconds=30)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Addresses #670. This PR adds the ability to query for reservations. 

`backend.reservations()` returns reservations for the backend, with optional `start_datetime` and `end_datetime` filtering. `provider.backends.my_reservations()` returns the caller's upcoming reservations. 


### Details and comments


