### PR TITLE
Rename provider.backends to provider.backend

### DIFF
--- a/docs/tutorials/1_the_ibmq_account.ipynb
+++ b/docs/tutorials/1_the_ibmq_account.ipynb
@@ -723,7 +723,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The backend service is defined as the `backends` attribute of a provider. All of the backends available to this provider are also attributes of the backend service, allowing the backend names to be autocompleted: "
+    "The backend service is defined as the `backend` attribute of a provider. All of the backends available to this provider are also attributes of the backend service, allowing the backend names to be autocompleted: "
    ]
   },
   {
@@ -743,7 +743,7 @@
     }
    ],
    "source": [
-    "provider.backends.ibmq_vigo"
+    "provider.backend.ibmq_vigo"
    ]
   },
   {
@@ -771,7 +771,7 @@
     }
    ],
    "source": [
-    "for ran_job in provider.backends.jobs(limit=5):\n",
+    "for ran_job in provider.backend.jobs(limit=5):\n",
     "    print(str(ran_job.job_id()) + \" \" + str(ran_job.status()))"
    ]
   },
@@ -789,7 +789,7 @@
    "outputs": [],
    "source": [
     "if ran_job is not None:\n",
-    "    job = provider.backends.retrieve_job(ran_job.job_id())"
+    "    job = provider.backend.retrieve_job(ran_job.job_id())"
    ]
   },
   {

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -15,7 +15,7 @@
 """Provider for a single IBM Quantum Experience account."""
 
 import logging
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
 from collections import OrderedDict
 
 from qiskit.providers import BaseProvider  # type: ignore[attr-defined]
@@ -25,7 +25,7 @@ from qiskit.providers.models import (QasmBackendConfiguration,
 from .api.clients import AccountClient
 from .ibmqbackend import IBMQBackend, IBMQSimulator
 from .credentials import Credentials
-from .ibmqbackendservice import IBMQBackendService
+from .ibmqbackendservice import IBMQBackendService, IBMQDeprecatedBackendService
 from .utils.json_decoder import decode_backend_configuration
 from .random.ibmqrandomservice import IBMQRandomService
 from .experiment.experimentservice import ExperimentService
@@ -61,15 +61,15 @@ class AccountProvider(BaseProvider):
 
         simulator_backend = provider.get_backend('ibmq_qasm_simulator')
 
-    It is also possible to use the ``backends`` attribute to reference a backend.
+    It is also possible to use the ``backend`` attribute to reference a backend.
     As an example, to retrieve the same backend from the example above::
 
-        simulator_backend = provider.backends.ibmq_qasm_simulator
+        simulator_backend = provider.backend.ibmq_qasm_simulator
 
     Note:
-        The ``backends`` attribute can be used to autocomplete the names of
+        The ``backend`` attribute can be used to autocomplete the names of
         backends available to this provider. To autocomplete, press ``tab``
-        after ``provider.backends.``. This feature may not be available
+        after ``provider.backend.``. This feature may not be available
         if an error occurs during backend discovery. Also note that
         this feature is only available in interactive sessions, such as
         in Jupyter Notebook and the Python interpreter.
@@ -91,7 +91,8 @@ class AccountProvider(BaseProvider):
 
         # Initialize the internal list of backends.
         self._backends = self._discover_remote_backends()
-        self.backends = IBMQBackendService(self)  # type: ignore[assignment]
+        self.backend = IBMQBackendService(self)
+        self.backends = IBMQDeprecatedBackendService(self.backend)  # type: ignore[assignment]
 
         # Initialize other services.
         self.random = IBMQRandomService(self, access_token)
@@ -99,9 +100,31 @@ class AccountProvider(BaseProvider):
         self._experiment = ExperimentService(self, access_token) \
             if credentials.experiment_url else None
 
-    def backends(self, name: Optional[str] = None, **kwargs: Any) -> List[IBMQBackend]:
-        """Return all backends accessible via this provider, subject to optional filtering."""
+    def backends(
+            self,
+            name: Optional[str] = None,
+            filters: Optional[Callable[[List[IBMQBackend]], bool]] = None,
+            **kwargs: Any
+    ) -> List[IBMQBackend]:
+        """Return all backends accessible via this provider, subject to optional filtering.
+
+        Args:
+            name: Backend name to filter by.
+            filters: More complex filters, such as lambda functions.
+                For example::
+
+                    AccountProvider.backends(filters=lambda b: b.configuration().n_qubits > 5)
+            kwargs: Simple filters that specify a ``True``/``False`` criteria in the
+                backend configuration, backends status, or provider credentials.
+                An example to get the operational backends with 5 qubits::
+
+                    AccountProvider.backends(n_qubits=5, operational=True)
+
+        Returns:
+            The list of available backends that match the filter.
+        """
         # pylint: disable=method-hidden
+        # pylint: disable=arguments-differ
         # This method is only for faking the subclassing of `BaseProvider`, as
         # `.backends()` is an abstract method. Upon initialization, it is
         # replaced by a `IBMQBackendService` instance.

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -62,7 +62,7 @@ class IBMQBackend(BaseBackend):
         from qiskit.circuit.random import random_circuit
 
         provider = IBMQ.load_account()
-        backend = provider.backends.ibmq_vigo
+        backend = provider.backend.ibmq_vigo
         qx = random_circuit(n_qubits=5, depth=4)
         qobj = assemble(transpile(qx, backend=backend), backend=backend)
         job = backend.run(qobj)
@@ -476,7 +476,7 @@ class IBMQBackend(BaseBackend):
         Raises:
             IBMQBackendValueError: If a keyword value is not recognized.
         """
-        return self._provider.backends.jobs(
+        return self._provider.backend.jobs(
             limit, skip, self.name(), status,
             job_name, start_datetime, end_datetime, job_tags, job_tags_operator,
             descending, db_filter)
@@ -514,7 +514,7 @@ class IBMQBackend(BaseBackend):
         Raises:
             IBMQBackendError: If job retrieval failed.
         """
-        job = self._provider.backends.retrieve_job(job_id)
+        job = self._provider.backend.retrieve_job(job_id)
         job_backend = job.backend()
 
         if self.name() != job_backend.name():

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -149,7 +149,7 @@ class ManagedJobSet:
         jobs = []  # type: List[IBMQJob]
         page_limit = 1000
         while True:
-            job_page = provider.backends.jobs(    # type: ignore[attr-defined]
+            job_page = provider.backend.jobs(    # type: ignore[attr-defined]
                 skip=len(jobs), limit=page_limit, job_tags=[self._id_long])
             jobs += job_page
             if len(job_page) < page_limit:

--- a/releasenotes/notes/backends-to-backend-76f460795926ed22.yaml
+++ b/releasenotes/notes/backends-to-backend-76f460795926ed22.yaml
@@ -1,0 +1,12 @@
+---
+deprecations:
+  - |
+    The ``backends`` attribute of :class:`qiskit.providers.ibmq.AccountProvider`
+    has been renamed to ``backend`` (sigular). For backward compatibility, you
+    can continue to use ``backends``, but it is deprecated and will be removed
+    in a future release. The :meth:`qiskit.providers.ibmq.AccountProvider.backends`
+    method remains unchanged. For example::
+
+      backend = provider.backend.ibmq_vigo   # This is the new syntax.
+      backend = provider.backends.ibmq_vigo  # This is deprecated.
+      backends = provider.backends()         # This continues to work as before.

--- a/test/ibmq/test_basic_server_paths.py
+++ b/test/ibmq/test_basic_server_paths.py
@@ -78,7 +78,7 @@ class TestBasicServerPaths(IBMQTestCase):
                 job = self._submit_job_with_retry(qobj, backend)
                 job_id = job.job_id()
 
-                retrieved_jobs = provider.backends.jobs(backend_name=backend_name)
+                retrieved_jobs = provider.backend.jobs(backend_name=backend_name)
                 self.assertGreaterEqual(len(retrieved_jobs), 1)
                 retrieved_job_ids = {job.job_id() for job in retrieved_jobs}
                 self.assertIn(job_id, retrieved_job_ids)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -215,7 +215,7 @@ class TestIBMQJob(JobTestCase):
 
     def test_retrieve_jobs(self):
         """Test retrieving jobs."""
-        job_list = self.provider.backends.jobs(
+        job_list = self.provider.backend.jobs(
             backend_name=self.sim_backend.name(), limit=5, skip=0)
         self.assertLessEqual(len(job_list), 5)
         for job in job_list:
@@ -223,7 +223,7 @@ class TestIBMQJob(JobTestCase):
 
     def test_retrieve_job(self):
         """Test retrieving a single job."""
-        retrieved_job = self.provider.backends.retrieve_job(self.sim_job.job_id())
+        retrieved_job = self.provider.backend.retrieve_job(self.sim_job.job_id())
         self.assertEqual(self.sim_job.job_id(), retrieved_job.job_id())
         self.assertEqual(self.sim_job.qobj().to_dict(), retrieved_job.qobj().to_dict())
         self.assertEqual(self.sim_job.result().get_counts(), retrieved_job.result().get_counts())
@@ -271,7 +271,7 @@ class TestIBMQJob(JobTestCase):
     def test_retrieve_job_error(self):
         """Test retrieving an invalid job."""
         self.assertRaises(IBMQBackendError,
-                          self.provider.backends.retrieve_job, 'BAD_JOB_ID')
+                          self.provider.backend.retrieve_job, 'BAD_JOB_ID')
 
     def test_retrieve_jobs_status(self):
         """Test retrieving jobs filtered by status."""
@@ -391,8 +391,8 @@ class TestIBMQJob(JobTestCase):
         # Add local tz in order to compare to `creation_date` which is tz aware.
         past_month_tz_aware = past_month.replace(tzinfo=tz.tzlocal())
 
-        job_list = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                               limit=2, start_datetime=past_month)
+        job_list = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
+                                              limit=2, start_datetime=past_month)
         self.assertTrue(job_list)
         for job in job_list:
             self.assertGreaterEqual(job.creation_date(), past_month_tz_aware,
@@ -405,8 +405,8 @@ class TestIBMQJob(JobTestCase):
         # Add local tz in order to compare to `creation_date` which is tz aware.
         past_month_tz_aware = past_month.replace(tzinfo=tz.tzlocal())
 
-        job_list = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                               limit=2, end_datetime=past_month)
+        job_list = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
+                                              limit=2, end_datetime=past_month)
         self.assertTrue(job_list)
         for job in job_list:
             self.assertLessEqual(job.creation_date(), past_month_tz_aware,
@@ -429,7 +429,7 @@ class TestIBMQJob(JobTestCase):
 
         for db_filter in db_filters:
             with self.subTest(db_filter=db_filter):
-                job_list = self.provider.backends.jobs(
+                job_list = self.provider.backend.jobs(
                     backend_name=self.sim_backend.name(), limit=2,
                     start_datetime=past_two_month, end_datetime=past_month, db_filter=db_filter)
                 self.assertTrue(job_list)
@@ -453,8 +453,8 @@ class TestIBMQJob(JobTestCase):
                      'summaryData.summary.qobj_config.n_qubits': 3,
                      'status': 'COMPLETED'}
 
-        job_list = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                               limit=2, skip=0, db_filter=my_filter)
+        job_list = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
+                                              limit=2, skip=0, db_filter=my_filter)
         self.assertTrue(job_list)
 
         for job in job_list:
@@ -538,11 +538,11 @@ class TestIBMQJob(JobTestCase):
         saved_backends = copy.copy(self.provider._backends)
         try:
             del self.provider._backends[self.sim_backend.name()]
-            new_job = self.provider.backends.retrieve_job(self.sim_job.job_id())
+            new_job = self.provider.backend.retrieve_job(self.sim_job.job_id())
             self.assertTrue(isinstance(new_job.backend(), IBMQRetiredBackend))
             self.assertNotEqual(new_job.backend().name(), 'unknown')
 
-            new_job2 = self.provider.backends.jobs(db_filter={'id': self.sim_job.job_id()})[0]
+            new_job2 = self.provider.backend.jobs(db_filter={'id': self.sim_job.job_id()})[0]
             self.assertTrue(isinstance(new_job2.backend(), IBMQRetiredBackend))
             self.assertNotEqual(new_job2.backend().name(), 'unknown')
         finally:

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -90,21 +90,21 @@ class TestIBMQJobAttributes(JobTestCase):
         job_name = str(time.time()).replace('.', '')
         job = self.sim_backend.run(qobj, job_name=job_name, validate_qobj=True)
         job_id = job.job_id()
-        rjob = self.provider.backends.retrieve_job(job_id)
+        rjob = self.provider.backend.retrieve_job(job_id)
         self.assertEqual(rjob.name(), job_name)
 
         # Check using partial matching.
         job_name_partial = job_name[8:]
-        retrieved_jobs = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                                     job_name=job_name_partial)
+        retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
+                                                    job_name=job_name_partial)
         self.assertGreaterEqual(len(retrieved_jobs), 1)
         retrieved_job_ids = {job.job_id() for job in retrieved_jobs}
         self.assertIn(job_id, retrieved_job_ids)
 
         # Check using regular expressions.
         job_name_regex = '^{}$'.format(job_name)
-        retrieved_jobs = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                                     job_name=job_name_regex)
+        retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
+                                                    job_name=job_name_regex)
         self.assertEqual(len(retrieved_jobs), 1)
         self.assertEqual(job_id, retrieved_jobs[0].job_id())
 
@@ -142,8 +142,8 @@ class TestIBMQJobAttributes(JobTestCase):
             job = self.sim_backend.run(qobj, job_name=job_name, validate_qobj=True)
             job_ids.add(job.job_id())
 
-        retrieved_jobs = self.provider.backends.jobs(backend_name=self.sim_backend.name(),
-                                                     job_name=job_name)
+        retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
+                                                    job_name=job_name)
 
         self.assertEqual(len(retrieved_jobs), 2,
                          "More than 2 jobs retrieved: {}".format(retrieved_jobs))
@@ -179,7 +179,7 @@ class TestIBMQJobAttributes(JobTestCase):
         message = job.error_message()
         self.assertIn('Experiment 1: ERROR', message)
 
-        r_message = self.provider.backends.retrieve_job(job.job_id()).error_message()
+        r_message = self.provider.backend.retrieve_job(job.job_id()).error_message()
         self.assertIn('Experiment 1: ERROR', r_message)
 
     def test_error_message_validation(self):
@@ -203,7 +203,7 @@ class TestIBMQJobAttributes(JobTestCase):
         if 'COMPLETED' not in self.sim_job.time_per_step():
             self.sim_job.refresh()
 
-        rjob = self.provider.backends.jobs(db_filter={'id': self.sim_job.job_id()})[0]
+        rjob = self.provider.backend.jobs(db_filter={'id': self.sim_job.job_id()})[0]
         self.assertFalse(rjob._time_per_step)
         rjob.refresh()
         self.assertEqual(rjob._time_per_step, self.sim_job._time_per_step)
@@ -238,7 +238,7 @@ class TestIBMQJobAttributes(JobTestCase):
                             'between the start date time {} and end date time {}'
                             .format(step, time_data, start_datetime, end_datetime))
 
-        rjob = self.provider.backends.jobs(db_filter={'id': job.job_id()})[0]
+        rjob = self.provider.backend.jobs(db_filter={'id': job.job_id()})[0]
         self.assertTrue(rjob.time_per_step())
 
     def test_new_job_attributes(self):

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -64,7 +64,7 @@ class TestIBMQJobManager(IBMQTestCase):
         if self._fake_api_backend:
             self._fake_api_backend._api_client.tear_down()
         # Restore provider backends since we cannot deep copy provider.
-        self.provider.backends._provider = self.provider
+        self.provider.backend._provider = self.provider
 
     @property
     def fake_api_backend(self):
@@ -75,7 +75,7 @@ class TestIBMQJobManager(IBMQTestCase):
             self._fake_api_provider._api_client = self._fake_api_backend._api_client \
                 = BaseFakeAccountClient()
             self._fake_api_backend._provider = self._fake_api_provider
-            self._fake_api_provider.backends._provider = self._fake_api_provider
+            self._fake_api_provider.backend._provider = self._fake_api_provider
             self._fake_api_backend._configuration.max_experiments = 10
         return self._fake_api_backend
 
@@ -142,7 +142,7 @@ class TestIBMQJobManager(IBMQTestCase):
         jobs = job_set.jobs()
         job_set.results()
         for i, qobj in enumerate(job_set.qobjs()):
-            rjob = self.fake_api_provider.backends.retrieve_job(jobs[i].job_id())
+            rjob = self.fake_api_provider.backend.retrieve_job(jobs[i].job_id())
             self.maxDiff = None  # pylint: disable=invalid-name
             self.assertDictEqual(qobj.to_dict(), rjob.qobj().to_dict())
 
@@ -262,7 +262,7 @@ class TestIBMQJobManager(IBMQTestCase):
         while JobStatus.INITIALIZING in job_set.statuses():
             time.sleep(1)
 
-        rjobs = self.provider.backends.jobs(job_tags=job_tags)
+        rjobs = self.provider.backend.jobs(job_tags=job_tags)
         self.assertEqual({job.job_id() for job in job_set.jobs()},
                          {rjob.job_id() for rjob in rjobs},
                          "Unexpected jobs retrieved. Job tag used was {}".format(job_tags))

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -129,7 +129,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
 
     def test_aliases(self):
         """Test that display names of devices map the regular names."""
-        aliased_names = self.provider.backends._aliased_backend_names()
+        aliased_names = self.provider.backend._aliased_backend_names()
 
         for display_name, backend_name in aliased_names.items():
             with self.subTest(display_name=display_name,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR renames the `backends` attribute of `AccountProvider` to `backend` (singular).

Main reasons for this change
- it matches with other IQX services
- there is also the `backends()` method, and having `backends` being both an attribute and a method is confusing. 

To maintain backward compatibility, this PR introduces a new `IBMQDeprecatedBackendService` class and directs all `provider.backends` requests there to issue proper deprecation warnings. 


### Details and comments


