### PR TITLE
Catch broad credential exception in test_experiment

### DIFF
--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -47,7 +47,7 @@ class TestExperiment(IBMQTestCase):
             cls.provider = cls._setup_provider()    # pylint: disable=no-value-for-parameter
             cls.experiments = cls.provider.experiment.experiments()
             cls.device_components = cls.provider.experiment.device_components()
-        except IBMQNotAuthorizedError:
+        except Exception:
             raise SkipTest("Not authorized to use experiment service.")
         finally:
             os.environ['USE_STAGING_CREDENTIALS'] = saved_environ


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`test_experiment` requires a staging account, which may not be available. This PR catches a broader exception when trying to enable such account.


### Details and comments


