### PR TITLE
Look only for credentials in qiskitrc section "ibmq"

### DIFF
--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -121,17 +121,12 @@ def write_qiskit_rc(
 
         return credentials_dict
 
-    def _section_name() -> str:
-        """Return the ibmq sction name string"""
-        base_name = 'ibmq'
-        return base_name
-
     filename = filename or DEFAULT_QISKITRC_FILE
     # Create the directories and the file if not found.
     os.makedirs(os.path.dirname(filename), exist_ok=True)
 
     unrolled_credentials = {
-        _section_name():
+        'ibmq':
             _credentials_object_to_dict(credentials_object, default_provider)
         for _, credentials_object in credentials.items()
     }

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -121,8 +121,8 @@ def write_qiskit_rc(
 
         return credentials_dict
 
-    def _section_name(credentials_: Credentials) -> str:
-        """Return a string suitable for use as a unique section name."""
+    def _section_name() -> str:
+        """Return the ibmq sction name string"""
         base_name = 'ibmq'
         return base_name
 

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -131,7 +131,7 @@ def write_qiskit_rc(
     os.makedirs(os.path.dirname(filename), exist_ok=True)
 
     unrolled_credentials = {
-        _section_name(credentials_object):
+        _section_name():
             _credentials_object_to_dict(credentials_object, default_provider)
         for _, credentials_object in credentials.items()
     }

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -124,9 +124,6 @@ def write_qiskit_rc(
     def _section_name(credentials_: Credentials) -> str:
         """Return a string suitable for use as a unique section name."""
         base_name = 'ibmq'
-        if credentials_.is_ibmq():
-            base_name = '{}_{}_{}_{}'.format(base_name,
-                                             *credentials_.unique_id().to_tuple())
         return base_name
 
     filename = filename or DEFAULT_QISKITRC_FILE

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -65,8 +65,8 @@ def read_credentials_from_qiskitrc(
     # Build the credentials dictionary.
     credentials_dict = OrderedDict()  # type: ignore[var-annotated]
     default_provider_hgp = None
-    for name in config_parser.sections():
-        single_credentials = dict(config_parser.items(name))
+    if config_parser.has_section('ibmq'):
+        single_credentials = dict(config_parser.items('ibmq'))
 
         # Individually convert keys to their right types.
         # TODO: consider generalizing, moving to json configuration or a more

--- a/releasenotes/notes/load_only_ibmq_sec_qiskitrc-dd1be6270154bff0.yaml
+++ b/releasenotes/notes/load_only_ibmq_sec_qiskitrc-dd1be6270154bff0.yaml
@@ -1,0 +1,8 @@
+---
+prelude: >
+    The qiskitrc file is a flexible way for saving multiple account credentials, among
+    other things.  However, this functionality was removed two years ago.  This
+    adds back that functionality.
+fixes:
+  - |
+    Loads IBM Quantum credentials from only the "ibmq" section of qiskitrc.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The config file `qiskitrc` is capable of handling credentials from multiple different providers.  However, this functionality was removed some time ago.  This allows for that functionality to exist once again by having the `qiskit_ibmq_provider` look for credentials only in the `ibmq` section of the config.


### Details and comments


