### PR TITLE
[WIP] Simple backend filtering

### DIFF
--- a/qiskit/providers/ibmq/collections/backend.py
+++ b/qiskit/providers/ibmq/collections/backend.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""BackendCollection module
+"""
+
+from typing import List
+from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
+
+
+class BackendCollection(list):
+    """A list subclass that makes handling IBMQBackends easier.
+    """
+    def __init__(self, data: List):
+        """BackendCollection constructor
+
+        Parameters:
+            data: List of IBMQbackend instances
+        """
+        for dd in data:
+            if not isinstance(dd, IBMQBackend):
+                raise TypeError('Backend collection requires IBMQBackend instances.')
+        super().__init__(data)
+
+    def __and__(self, other):
+        return BackendCollection(set(self) & set(other))
+
+    def __or__(self, other):
+        return BackendCollection(set(self) | set(other))
+
+    def __add__(self, other):
+        """Adds to BackendCollections together.
+        """
+        if not isinstance(other, (BackendCollection, list)):
+            if isinstance(other, list):
+                other = BackendCollection(other)
+            else:
+                raise TypeError('BackendCollection addition works only for collections and lists.')
+
+        return BackendCollection(set(self) | set(other))
+
+    def __radd__(self, other):
+        """Adds to BackendCollections together.
+        """
+        if not isinstance(other, (BackendCollection, list)):
+            if isinstance(other, list):
+                other = BackendCollection(other)
+            else:
+                raise TypeError('BackendCollection addition works only for collections and lists.')
+
+        return BackendCollection(set(self) | set(other))
+
+    def __getattr__(self, name):
+        if name == 'num_qubits':
+            return NumQubits(self)
+        elif name == 'simulator':
+            return IsSimulator(self)
+        elif name == 'real':
+            return IsReal(self)
+        elif name == 'open_pulse':
+            return HasPulse(self)
+        elif name == 'quantum_volume':
+            return QVCompare(self)
+        elif name == 'operational':
+            return IsOperational(self)
+        else:
+            raise AttributeError("BackendCollection does not have attr '{}'.".format(name))
+
+
+class Comparator(BackendCollection):
+    """A skeleton constructor class built on BackendCollection.
+    """
+    def __eq__(self, other):
+        raise Exception('Not implimented')
+
+    def __ne__(self, other):
+        raise Exception('Not implimented')
+
+    def __gt__(self, other):
+        raise Exception('Not implimented')
+
+    def __ge__(self, other):
+        raise Exception('Not implimented')
+
+    def __lt__(self, other):
+        raise Exception('Not implimented')
+
+    def __le__(self, other):
+        raise Exception('Not implimented')
+
+
+class IsSimulator(Comparator):
+    """Impliments a simulator check.
+    """
+    def __init__(self, data: List):
+        """BackendCollection constructor
+
+        Parameters:
+            data: List of IBMQbackend instances
+        """
+        self._full_data = data
+        super().__init__([back for back in data if back.configuration().simulator])
+
+    def __eq__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self._full_data if back.configuration().simulator == other]
+        return BackendCollection(out)
+
+    def __ne__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self._full_data if back.configuration().simulator != other]
+        return BackendCollection(out)
+
+
+class IsReal(Comparator):
+    """Impliments a real system check.
+    """
+    def __init__(self, data: List):
+        """BackendCollection constructor
+
+        Parameters:
+            data: List of IBMQbackend instances
+        """
+        self._full_data = data
+        super().__init__([back for back in data if not back.configuration().simulator])
+
+    def __eq__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self._full_data if back.configuration().simulator != other]
+        return BackendCollection(out)
+
+    def __ne__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self._full_data if back.configuration().simulator == other]
+        return BackendCollection(out)
+
+
+class IsOperational(Comparator):
+    """Impliments a is operational check.
+    """
+    def __init__(self, data: List):
+        """BackendCollection constructor
+
+        Parameters:
+            data: List of IBMQbackend instances
+        """
+        self._full_data = data
+        super().__init__([back for back in data if back.status().operational])
+
+    def __eq__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self._full_data if back.status().operational == other]
+        return BackendCollection(out)
+
+    def __ne__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self._full_data if back.status().operational != other]
+        return BackendCollection(out)
+
+
+class HasPulse(Comparator):
+    """Impliments a open_pulse check.
+    """
+    def __init__(self, data: List):
+        """BackendCollection constructor
+
+        Parameters:
+            data: List of IBMQbackend instances
+        """
+        self._full_data = data
+        super().__init__([back for back in data if back.configuration().open_pulse])
+
+    def __eq__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self if back.configuration().open_pulse == other]
+        return BackendCollection(out)
+
+    def __ne__(self, other):
+        if (other is not None) and not isinstance(other, (bool, int)):
+            raise Exception('Can only compare against boolean and int values.')
+        if isinstance(other, int) and other not in [0, 1]:
+            raise Exception('Integer comparison must be against 0 or 1.')
+        out = [back for back in self if back.configuration().open_pulse != other]
+        return BackendCollection(out)
+
+
+class NumQubits(Comparator):
+    """Impliments a number of qubits comparator.
+    """
+    def __eq__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = [back for back in self if back.configuration().num_qubits == other]
+        return BackendCollection(out)
+
+    def __ne__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = [back for back in self if back.configuration().num_qubits != other]
+        return BackendCollection(out)
+
+    def __gt__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = [back for back in self if back.configuration().num_qubits > other]
+        return BackendCollection(out)
+
+    def __ge__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = [back for back in self if back.configuration().num_qubits >= other]
+        return BackendCollection(out)
+
+    def __lt__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = [back for back in self if back.configuration().num_qubits < other]
+        return BackendCollection(out)
+
+    def __le__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = [back for back in self if back.configuration().num_qubits <= other]
+        return BackendCollection(out)
+
+
+class QVCompare(Comparator):
+    """Impliments a quantum volume comparator.
+    """
+    def __eq__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = []
+        for back in self:
+            if hasattr(back.configuration(), 'quantum_volume'):
+                qv_val = back.configuration().quantum_volume
+                if qv_val and qv_val == other:
+                    out.append(back)
+        return BackendCollection(out)
+
+    def __ne__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = []
+        for back in self:
+            if hasattr(back.configuration(), 'quantum_volume'):
+                qv_val = back.configuration().quantum_volume
+                if qv_val and qv_val != other:
+                    out.append(back)
+        return BackendCollection(out)
+
+    def __gt__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = []
+        for back in self:
+            if hasattr(back.configuration(), 'quantum_volume'):
+                qv_val = back.configuration().quantum_volume
+                if qv_val and qv_val > other:
+                    out.append(back)
+        return BackendCollection(out)
+
+    def __ge__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = []
+        for back in self:
+            if hasattr(back.configuration(), 'quantum_volume'):
+                qv_val = back.configuration().quantum_volume
+                if qv_val and qv_val >= other:
+                    out.append(back)
+        return BackendCollection(out)
+
+    def __lt__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = []
+        for back in self:
+            if hasattr(back.configuration(), 'quantum_volume'):
+                qv_val = back.configuration().quantum_volume
+                if qv_val and qv_val < other:
+                    out.append(back)
+        return BackendCollection(out)
+
+    def __le__(self, other):
+        if not isinstance(other, int):
+            raise Exception('Can only compare against ints')
+        out = []
+        for back in self:
+            if hasattr(back.configuration(), 'quantum_volume'):
+                qv_val = back.configuration().quantum_volume
+                if qv_val and qv_val <= other:
+                    out.append(back)
+        return BackendCollection(out)

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -46,6 +46,7 @@ from .utils.json_decoder import decode_pulse_defaults, decode_backend_properties
 from .utils.backend import convert_reservation_data
 from .utils.utils import api_status_to_job_status
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -36,6 +36,8 @@ from .utils.utils import to_python_identifier, validate_job_tags, filter_data
 from .utils.converters import local_to_utc
 from .utils.backend import convert_reservation_data
 
+from .collections.backend import BackendCollection
+
 logger = logging.getLogger(__name__)
 
 
@@ -120,7 +122,7 @@ class IBMQBackendService:
             name = aliases.get(name, name)
             kwargs['backend_name'] = name
 
-        return filter_backends(backends, filters=filters, **kwargs)
+        return BackendCollection(filter_backends(backends, filters=filters, **kwargs))
 
     def jobs(
             self,

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -75,6 +75,25 @@ class TestBackendFilters(IBMQTestCase):
                 self.assertFalse(backend.configuration().simulator)
                 self.assertGreaterEqual(backend.configuration().n_qubits, 5)
 
+    def test_filter_collection(self):
+        """Test filtering by using BackendCollection configuration properties."""
+        filtered_backends = self.provider.backends().real.num_qubits >= 5
+
+        self.assertTrue(filtered_backends)
+        for backend in filtered_backends[:5]:
+            with self.subTest(backend=backend):
+                self.assertFalse(backend.configuration().simulator)
+                self.assertGreaterEqual(backend.configuration().n_qubits, 5)
+
+    def test_filter_collection2(self):
+        """Test filtering (#2) by using BackendCollection configuration properties."""
+        filtered_backends = self.provider.backends().quantum_volume > 16
+
+        self.assertTrue(filtered_backends)
+        for backend in filtered_backends:
+            with self.subTest(backend=backend):
+                self.assertGreater(backend.configuration().quantum_volume, 16)
+
     def test_filter_least_busy(self):
         """Test filtering by least busy function."""
         backends = self.provider.backends()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Simplifies backend filtering for most commonly used comparators.  For example, all 5Q devices is:

```python
provider.backends().num_qubits == 5
```

or all real devices is:

```python
provider.backends().real
```

Things can be combined.  For example, all open_pulse capable devices with more than 5Q is:

```python
provider.backends().open_pulse.num_qubits > 5
```

or 

```python
(provider.backends().open_pulse) & (provider.backends().num_qubits > 5)
```
### Details and comments

Still needs to be documented.
