### PR TITLE
Add __getstate__ in RetrySession

### DIFF
--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -384,3 +384,9 @@ class RetrySession(Session):
             return False
 
         return True
+
+    def __getstate__(self) -> Dict:
+        """Overwrite Session's getstate to include all attributes."""
+        state = super().__getstate__()  # type: ignore
+        state.update(self.__dict__)
+        return state


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #803. 
`RetrySession` inherits from `Session`, which has a `__getstate__` defined that only includes a list of hard-coded attributes (i.e. none of `RetrySession`'s). This means one cannot use Python's `ProcessPoolExecutor` to run methods like `job.result()` in separate processes as Python uses `__getstate__` to pickle and pass the objects.

This PR adds a `__getstate__` in `RertySession` to include the additional attributes. 

### Details and comments


