### PR TITLE
Add pylintfileheader to tox lint deps

### DIFF
--- a/qiskit/providers/ibmq/credentials/environ.py
+++ b/qiskit/providers/ibmq/credentials/environ.py
@@ -16,7 +16,7 @@
 
 import os
 from collections import OrderedDict
-from typing import Dict, Tuple
+from typing import Dict
 
 from .credentials import Credentials
 from .hubgroupproject import HubGroupProject

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands =
 deps =
   pycodestyle
   pylint
+  pylintfileheader
   doc8
   ipython
 commands =


### PR DESCRIPTION

### Summary

The `tox -e lint` target fails unless `pylintfileheader` is
installed so this adds it to the `deps` list for that target.
This isn't an issue in CI because that uses `requirements-dev.txt`
which the tox.ini config does not.

### Details and comments

Closes #828
