### PR TITLE
Cancel job if submit failed partially

### DIFF
--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -17,7 +17,7 @@
 import time
 import copy
 from datetime import datetime, timedelta
-from unittest import SkipTest
+from unittest import SkipTest, mock
 from threading import Thread, Event
 
 import numpy
@@ -33,10 +33,12 @@ from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.providers.ibmq import least_busy
 from qiskit.providers.ibmq.apiconstants import ApiJobStatus, API_JOB_FINAL_STATES
 from qiskit.providers.ibmq.ibmqbackend import IBMQRetiredBackend
-from qiskit.providers.ibmq.exceptions import IBMQBackendError
+from qiskit.providers.ibmq.exceptions import IBMQBackendError, IBMQBackendApiError
 from qiskit.providers.ibmq.utils.utils import api_status_to_job_status
 from qiskit.providers.ibmq.job.exceptions import IBMQJobInvalidStateError, IBMQJobTimeoutError
 from qiskit.providers.ibmq.utils.converters import local_to_utc
+from qiskit.providers.ibmq.api.rest.job import Job as RestJob
+from qiskit.providers.ibmq.api.exceptions import RequestsApiError
 
 from ..jobtestcase import JobTestCase
 from ..decorators import (requires_provider, requires_device)
@@ -629,3 +631,43 @@ class TestIBMQJob(JobTestCase):
             for thread in job._executor._threads:
                 thread.join(0.1)
             cancel_job(job)
+
+    def test_job_upload_fail(self):
+        """Test job upload fails."""
+        qobj = bell_in_qobj(backend=self.sim_backend)
+        job_id = []
+
+        def _side_effect(self, *args, **kwargs):
+            # pylint: disable=unused-argument
+            job_id.append(self.job_id)
+            raise RequestsApiError('Kaboom')
+
+        with mock.patch.object(RestJob, 'put_object_storage',
+                               side_effect=_side_effect, autospec=True):
+            with self.assertRaises(IBMQBackendApiError):
+                self.sim_backend.run(qobj)
+
+        self.assertTrue(job_id, "Job ID not saved.")
+        job = self.sim_backend.retrieve_job(job_id[0])
+        self.assertEqual(job.status(), JobStatus.CANCELLED,
+                         f"Job {job.job_id()} status is {job.status()} and not cancelled!")
+
+    def test_job_ack_fail(self):
+        """Test job upload ack fails."""
+        qobj = bell_in_qobj(backend=self.sim_backend)
+        job_id = []
+
+        def _side_effect(self, *args, **kwargs):
+            # pylint: disable=unused-argument
+            job_id.append(self.job_id)
+            raise RequestsApiError('Kaboom')
+
+        with mock.patch.object(RestJob, 'callback_upload',
+                               side_effect=_side_effect, autospec=True):
+            with self.assertRaises(IBMQBackendApiError):
+                self.sim_backend.run(qobj)
+
+        self.assertTrue(job_id, "Job ID not saved.")
+        job = self.sim_backend.retrieve_job(job_id[0])
+        self.assertEqual(job.status(), JobStatus.CANCELLED,
+                         f"Job {job.job_id()} status is {job.status()} and not cancelled!")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #728. 

Today a job submit actually consists of 3 steps:
1 POST to /Jobs
2 PUT to object storage
3 POST to /jobDataUploaded

If steps 2 or 3 fails, the "job" created by step 1 will stuck in CREATING until recovery kicks in hours later. This PR cancels the job if step 2 or 3 fail to speed up the recovery process. 

This is slightly different from the solution suggested in the issue, which says to suppress the error if the request actually completed successfully. But since it's really difficult to ascertain whether the request actually succeeded despite the error, it's safer to just cancel the job.

### Details and comments


