### PR TITLE
Suppress timeout error from waiting for old job

### DIFF
--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -127,7 +127,12 @@ class ManagedJob:
                         logger.warning("Job limit reached, waiting for job %s to finish "
                                        "before submitting the next one.",
                                        oldest_running.job_id())
-                        oldest_running.wait_for_final_state(timeout=300)
+                        try:
+                            oldest_running.wait_for_final_state(timeout=300)
+                        except Exception as err:  # pylint: disable=broad-except
+                            # Don't kill the submit if unable to wait for old job.
+                            logger.debug("An error occurred while waiting for "
+                                         "job %s to finish: %s", oldest_running.job_id(), err)
 
         except Exception as err:  # pylint: disable=broad-except
             warnings.warn("Unable to submit job for experiments {}-{}: {}".format(

--- a/releasenotes/notes/jm-timeout-error-e166adbbaed8a0a6.yaml
+++ b/releasenotes/notes/jm-timeout-error-e166adbbaed8a0a6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :class:`~qiskit.providers.ibmq.managed.IBMQJobManager` has been updated so
+    that if a time out happens while waiting for an old job to finish, the
+    time out error doesn't prevent a new job to be submitted. Fixes
+    `#737 <https://github.com/Qiskit/qiskit-ibmq-provider/issues/737>`_

--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -323,9 +323,9 @@ class JobTimeoutClient(BaseFakeAccountClient):
         self._fail_count = max_fail_count
         super().__init__(*args, **kwargs)
 
-    def job_final_status(self, *_args, **_kwargs):
+    def job_final_status(self, job_id, *_args, **_kwargs):
         """Wait until the job progress to a final state."""
         if self._fail_count != 0:
             self._fail_count -= 1
             raise UserTimeoutExceededError('Job timed out!')
-        return super().job_final_status(*_args, **_kwargs)
+        return super().job_final_status(job_id, *_args, **_kwargs)

--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -23,7 +23,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 
 from qiskit.test.mock.backends.poughkeepsie.fake_poughkeepsie import FakePoughkeepsie
 from qiskit.providers.ibmq.apiconstants import ApiJobStatus, API_JOB_FINAL_STATES, ApiJobShareLevel
-from qiskit.providers.ibmq.api.exceptions import RequestsApiError
+from qiskit.providers.ibmq.api.exceptions import RequestsApiError, UserTimeoutExceededError
 
 
 VALID_RESULT_RESPONSE = {
@@ -309,7 +309,23 @@ class JobSubmitFailClient(BaseFakeAccountClient):
 
     def job_submit(self, *_args, **_kwargs):  # pylint: disable=arguments-differ
         """Failing job submit."""
-        if self._fail_count > 0:
+        if self._fail_count != 0:
             self._fail_count -= 1
             raise RequestsApiError('Job submit failed!')
         return super().job_submit(*_args, **_kwargs)
+
+
+class JobTimeoutClient(BaseFakeAccountClient):
+    """Fake AccountClient used to fail a job submit."""
+
+    def __init__(self, *args, max_fail_count=-1, **kwargs):
+        """JobTimeoutClient constructor."""
+        self._fail_count = max_fail_count
+        super().__init__(*args, **kwargs)
+
+    def job_final_status(self, *_args, **_kwargs):
+        """Wait until the job progress to a final state."""
+        if self._fail_count != 0:
+            self._fail_count -= 1
+            raise UserTimeoutExceededError('Job timed out!')
+        return super().job_final_status(*_args, **_kwargs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #737. This PR suppresses job timeout error raised when an old job doesn't finish within the hard coded 5 minutes. 


### Details and comments


