### PR TITLE
Use verify_headers.py from terra instead of pylintfileheader

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,9 +22,6 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=pylint.extensions.docparams, # enable checking of docstring args
     pylint.extensions.docstyle,  # basic docstring style checks
-    pylintfileheader  # Check license comments
-
-file-header=(?:(?:#[^\n]*)?\n)*# This code is part of Qiskit.\n#\n# \(C\) Copyright IBM [0-9, -]*.\n#\n# This code is licensed under the Apache License, Version 2.0. You may\n# obtain a copy of this license in the LICENSE.txt file in the root directory\n# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.\n#\n# Any modifications or derivative works of this code must retain this\n# copyright notice, and modified files need to carry a notice indicating\n# that they have been altered from the originals.\n
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 
 lint:
 	pylint -rn qiskit/providers/ibmq test
+	tools/verify_headers.py qiskit test
 
 mypy:
 	mypy --module qiskit.providers.ibmq --show-error-codes --no-site-packages --python-version 3.7

--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/providers/ibmq/api/__init__.py
+++ b/qiskit/providers/ibmq/api/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/api/clients/__init__.py
+++ b/qiskit/providers/ibmq/api/clients/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/clients/account.py
+++ b/qiskit/providers/ibmq/api/clients/account.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/api/clients/auth.py
+++ b/qiskit/providers/ibmq/api/clients/auth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/clients/base.py
+++ b/qiskit/providers/ibmq/api/clients/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/clients/experiment.py
+++ b/qiskit/providers/ibmq/api/clients/experiment.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/api/clients/random.py
+++ b/qiskit/providers/ibmq/api/clients/random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/api/clients/version.py
+++ b/qiskit/providers/ibmq/api/clients/version.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/clients/websocket.py
+++ b/qiskit/providers/ibmq/api/clients/websocket.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/exceptions.py
+++ b/qiskit/providers/ibmq/api/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/api/rest/__init__.py
+++ b/qiskit/providers/ibmq/api/rest/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/rest/account.py
+++ b/qiskit/providers/ibmq/api/rest/account.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/api/rest/analysis_result.py
+++ b/qiskit/providers/ibmq/api/rest/analysis_result.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/api/rest/backend.py
+++ b/qiskit/providers/ibmq/api/rest/backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/api/rest/base.py
+++ b/qiskit/providers/ibmq/api/rest/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/rest/experiment.py
+++ b/qiskit/providers/ibmq/api/rest/experiment.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/api/rest/job.py
+++ b/qiskit/providers/ibmq/api/rest/job.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/api/rest/random.py
+++ b/qiskit/providers/ibmq/api/rest/random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/api/rest/utils/__init__.py
+++ b/qiskit/providers/ibmq/api/rest/utils/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/api/rest/utils/data_mapper.py
+++ b/qiskit/providers/ibmq/api/rest/utils/data_mapper.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/apiconstants.py
+++ b/qiskit/providers/ibmq/apiconstants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/backendjoblimit.py
+++ b/qiskit/providers/ibmq/backendjoblimit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/backendreservation.py
+++ b/qiskit/providers/ibmq/backendreservation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/credentials/__init__.py
+++ b/qiskit/providers/ibmq/credentials/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/credentials/configrc.py
+++ b/qiskit/providers/ibmq/credentials/configrc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/credentials/credentials.py
+++ b/qiskit/providers/ibmq/credentials/credentials.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/credentials/environ.py
+++ b/qiskit/providers/ibmq/credentials/environ.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/credentials/exceptions.py
+++ b/qiskit/providers/ibmq/credentials/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/credentials/hubgroupproject.py
+++ b/qiskit/providers/ibmq/credentials/hubgroupproject.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/credentials/qconfig.py
+++ b/qiskit/providers/ibmq/credentials/qconfig.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/credentials/updater.py
+++ b/qiskit/providers/ibmq/credentials/updater.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/exceptions.py
+++ b/qiskit/providers/ibmq/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/experiment/__init__.py
+++ b/qiskit/providers/ibmq/experiment/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/experiment/analysis_result.py
+++ b/qiskit/providers/ibmq/experiment/analysis_result.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/experiment/constants.py
+++ b/qiskit/providers/ibmq/experiment/constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/experiment/exceptions.py
+++ b/qiskit/providers/ibmq/experiment/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/experiment/experiment.py
+++ b/qiskit/providers/ibmq/experiment/experiment.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/experiment/experimentservice.py
+++ b/qiskit/providers/ibmq/experiment/experimentservice.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/experiment/utils.py
+++ b/qiskit/providers/ibmq/experiment/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/job/__init__.py
+++ b/qiskit/providers/ibmq/job/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/providers/ibmq/job/job_monitor.py
+++ b/qiskit/providers/ibmq/job/job_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/job/queueinfo.py
+++ b/qiskit/providers/ibmq/job/queueinfo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/providers/ibmq/job/utils.py
+++ b/qiskit/providers/ibmq/job/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/jupyter/__init__.py
+++ b/qiskit/providers/ibmq/jupyter/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2012.

--- a/qiskit/providers/ibmq/jupyter/backend_info.py
+++ b/qiskit/providers/ibmq/jupyter/backend_info.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/config_widget.py
+++ b/qiskit/providers/ibmq/jupyter/config_widget.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/dashboard/__init__.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/dashboard/backend_update.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/backend_update.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/backend_widget.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/dashboard/constants.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/jupyter/dashboard/dashboard.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/dashboard.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/dashboard/job_widgets.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/job_widgets.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/providers/ibmq/jupyter/dashboard/provider_buttons.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/provider_buttons.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/dashboard/utils.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/jupyter/dashboard/watcher_monitor.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/watcher_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/gates_widget.py
+++ b/qiskit/providers/ibmq/jupyter/gates_widget.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/jobs_widget.py
+++ b/qiskit/providers/ibmq/jupyter/jobs_widget.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/jupyter/qubits_widget.py
+++ b/qiskit/providers/ibmq/jupyter/qubits_widget.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/providers/ibmq/jupyter/utils.py
+++ b/qiskit/providers/ibmq/jupyter/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/managed/__init__.py
+++ b/qiskit/providers/ibmq/managed/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/managed/exceptions.py
+++ b/qiskit/providers/ibmq/managed/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/managed/ibmqjobmanager.py
+++ b/qiskit/providers/ibmq/managed/ibmqjobmanager.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/qiskit/providers/ibmq/managed/managedresults.py
+++ b/qiskit/providers/ibmq/managed/managedresults.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/providers/ibmq/managed/utils.py
+++ b/qiskit/providers/ibmq/managed/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/qiskit/providers/ibmq/random/__init__.py
+++ b/qiskit/providers/ibmq/random/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/random/baserandomservice.py
+++ b/qiskit/providers/ibmq/random/baserandomservice.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/random/cqcextractor.py
+++ b/qiskit/providers/ibmq/random/cqcextractor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/random/cqcextractorjob.py
+++ b/qiskit/providers/ibmq/random/cqcextractorjob.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/random/ibmqrandomservice.py
+++ b/qiskit/providers/ibmq/random/ibmqrandomservice.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/random/utils.py
+++ b/qiskit/providers/ibmq/random/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/utils/__init__.py
+++ b/qiskit/providers/ibmq/utils/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/utils/backend.py
+++ b/qiskit/providers/ibmq/utils/backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/utils/converters.py
+++ b/qiskit/providers/ibmq/utils/converters.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/utils/json_decoder.py
+++ b/qiskit/providers/ibmq/utils/json_decoder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/utils/json_encoder.py
+++ b/qiskit/providers/ibmq/utils/json_encoder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/utils/qobj_utils.py
+++ b/qiskit/providers/ibmq/utils/qobj_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/providers/ibmq/utils/utils.py
+++ b/qiskit/providers/ibmq/utils/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/providers/ibmq/version.py
+++ b/qiskit/providers/ibmq/version.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/ibmq/visualization/__init__.py
+++ b/qiskit/providers/ibmq/visualization/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/visualization/colormaps.py
+++ b/qiskit/providers/ibmq/visualization/colormaps.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/visualization/device_layouts.py
+++ b/qiskit/providers/ibmq/visualization/device_layouts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/visualization/exceptions.py
+++ b/qiskit/providers/ibmq/visualization/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/ibmq/visualization/interactive/__init__.py
+++ b/qiskit/providers/ibmq/visualization/interactive/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/qiskit/providers/ibmq/visualization/interactive/error_map.py
+++ b/qiskit/providers/ibmq/visualization/interactive/error_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/visualization/interactive/gate_map.py
+++ b/qiskit/providers/ibmq/visualization/interactive/gate_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/ibmq/visualization/interactive/plotly_wrapper.py
+++ b/qiskit/providers/ibmq/visualization/interactive/plotly_wrapper.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 mypy
 pycodestyle
 pylint==2.4.4
-pylintfileheader>=0.0.2
 vcrpy
 pproxy==2.1.8
 Sphinx>=1.8.3

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/http_server.py
+++ b/test/http_server.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/__init__.py
+++ b/test/ibmq/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2020.

--- a/test/ibmq/test_basic_server_paths.py
+++ b/test/ibmq/test_basic_server_paths.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/ibmq/test_ibmq_factory.py
+++ b/test/ibmq/test_ibmq_factory.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019, 2020.

--- a/test/ibmq/test_ibmq_logger.py
+++ b/test/ibmq/test_ibmq_logger.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/test_jupyter.py
+++ b/test/ibmq/test_jupyter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/test/ibmq/test_random.py
+++ b/test/ibmq/test_random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/test_registration.py
+++ b/test/ibmq/test_registration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/test_tutorials.py
+++ b/test/ibmq/test_tutorials.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ibmq/websocket/__init__.py
+++ b/test/ibmq/websocket/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/test/ibmq/websocket/websocket_server.py
+++ b/test/ibmq/websocket/websocket_server.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/ibmqtestcase.py
+++ b/test/ibmqtestcase.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/jobtestcase.py
+++ b/test/jobtestcase.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import argparse
+import multiprocessing
+import os
+import sys
+import re
+
+# regex for character encoding from PEP 263
+pep263 = re.compile(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+
+def discover_files(code_paths):
+    out_paths = []
+    for path in code_paths:
+        if os.path.isfile(path):
+            out_paths.append(path)
+        else:
+            for directory in os.walk(path):
+                dir_path = directory[0]
+                for subfile in directory[2]:
+                    if subfile.endswith('.py') or subfile.endswith('.pyx'):
+                        out_paths.append(os.path.join(dir_path, subfile))
+    return out_paths
+
+
+def validate_header(file_path):
+    header = """# This code is part of Qiskit.
+#
+"""
+    apache_text = """#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+    count = 0
+    with open(file_path, encoding='utf8') as fd:
+        lines = fd.readlines()
+    start = 0
+    for index, line in enumerate(lines):
+        count += 1
+        if count > 5:
+            return file_path, False, "Header not found in first 5 lines"
+        if count<=2 and pep263.match(line):
+            return file_path, False, "Unnecessary encoding specification (PEP 263, 3120)"
+        if line == "# This code is part of Qiskit.\n":
+            start = index
+            break
+    if ''.join(lines[start:start + 2]) != header:
+        return (file_path, False,
+                "Header up to copyright line does not match: %s" % header)
+    if not lines[start + 2].startswith("# (C) Copyright IBM 20"):
+        return (file_path, False,
+                "Header copyright line not found")
+    if ''.join(lines[start + 3:start + 11]) != apache_text:
+        return (file_path, False,
+                "Header apache text string doesn't match:\n %s" % apache_text)
+    return (file_path, True, None)
+
+
+def main():
+    default_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'qiskit')
+    parser = argparse.ArgumentParser(description="Check file headers.")
+    parser.add_argument("paths", type=str, nargs='*',
+                        default=[default_path],
+                        help='Paths to scan by default uses ../qiskit from the'
+                             ' script')
+    args = parser.parse_args()
+    files = discover_files(args.paths)
+    pool = multiprocessing.Pool()
+    res = pool.map(validate_header, files)
+    failed_files = [x for x in res if x[1] is False]
+    if len(failed_files) > 0:
+        for failed_file in failed_files:
+            sys.stderr.write("%s failed header check because:\n" % failed_file[0])
+            sys.stderr.write("%s\n\n" % failed_file[2])
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
   pycodestyle test
   pylint -rn --rcfile={toxinidir}/.pylintrc test
   doc8 docs
+  {toxinidir}/tools/verify_headers.py qiskit test
 
 [testenv:asv]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The pylintfileheader pylint plugin to verify copyright headers
conform to the project guidelines is problematic for a number of reasons.
The first is it has proven to be unstable there have been several
instances of both users and CI failing on header files that
do not have any issues. This is pretty common with pylint in general
since it's very sensitive to differences in environment. Additionally,
it was using a regex to try and match the entire header string. This
provided no practical debugability when it fails (especially when the
failure is unexpected) because we end up with only a match error.
This commit addresses these issues by removing the use of the regex
based pylint plugin and adding a small script to verify the header in
every qiskit file and provide useful debugging if there is an issue with
a header in a python file.

### Details and comments

This is borrowed from the same script in qiskit-terra, you can see the
full history of it at the point of copying it:
https://github.com/Qiskit/qiskit-terra/blob/5d82781e2467e6663462f939884b80345ff1b2c9/tools/verify_headers.py

Fixes #828