### PR TITLE
Suppress pylint import error

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -75,7 +75,9 @@ disable=no-self-use,        # disabled as it is too verbose
     missing-yield-doc,      # in coroutines, these checks can yield false
     missing-yield-type-doc,  # positives (pun intended)
     import-outside-toplevel,
-    docstring-first-line-empty
+    docstring-first-line-empty,
+    no-name-in-module,  # remove when pylint behaves
+    import-error    # remove when pylint behaves
 
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
     - stage: lint and pure python test
       <<: *stage_linux
       if: type != cron
-      python: 3.6
+      python: 3.6.5
       script: make style && make lint
 
     # Type checking using mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,11 +114,9 @@ jobs:
     ###########################################################################
     # Linter and style check (GNU/Linux, Python 3.7)
     - stage: lint and pure python test
-      <<: *stage_osx
+      <<: *stage_linux
       if: type != cron
-      env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.6.5
+      python: 3.7
       script: make style && make lint
 
     # Type checking using mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,9 +114,11 @@ jobs:
     ###########################################################################
     # Linter and style check (GNU/Linux, Python 3.7)
     - stage: lint and pure python test
-      <<: *stage_linux
+      <<: *stage_osx
       if: type != cron
-      python: 3.6.5
+      env:
+        - MPLBACKEND=ps
+        - PYTHON_VERSION=3.6.5
       script: make style && make lint
 
     # Type checking using mypy
@@ -133,12 +135,6 @@ jobs:
 
     # "test" stage
     ###########################################################################
-
-    # GNU/Linux, Python 3.6
-    - stage: test
-      <<: *stage_linux
-      if: type != cron
-      python: 3.6
 
     # GNU/Linux, Python 3.7
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
     - stage: lint and pure python test
       <<: *stage_linux
       if: type != cron
-      python: 3.7
+      python: 3.6
       script: make style && make lint
 
     # Type checking using mypy

--- a/qiskit/providers/ibmq/api/clients/websocket.py
+++ b/qiskit/providers/ibmq/api/clients/websocket.py
@@ -42,7 +42,6 @@ logger = logging.getLogger(__name__)
 
 # WindowsProactorEventLoopPolicy raises an exception in tornado (used by Jupyter)
 # and causes a hang with websockets.
-# pylint: disable=no-member
 if sys.platform.startswith('win') and sys.version_info[:3] >= (3, 8, 0) and \
         isinstance(asyncio.get_event_loop_policy(), asyncio.WindowsProactorEventLoopPolicy):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/qiskit/providers/ibmq/api/clients/websocket.py
+++ b/qiskit/providers/ibmq/api/clients/websocket.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 # WindowsProactorEventLoopPolicy raises an exception in tornado (used by Jupyter)
 # and causes a hang with websockets.
+# pylint: disable=no-member
 if sys.platform.startswith('win') and sys.version_info[:3] >= (3, 8, 0) and \
         isinstance(asyncio.get_event_loop_policy(), asyncio.WindowsProactorEventLoopPolicy):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`qiskit-terra` 0.16.0 is causing pylint to incorrectly fail with lots of `no-name-in-module` and `import-error`. It appears to be caused by the long docstring in `qiskit/provider/__init__.py`. This PR suppresses those errors for now so PRs can pass CI. True import errors should easily be caught by tests.


### Details and comments


