### PR TITLE
Take reservations into account in least_busy

### DIFF
--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -114,7 +114,7 @@ QISKIT_IBMQ_PROVIDER_LOG_FILE = 'QISKIT_IBMQ_PROVIDER_LOG_FILE'
 
 def least_busy(
         backends: List[BaseBackend],
-        reservation_lookahead: Optional[int] = 6
+        reservation_lookahead: Optional[int] = 60
 ) -> BaseBackend:
     """Return the least busy backend from a list.
 
@@ -145,10 +145,10 @@ def least_busy(
         for back in backends:
             if not back.status().operational:
                 continue
-            if reservation_lookahead:
+            if reservation_lookahead and isinstance(back, IBMQBackend):
                 now = datetime.now()
                 end_time = now + timedelta(minutes=reservation_lookahead)
-                if isinstance(back, IBMQBackend) and back.reservations(now, end_time):
+                if back.reservations(now, end_time):
                     continue
             candidates.append(back)
         if not candidates:

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -121,8 +121,11 @@ def least_busy(backends: List[BaseBackend], reservation_free: Optional[int] = 60
 
     Args:
         backends: The backends to choose from.
-        reservation_free: The number of minutes the backend needs to be free
-            of any reservations. If ``None``, reservations are not taken into consideration.
+        reservation_free: The number of minutes the backend needs not have
+            any reservations to be considered available. For example, if
+            the default value of 60 is used, then any backends that have
+            reservations in the next 60 minutes are considered unavailable.
+            If ``None``, reservations are not taken into consideration.
 
     Returns:
         The backend with the fewest number of pending jobs.

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -142,11 +142,11 @@ def least_busy(
                         'backend from an empty list.') from None
     try:
         candidates = []
+        now = datetime.now()
         for back in backends:
             if not back.status().operational:
                 continue
             if reservation_lookahead and isinstance(back, IBMQBackend):
-                now = datetime.now()
                 end_time = now + timedelta(minutes=reservation_lookahead)
                 if back.reservations(now, end_time):
                     continue

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -81,7 +81,8 @@ Exceptions
 """
 
 import logging
-from typing import List
+from typing import List, Optional
+from datetime import datetime, timedelta
 
 from .ibmqfactory import IBMQFactory
 from .ibmqbackend import IBMQBackend, BaseBackend
@@ -111,7 +112,7 @@ QISKIT_IBMQ_PROVIDER_LOG_FILE = 'QISKIT_IBMQ_PROVIDER_LOG_FILE'
 """The environment variable name that is used to set the file for the IBM Quantum logger."""
 
 
-def least_busy(backends: List[BaseBackend]) -> BaseBackend:
+def least_busy(backends: List[BaseBackend], reservation_free: Optional[int] = 60) -> BaseBackend:
     """Return the least busy backend from a list.
 
     Return the least busy available backend for those that
@@ -120,20 +121,34 @@ def least_busy(backends: List[BaseBackend]) -> BaseBackend:
 
     Args:
         backends: The backends to choose from.
+        reservation_free: The number of minutes the backend needs to be free
+            of any reservations. If ``None``, reservations are not taken into consideration.
 
     Returns:
         The backend with the fewest number of pending jobs.
 
     Raises:
-        IBMQError: If the backends list is empty or if a backend in the list
+        IBMQError: If the backends list is empty, or if none of the backends
+            is available, or if a backend in the list
             does not have the ``pending_jobs`` attribute in its status.
     """
-    try:
-        return min([b for b in backends if b.status().operational],
-                   key=lambda b: b.status().pending_jobs)
-    except (ValueError, TypeError):
+    if not backends:
         raise IBMQError('Unable to find the least_busy '
                         'backend from an empty list.') from None
+    try:
+        candidates = []
+        for back in backends:
+            if not back.status().operational:
+                continue
+            if reservation_free:
+                now = datetime.now()
+                end_time = now + timedelta(minutes=reservation_free)
+                if isinstance(back, IBMQBackend) and back.reservations(now, end_time):
+                    continue
+            candidates.append(back)
+        if not candidates:
+            raise IBMQError('No backend matches the criteria.')
+        return min(candidates, key=lambda b: b.status().pending_jobs)
     except AttributeError as ex:
         raise IBMQError('A backend in the list does not have the `pending_jobs` '
                         'attribute in its status.') from ex

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -112,7 +112,10 @@ QISKIT_IBMQ_PROVIDER_LOG_FILE = 'QISKIT_IBMQ_PROVIDER_LOG_FILE'
 """The environment variable name that is used to set the file for the IBM Quantum logger."""
 
 
-def least_busy(backends: List[BaseBackend], reservation_free: Optional[int] = 60) -> BaseBackend:
+def least_busy(
+        backends: List[BaseBackend],
+        reservation_lookahead: Optional[int] = 6
+) -> BaseBackend:
     """Return the least busy backend from a list.
 
     Return the least busy available backend for those that
@@ -121,10 +124,9 @@ def least_busy(backends: List[BaseBackend], reservation_free: Optional[int] = 60
 
     Args:
         backends: The backends to choose from.
-        reservation_free: The number of minutes the backend needs not have
-            any reservations to be considered available. For example, if
-            the default value of 60 is used, then any backends that have
-            reservations in the next 60 minutes are considered unavailable.
+        reservation_lookahead: A backend is considered unavailable if it
+            has reservations in the next ``n`` minutes, where ``n`` is
+            the value of ``reservation_lookahead``.
             If ``None``, reservations are not taken into consideration.
 
     Returns:
@@ -143,9 +145,9 @@ def least_busy(backends: List[BaseBackend], reservation_free: Optional[int] = 60
         for back in backends:
             if not back.status().operational:
                 continue
-            if reservation_free:
+            if reservation_lookahead:
                 now = datetime.now()
-                end_time = now + timedelta(minutes=reservation_free)
+                end_time = now + timedelta(minutes=reservation_lookahead)
                 if isinstance(back, IBMQBackend) and back.reservations(now, end_time):
                     continue
             candidates.append(back)

--- a/qiskit/providers/ibmq/backendreservation.py
+++ b/qiskit/providers/ibmq/backendreservation.py
@@ -62,7 +62,7 @@ class BackendReservation:
         self.backend_name = backend_name
         self.start_datetime = start_datetime
         self.end_datetime = end_datetime
-        self.duration = (end_datetime - start_datetime).seconds / 60
+        self.duration = int((end_datetime - start_datetime).seconds / 60)
         self.mode = mode
         self.reservation_id = reservation_id
         self.creation_datetime = creation_datetime

--- a/releasenotes/notes/least-busy-reservations-156f81daf69c5e56.yaml
+++ b/releasenotes/notes/least-busy-reservations-156f81daf69c5e56.yaml
@@ -2,7 +2,8 @@
 features:
   - |
     The :func:`~qiskit.providers.ibmq.least_busy` function now takes a new,
-    optional parameter ``reservation_free`` that specifies the number of
-    minutes a backend needs not have any reservations to be considered available.
+    optional parameter ``reservation_lookahead``. If specified or defaulted to,
+    a backend is considered unavailable if it has reservations in the next
+    ``n`` minutes, where ``n`` is the value of ``reservation_lookahead``.
     For example, if the default value of 60 is used, then any
     backends that have reservations in the next 60 minutes are considered unavailable.

--- a/releasenotes/notes/least-busy-reservations-156f81daf69c5e56.yaml
+++ b/releasenotes/notes/least-busy-reservations-156f81daf69c5e56.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The :func:`~qiskit.providers.ibmq.least_busy` function now takes a new,
+    optional parameter ``reservation_free`` that specifies the number of
+    minutes a backend needs not have any reservations to be considered available.
+    For example, if the default value of 60 is used, then any
+    backends that have reservations in the next 60 minutes are considered unavailable.

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -14,7 +14,11 @@
 
 """Backends Filtering Test."""
 
+from datetime import datetime
+from dateutil import tz
+
 from qiskit.providers.ibmq import least_busy
+from qiskit.providers.ibmq import IBMQError
 
 from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_provider, requires_device
@@ -76,3 +80,23 @@ class TestBackendFilters(IBMQTestCase):
         backends = self.provider.backends()
         least_busy_backend = least_busy(backends)
         self.assertTrue(least_busy_backend)
+
+    def test_filter_least_busy_reservation(self):
+        """Test filtering by least busy function, with reservations."""
+        backend = reservations = None
+        for backend in self.provider.backends(simulator=False, operational=True):
+            reservations = backend.reservations()
+            if reservations:
+                break
+
+        if not reservations:
+            self.skipTest("Test case requires reservations.")
+
+        reserv = reservations[0]
+        now = datetime.now().astimezone(tz.tzlocal())
+        window = 60
+        if reserv.start_datetime > now:
+            window = (reserv.start_datetime - now).seconds * 60
+        self.assertRaises(IBMQError, least_busy, [backend], window)
+
+        self.assertEqual(least_busy([backend], None), backend)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR introduces a new parameter, `reservation_lookahead` to the `least_busy()` function. If specified or defaulted to, a backend is considered unavailable if it has reservations in the next `n` minutes, where `n` is the value of `reservation_lookahead`.



### Details and comments

