### PR TITLE
Skip experiment tests on production

### DIFF
--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -16,7 +16,7 @@
 
 import os
 import uuid
-from unittest import mock, SkipTest
+from unittest import mock, SkipTest, skipIf
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -33,6 +33,7 @@ from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_provider
 
 
+@skipIf(not os.environ.get('USE_STAGING_CREDENTIALS', ''), "Only runs on staging")
 class TestExperiment(IBMQTestCase):
     """Test experiment modules."""
 
@@ -41,16 +42,12 @@ class TestExperiment(IBMQTestCase):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
-        saved_environ = os.environ.get('USE_STAGING_CREDENTIALS') or ""
         try:
-            os.environ['USE_STAGING_CREDENTIALS'] = 'true'
             cls.provider = cls._setup_provider()    # pylint: disable=no-value-for-parameter
             cls.experiments = cls.provider.experiment.experiments()
             cls.device_components = cls.provider.experiment.device_components()
         except Exception:
             raise SkipTest("Not authorized to use experiment service.")
-        finally:
-            os.environ['USE_STAGING_CREDENTIALS'] = saved_environ
 
     @classmethod
     @requires_provider


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Since there are many backward incompatible changes related the experiment service coming out, this PR disables experiment service related tests on production. This allows the new features to be tested in a different environment without impacting CI. 


### Details and comments


