### PR TITLE
Fix tests for python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum api ibmq",

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -89,7 +89,7 @@ class TestWebsocketClientMock(IBMQTestCase):
             # Suppress websockets deprecation warning
             warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
             # Manually cancel any pending asyncio tasks.
-            pending = asyncio.Task.all_tasks()
+            pending = asyncio.all_tasks()
         for task in pending:
             task.cancel()
             try:


### PR DESCRIPTION
✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Tests currently seem to fail due to asyncio API changes in python 3.9, and deprecated in earlier versions, as can be seen [here](https://docs.python.org/3/whatsnew/3.7.html#asyncio)

This is an attempt to fix the same