### PR TITLE
Avoid infinite loop when passing IBMQRandomService to child

### DIFF
--- a/qiskit/providers/ibmq/random/ibmqrandomservice.py
+++ b/qiskit/providers/ibmq/random/ibmqrandomservice.py
@@ -110,7 +110,8 @@ class IBMQRandomService:
         return self.__dict__
 
     def __getattr__(self, item: str) -> Any:
-        self._discover_services()
+        if not self.__getattribute__('_initialized'):
+            self._discover_services()
         try:
             return self._services[item]
         except KeyError:

--- a/releasenotes/notes/random-loop-85cc24a9ac024a8f.yaml
+++ b/releasenotes/notes/random-loop-85cc24a9ac024a8f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the infinite loop raised when passing an ``IBMQRandomService`` instance
+    to a child process.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #804 . 
This PR explicitly checks for `_initialized` instead of assuming it's available.


### Details and comments


