### PR TITLE
Deprecate loading from multiple ibmq accounts

### DIFF
--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import warnings
 from ast import literal_eval
 from collections import OrderedDict
 from configparser import ConfigParser, ParsingError
@@ -65,29 +66,35 @@ def read_credentials_from_qiskitrc(
     # Build the credentials dictionary.
     credentials_dict = OrderedDict()  # type: ignore[var-annotated]
     default_provider_hgp = None
+    credentials_count = 0
     for name in config_parser.sections():
-        single_credentials = dict(config_parser.items(name))
+        if name.startswith('ibmq'):
+            single_credentials = dict(config_parser.items(name))
+            credentials_count += 1
+            # Individually convert keys to their right types.
+            # TODO: consider generalizing, moving to json configuration or a more
+            # robust alternative.
+            if 'proxies' in single_credentials.keys():
+                single_credentials['proxies'] = literal_eval(
+                    single_credentials['proxies'])
+            if 'verify' in single_credentials.keys():
+                single_credentials['verify'] = bool(  # type: ignore[assignment]
+                    single_credentials['verify'])
+            if 'default_provider' in single_credentials.keys():
+                default_provider_hgp = HubGroupProject.from_stored_format(
+                    single_credentials['default_provider'])
 
-        # Individually convert keys to their right types.
-        # TODO: consider generalizing, moving to json configuration or a more
-        # robust alternative.
-        if 'proxies' in single_credentials.keys():
-            single_credentials['proxies'] = literal_eval(
-                single_credentials['proxies'])
-        if 'verify' in single_credentials.keys():
-            single_credentials['verify'] = bool(  # type: ignore[assignment]
-                single_credentials['verify'])
-        if 'default_provider' in single_credentials.keys():
-            default_provider_hgp = HubGroupProject.from_stored_format(
-                single_credentials['default_provider'])
+                # Delete `default_provider`, since it's not used by the `Credentials` constructor.
+                del single_credentials['default_provider']
 
-            # Delete `default_provider`, since it's not used by the `Credentials` constructor.
-            del single_credentials['default_provider']
+            new_credentials = Credentials(**single_credentials)  # type: ignore[arg-type]
 
-        new_credentials = Credentials(**single_credentials)  # type: ignore[arg-type]
+            credentials_dict[new_credentials.unique_id()] = new_credentials
 
-        credentials_dict[new_credentials.unique_id()] = new_credentials
-
+    if credentials_count > 1:
+        warnings.warn("Loading from multiple accounts is deprecated and "
+                      "will no longer be supported in future releases.",
+                      DeprecationWarning, stacklevel=4)
     return credentials_dict, default_provider_hgp
 
 

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -66,11 +66,10 @@ def read_credentials_from_qiskitrc(
     # Build the credentials dictionary.
     credentials_dict = OrderedDict()  # type: ignore[var-annotated]
     default_provider_hgp = None
-    credentials_count = 0
+
     for name in config_parser.sections():
         if name.startswith('ibmq'):
             single_credentials = dict(config_parser.items(name))
-            credentials_count += 1
             # Individually convert keys to their right types.
             # TODO: consider generalizing, moving to json configuration or a more
             # robust alternative.
@@ -91,10 +90,6 @@ def read_credentials_from_qiskitrc(
 
             credentials_dict[new_credentials.unique_id()] = new_credentials
 
-    if credentials_count > 1:
-        warnings.warn("Loading from multiple accounts is deprecated and "
-                      "will no longer be supported in future releases.",
-                      DeprecationWarning, stacklevel=4)
     return credentials_dict, default_provider_hgp
 
 

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import warnings
 from ast import literal_eval
 from collections import OrderedDict
 from configparser import ConfigParser, ParsingError

--- a/releasenotes/notes/load_ibmq_accounts_only-281e3c606935aea7.yaml
+++ b/releasenotes/notes/load_ibmq_accounts_only-281e3c606935aea7.yaml
@@ -1,0 +1,8 @@
+---
+prelude: >
+    Loads IBM Quantum credentials only from those sections of the qiskitrc
+    file that start with 'ibmq'.
+upgrade:
+  - |
+    Loads credentials only from sections in qiskitrc starting with ibmq.
+    This allows the qiskitrc to be used for other functionality.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Replaces #823

Looks for `qiskitrc` sections that start with `ibmq`.  If more than one, raises a deprecation warning.


### Details and comments


