### PR TITLE
Fix provider not found in test case

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -278,8 +278,13 @@ def _get_custom_provider(ibmq_factory: IBMQFactory) -> Optional[AccountProvider]
 def _enable_account(qe_token: str, qe_url: str) -> None:
     """Enable the account if one is not already active.
 
-    :param qe_token: API token.
-    :param qe_url: API URL.
+    Args:
+        qe_token: API token.
+        qe_url: API URL.
     """
-    if not IBMQ.active_account():
-        IBMQ.enable_account(qe_token, qe_url)
+    active_account = IBMQ.active_account()
+    if active_account:
+        if active_account.get('token', '') == qe_token:
+            return
+        IBMQ.disable_account()
+    IBMQ.enable_account(qe_token, qe_url)

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -47,8 +47,7 @@ class TestExperiment(IBMQTestCase):
             cls.provider = cls._setup_provider()    # pylint: disable=no-value-for-parameter
             cls.experiments = cls.provider.experiment.experiments()
             cls.device_components = cls.provider.experiment.device_components()
-        except Exception:
-            # TODO switch to IBMQNotAuthorizedError when API is fixed.
+        except IBMQNotAuthorizedError:
             raise SkipTest("Not authorized to use experiment service.")
         finally:
             os.environ['USE_STAGING_CREDENTIALS'] = saved_environ


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Depending on the order the tests are executed, some might fail with "provider not found". This is due to #765 introduced tests in mixed environments. This PR checks if the active account matches the one the tests want to use. If not, it disables the active account and enable the new one.


### Details and comments


