### PR TITLE
Add min_num_qubits as a backends filter

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -89,6 +89,7 @@ class IBMQBackendService:
             name: Optional[str] = None,
             filters: Optional[Callable[[List[IBMQBackend]], bool]] = None,
             timeout: Optional[float] = None,
+            min_num_qubits: Optional[int] = None,
             **kwargs: Any
     ) -> List[IBMQBackend]:
         """Return all backends accessible via this provider, subject to optional filtering.
@@ -98,9 +99,11 @@ class IBMQBackendService:
             filters: More complex filters, such as lambda functions.
                 For example::
 
-                    AccountProvider.backends(filters=lambda b: b.configuration().n_qubits > 5)
+                    AccountProvider.backends(
+                        filters=lambda b: b.configuration().quantum_volume > 16)
             timeout: Maximum number of seconds to wait for the discovery of
                 remote backends.
+            min_num_qubits: Minimum number of qubits the backend has to have.
             kwargs: Simple filters that specify a ``True``/``False`` criteria in the
                 backend configuration, backends status, or provider credentials.
                 An example to get the operational backends with 5 qubits::
@@ -110,7 +113,7 @@ class IBMQBackendService:
         Returns:
             The list of available backends that match the filter.
         """
-        backends = self._provider._backends.values()
+        backends = list(self._provider._backends.values())
 
         # Special handling of the `name` parameter, to support alias
         # resolution.
@@ -119,6 +122,10 @@ class IBMQBackendService:
             aliases.update(self._deprecated_backend_names())
             name = aliases.get(name, name)
             kwargs['backend_name'] = name
+
+        if min_num_qubits:
+            backends = list(filter(
+                lambda b: b.configuration().n_qubits > min_num_qubits, backends))
 
         return filter_backends(backends, filters=filters, **kwargs)
 

--- a/releasenotes/notes/backend-filter-min-qubits-05a96da6f5e08487.yaml
+++ b/releasenotes/notes/backend-filter-min-qubits-05a96da6f5e08487.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :meth:`qiskit.providers.ibmq.AccountProvider.backends` now has a new
+    parameter `min_num_qubits` that allows you to filter by the minimum number
+    of qubits.

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -211,7 +211,7 @@ def requires_device(func):
                     break
         else:
             _backend = least_busy(provider.backends(
-                simulator=False, filters=lambda b: b.configuration().n_qubits >= 5))
+                simulator=False, min_num_qubits=5))
 
         if not _backend:
             raise Exception('Unable to find a suitable backend.')

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -107,3 +107,15 @@ class TestBackendFilters(IBMQTestCase):
                 backs.append(back)
                 break
         self.assertTrue(least_busy(backs, window))
+
+    def test_filter_min_num_qubits(self):
+        """Test filtering by minimum number of qubits."""
+        filtered_backends = self.provider.backends(
+            min_num_qubits=10, simulator=False,
+            filters=lambda b: b.configuration().quantum_volume >= 10)
+
+        self.assertTrue(filtered_backends)
+        for backend in filtered_backends[:5]:
+            with self.subTest(backend=backend):
+                self.assertGreaterEqual(backend.configuration().n_qubits, 10)
+                self.assertTrue(backend.configuration().quantum_volume, 10)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #813 . 

The minimum number of qubits is a frequently used filter and users currently need to pass in a lambda function for that.
This PR adds a `min_num_qubits` parameter to `provider.backends()` to make it more user friendly. 


### Details and comments


