### PR TITLE
Add error_string to job.error_message

### DIFF
--- a/qiskit/providers/ibmq/error_string.py
+++ b/qiskit/providers/ibmq/error_string.py
@@ -31,8 +31,8 @@ HTML_STR = """
   cursor: pointer;
 }
 .iqx-button {
-  background-color: #0f62fe; 
-  color: white; 
+  background-color: #0f62fe;
+  color: white;
 }
 .iqx-button:hover {
   background-color: #0043ce;
@@ -43,6 +43,7 @@ HTML_STR = """
 """
 
 URL = 'https://quantum-computing.ibm.com/docs/manage/errors#error'
+
 
 class IBMQErrorString(str):
     """A subclass of str that displays a button in jupyter

--- a/qiskit/providers/ibmq/error_string.py
+++ b/qiskit/providers/ibmq/error_string.py
@@ -53,7 +53,11 @@ class IBMQErrorString(str):
         # pylint: disable=import-outside-toplevel
         from IPython.display import HTML, display
         error_msg = self.__str__()
-        match = re.search(r'\d{4}', error_msg)
+        match = None
+        if 'Error code:' in error_msg:
+            error_split = error_msg.split('Error code:')
+            if len(error_split) > 1:
+                match = re.search(r'\d{4}', error_split[1])
         if match:
             error_code = match.group()
             html_str = HTML_STR % (URL+error_code, error_code)

--- a/qiskit/providers/ibmq/error_string.py
+++ b/qiskit/providers/ibmq/error_string.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A subclass of string that allows for linking out to solutions on IBM Quantum cloud"""
+
+import re
+
+HTML_STR = """
+<style>
+.button {
+  border: none;
+  color: white;
+  padding: 8px 16px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  margin: 4px 2px;
+  transition-duration: 0.2s;
+  cursor: pointer;
+}
+.iqx-button {
+  background-color: #0f62fe; 
+  color: white; 
+}
+.iqx-button:hover {
+  background-color: #0043ce;
+  color: white;
+}
+</style>
+<a href="%s" target='_blank'><button class='button iqx-button'>Go to solution #%s</button></a>
+"""
+
+URL = 'https://quantum-computing.ibm.com/docs/manage/errors#error'
+
+class IBMQErrorString(str):
+    """A subclass of str that displays a button in jupyter
+    that takes me to the solution of the error message.
+    """
+    def _repr_html_(self):
+        # pylint: disable=import-outside-toplevel
+        from IPython.display import HTML, display
+        error_msg = self.__str__()
+        match = re.search(r'\d{4}', error_msg)
+        if match:
+            error_code = match.group()
+            html_str = HTML_STR % (URL+error_code, error_code)
+            html = HTML(html_str)
+            display(html)

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -33,6 +33,7 @@ from qiskit.providers.ibmq import ibmqbackend  # pylint: disable=unused-import
 from ..apiconstants import ApiJobStatus, ApiJobKind
 from ..api.clients import AccountClient
 from ..api.exceptions import ApiError, UserTimeoutExceededError
+from ..error_string import IBMQErrorString
 from ..utils.utils import RefreshQueue, validate_job_tags
 from ..utils.qobj_utils import dict_to_qobj
 from ..utils.json_decoder import decode_backend_properties, decode_result
@@ -535,7 +536,7 @@ class IBMQJob(BaseJob):
             else:
                 self._job_error_msg = "Unknown error."
 
-        return self._job_error_msg
+        return IBMQErrorString(self._job_error_msg)
 
     def queue_position(self, refresh: bool = False) -> Optional[int]:
         """Return the position of the job in the server queue.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Creates `IBMQErrorString` class that is a simple wrapper of `str` that returns a button in Jupyter that links out to the solution for errors with 4-digit error codes associated with them.  If not on Jupyter, or no 4-digit code exists, the functionality is the exact same a standard string.

<img width="414" alt="Screen Shot 2020-09-17 at 13 44 13" src="https://user-images.githubusercontent.com/1249193/93507587-e1f2a500-f8eb-11ea-9201-41da47cb316b.png">

<img width="464" alt="Screen Shot 2020-09-17 at 13 44 48" src="https://user-images.githubusercontent.com/1249193/93507646-f636a200-f8eb-11ea-9643-de41d0c3c19f.png">


### Details and comments


