### PR TITLE
Ignore reservation error in least_busy

### DIFF
--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -148,8 +148,12 @@ def least_busy(
                 continue
             if reservation_lookahead and isinstance(back, IBMQBackend):
                 end_time = now + timedelta(minutes=reservation_lookahead)
-                if back.reservations(now, end_time):
-                    continue
+                try:
+                    if back.reservations(now, end_time):
+                        continue
+                except Exception as err:
+                    logger.warning("Unable to find backend reservation information. "
+                                   "It will not be taken into consideration. {}".format(err))
             candidates.append(back)
         if not candidates:
             raise IBMQError('No backend matches the criteria.')

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -151,9 +151,9 @@ def least_busy(
                 try:
                     if back.reservations(now, end_time):
                         continue
-                except Exception as err:
+                except Exception as err:  # pylint: disable=broad-except
                     logger.warning("Unable to find backend reservation information. "
-                                   "It will not be taken into consideration. {}".format(err))
+                                   "It will not be taken into consideration. %s", str(err))
             candidates.append(back)
         if not candidates:
             raise IBMQError('No backend matches the criteria.')

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -566,8 +566,9 @@ class IBMQJob(BaseJob):
         :class:`QueueInfo` for more information.
 
         Note:
-            Even if the job is queued, some of its queue information may not
-            be immediately available.
+            The queue information is calculated after the job enters the queue.
+            Therefore, some or all of the information may not be immediately
+            available, and this method may return ``None``.
 
         Returns:
             A :class:`QueueInfo` instance that contains queue information for


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`least_busy()` now looks for backend reservation information when picking the least busy backend. However, if this query fails, `least_busy()` should just ignore the reservation data and continue on.

This PR also made minor change in the `queue_info()` docstring to make it clearer.


### Details and comments


