### PR TITLE
Use least_busy backend in tutorial when possible

### DIFF
--- a/docs/tutorials/2_jupyter_tools.ipynb
+++ b/docs/tutorials/2_jupyter_tools.ipynb
@@ -75,7 +75,16 @@
      "start_time": "2019-08-09T14:27:20.241689Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/ibmqfactory.py:192: UserWarning: Timestamps in IBMQ backend properties, jobs, and job results are all now in local time instead of UTC.\n",
+      "  warnings.warn('Timestamps in IBMQ backend properties, jobs, and job results '\n"
+     ]
+    }
+   ],
    "source": [
     "IBMQ.load_account();"
    ]
@@ -192,9 +201,39 @@
      "start_time": "2019-08-09T14:28:37.321568Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception in thread Thread-36:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 932, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 870, in run\n",
+      "    self._target(*self._args, **self._kwargs)\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/dashboard.py\", line 74, in _add_device_to_list\n",
+      "    device_pane = make_backend_widget(backend)\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py\", line 39, in make_backend_widget\n",
+      "    props = backend.properties().to_dict()\n",
+      "AttributeError: 'NoneType' object has no attribute 'to_dict'\n",
+      "Exception in thread Thread-35:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 932, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 870, in run\n",
+      "    self._target(*self._args, **self._kwargs)\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/dashboard.py\", line 74, in _add_device_to_list\n",
+      "    device_pane = make_backend_widget(backend)\n",
+      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py\", line 39, in make_backend_widget\n",
+      "    props = backend.properties().to_dict()\n",
+      "AttributeError: 'NoneType' object has no attribute 'to_dict'\n"
+     ]
+    }
+   ],
    "source": [
-    "backend = provider.get_backend('ibmq_essex')\n",
+    "from qiskit.providers.ibmq import least_busy\n",
+    "backend = least_busy(provider.backends(simulator=False, filters=lambda b: b.configuration().n_qubits >= 5))\n",
     "\n",
     "qc = QuantumCircuit(2, 2)\n",
     "qc.h(0)\n",
@@ -278,12 +317,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db5e5bfa612f4415a570850b32a0c54f",
+       "model_id": "9bae823cdfe442cea28fd753a1d47db8",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Card(children=[Toolbar(children=[ToolbarTitle(children=['ibmq_essex @ (ibm-q/open/main)'], style_='color:white…"
+       "Card(children=[Toolbar(children=[ToolbarTitle(children=['ibmq_ourense @ (ibm-q/open/main)'], style_='color:whi…"
       ]
      },
      "metadata": {},
@@ -292,7 +331,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_essex') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 8,
@@ -313,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-09T14:39:13.642631Z",
@@ -324,8 +363,8 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.15.0</td></tr><tr><td>Terra</td><td>0.12.0</td></tr><tr><td>Aer</td><td>0.4.0</td></tr><tr><td>Ignis</td><td>0.2.0</td></tr><tr><td>Aqua</td><td>0.6.4</td></tr><tr><td>IBM Q Provider</td><td>0.5.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.6.7 (v3.6.7:6ec5cf24b7, Oct 20 2018, 03:02:14) \n",
-       "[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Tue Mar 24 13:02:33 2020 EDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.20.0</td></tr><tr><td>Terra</td><td>0.15.1</td></tr><tr><td>Aer</td><td>0.6.1</td></tr><tr><td>Ignis</td><td>0.4.0</td></tr><tr><td>Aqua</td><td>0.7.5</td></tr><tr><td>IBM Q Provider</td><td>0.8.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.1 (default, Jul 15 2020, 18:48:27) \n",
+       "[Clang 11.0.3 (clang-1103.0.32.62)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Sep 04 09:11:57 2020 EDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -377,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.1"
   },
   "varInspector": {
    "cols": {

--- a/docs/tutorials/2_jupyter_tools.ipynb
+++ b/docs/tutorials/2_jupyter_tools.ipynb
@@ -75,16 +75,7 @@
      "start_time": "2019-08-09T14:27:20.241689Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/ibmqfactory.py:192: UserWarning: Timestamps in IBMQ backend properties, jobs, and job results are all now in local time instead of UTC.\n",
-      "  warnings.warn('Timestamps in IBMQ backend properties, jobs, and job results '\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "IBMQ.load_account();"
    ]
@@ -201,36 +192,7 @@
      "start_time": "2019-08-09T14:28:37.321568Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Exception in thread Thread-36:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 932, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 870, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/dashboard.py\", line 74, in _add_device_to_list\n",
-      "    device_pane = make_backend_widget(backend)\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py\", line 39, in make_backend_widget\n",
-      "    props = backend.properties().to_dict()\n",
-      "AttributeError: 'NoneType' object has no attribute 'to_dict'\n",
-      "Exception in thread Thread-35:\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 932, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/lib/python3.8/threading.py\", line 870, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/dashboard.py\", line 74, in _add_device_to_list\n",
-      "    device_pane = make_backend_widget(backend)\n",
-      "  File \"/Users/jessieyu/.pyenv/versions/3.8.1/envs/qiskit-meta/lib/python3.8/site-packages/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py\", line 39, in make_backend_widget\n",
-      "    props = backend.properties().to_dict()\n",
-      "AttributeError: 'NoneType' object has no attribute 'to_dict'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qiskit.providers.ibmq import least_busy\n",
     "backend = least_busy(provider.backends(simulator=False, filters=lambda b: b.configuration().n_qubits >= 5))\n",
@@ -240,7 +202,7 @@
     "qc.cx(0, 1)\n",
     "qc.measure([0,1], [0,1])\n",
     "\n",
-    "job = execute(qc, backend)"
+    "job = execute(qc, backend=backend)"
    ]
   },
   {
@@ -317,7 +279,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9bae823cdfe442cea28fd753a1d47db8",
+       "model_id": "a831681d7c7043daabd8c285218d9e8c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -364,7 +326,7 @@
      "data": {
       "text/html": [
        "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.20.0</td></tr><tr><td>Terra</td><td>0.15.1</td></tr><tr><td>Aer</td><td>0.6.1</td></tr><tr><td>Ignis</td><td>0.4.0</td></tr><tr><td>Aqua</td><td>0.7.5</td></tr><tr><td>IBM Q Provider</td><td>0.8.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.1 (default, Jul 15 2020, 18:48:27) \n",
-       "[Clang 11.0.3 (clang-1103.0.32.62)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Sep 04 09:11:57 2020 EDT</td></tr></table>"
+       "[Clang 11.0.3 (clang-1103.0.32.62)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Sep 04 10:29:29 2020 EDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Tutorial `2_jupyter_tools` used hard-coded backend `ibmq_essex`, which is no longer available. This PR updates that tutorial to use `least_busy` backend instead. Tutorial 1 uses hard coded backend as well, but it can't really be avoided since it uses demonstrates methods like `get_backend()`. 


### Details and comments


