### PR TITLE
Add start_datetime to tests

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -18,7 +18,7 @@ import copy
 from functools import wraps
 
 from typing import Dict, List, Callable, Optional, Any, Union
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -226,6 +226,11 @@ class IBMQBackendService:
                 cur_dt_filter={},
                 gte_dt=local_to_utc(start_datetime).isoformat() if start_datetime else None,
                 lte_dt=local_to_utc(end_datetime).isoformat() if end_datetime else None)
+        else:
+            start = datetime.now() - timedelta(days=30)
+            api_filter['creationDate'] = self._update_creation_date_filter(
+                cur_dt_filter={},
+                gte_dt=local_to_utc(start).isoformat())
 
         if job_tags:
             validate_job_tags(job_tags, IBMQBackendValueError)

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -18,7 +18,7 @@ import copy
 from functools import wraps
 
 from typing import Dict, List, Callable, Optional, Any, Union
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -226,11 +226,6 @@ class IBMQBackendService:
                 cur_dt_filter={},
                 gte_dt=local_to_utc(start_datetime).isoformat() if start_datetime else None,
                 lte_dt=local_to_utc(end_datetime).isoformat() if end_datetime else None)
-        else:
-            start = datetime.now() - timedelta(days=30)
-            api_filter['creationDate'] = self._update_creation_date_filter(
-                cur_dt_filter={},
-                gte_dt=local_to_utc(start).isoformat())
 
         if job_tags:
             validate_job_tags(job_tags, IBMQBackendValueError)

--- a/test/ibmq/test_basic_server_paths.py
+++ b/test/ibmq/test_basic_server_paths.py
@@ -13,6 +13,7 @@
 """Tests that hit all the basic server endpoints using both a public and premium provider."""
 
 import time
+from datetime import datetime, timedelta
 
 from qiskit import transpile
 from qiskit.test import slow_test
@@ -34,6 +35,7 @@ class TestBasicServerPaths(IBMQTestCase):
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.providers = providers  # Dict[str, AccountProvider]
+        cls.last_week = datetime.now() - timedelta(days=7)
 
     @slow_test
     def test_job_submission(self):
@@ -75,7 +77,8 @@ class TestBasicServerPaths(IBMQTestCase):
                 job = self._submit_job_with_retry(ReferenceCircuits.bell(), backend)
                 job_id = job.job_id()
 
-                retrieved_jobs = provider.backend.jobs(backend_name=backend_name)
+                retrieved_jobs = provider.backend.jobs(
+                    backend_name=backend_name, start_datetime=self.last_week)
                 self.assertGreaterEqual(len(retrieved_jobs), 1)
                 retrieved_job_ids = {job.job_id() for job in retrieved_jobs}
                 self.assertIn(job_id, retrieved_job_ids)

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -215,4 +215,4 @@ class TestIBMQBackendService(IBMQTestCase):
             self.provider.backends.retrieve_job(ref_job.job_id())
             self.provider.backends.jobs(limit=1, start_datetime=self.last_week)
             self.provider.backends.my_reservations()
-            self.assertEqual(len(w), 1)
+            self.assertGreaterEqual(len(w), 1)

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -13,7 +13,7 @@
 """IBMQBackend Test."""
 
 from inspect import getfullargspec
-from datetime import timedelta
+from datetime import timedelta, datetime
 import warnings
 from unittest import SkipTest
 
@@ -189,6 +189,7 @@ class TestIBMQBackendService(IBMQTestCase):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         cls.provider = provider
+        cls.last_week = datetime.now() - timedelta(days=7)
 
     def test_my_reservations(self):
         """Test my_reservations method"""
@@ -201,7 +202,7 @@ class TestIBMQBackendService(IBMQTestCase):
 
     def test_deprecated_service(self):
         """Test deprecated backend service module."""
-        ref_job = self.provider.backend.jobs(limit=1)[0]
+        ref_job = self.provider.backend.jobs(limit=1, start_datetime=self.last_week)[0]
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", category=DeprecationWarning)
@@ -212,6 +213,6 @@ class TestIBMQBackendService(IBMQTestCase):
             warnings.simplefilter("always", category=DeprecationWarning)
             _ = self.provider.backends.ibmq_qasm_simulator
             self.provider.backends.retrieve_job(ref_job.job_id())
-            self.provider.backends.jobs(limit=1)
+            self.provider.backends.jobs(limit=1, start_datetime=self.last_week)
             self.provider.backends.my_reservations()
             self.assertEqual(len(w), 1)

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -55,6 +55,7 @@ class TestIBMQJob(JobTestCase):
         cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
         cls.bell = transpile(ReferenceCircuits.bell(), cls.sim_backend)
         cls.sim_job = cls.sim_backend.run(cls.bell, validate_qobj=True)
+        cls.last_month = datetime.now() - timedelta(days=30)
 
     @slow_test
     @requires_device
@@ -177,7 +178,7 @@ class TestIBMQJob(JobTestCase):
     def test_retrieve_jobs(self):
         """Test retrieving jobs."""
         job_list = self.provider.backend.jobs(
-            backend_name=self.sim_backend.name(), limit=5, skip=0)
+            backend_name=self.sim_backend.name(), limit=5, skip=0, start_datetime=self.last_month)
         self.assertLessEqual(len(job_list), 5)
         for job in job_list:
             self.assertTrue(isinstance(job.job_id(), str))
@@ -237,7 +238,8 @@ class TestIBMQJob(JobTestCase):
         status_args = [JobStatus.DONE, 'DONE', [JobStatus.DONE], ['DONE']]
         for arg in status_args:
             with self.subTest(arg=arg):
-                backend_jobs = self.sim_backend.jobs(limit=5, skip=0, status=arg)
+                backend_jobs = self.sim_backend.jobs(limit=5, skip=0, status=arg,
+                                                     start_datetime=self.last_month)
                 self.assertTrue(backend_jobs)
 
                 for job in backend_jobs:
@@ -264,7 +266,8 @@ class TestIBMQJob(JobTestCase):
         for status_filter in status_filters:
             with self.subTest(status_filter=status_filter):
                 job_list = self.sim_backend.jobs(status=status_filter['status'],
-                                                 db_filter=status_filter['db_filter'])
+                                                 db_filter=status_filter['db_filter'],
+                                                 start_datetime=self.last_month)
                 job_list_ids = [_job.job_id() for _job in job_list]
                 if job_to_cancel.status() is JobStatus.CANCELLED:
                     self.assertIn(job_to_cancel.job_id(), job_list_ids)
@@ -307,7 +310,8 @@ class TestIBMQJob(JobTestCase):
             time.sleep(0.5)
 
         before_status = job._status
-        job_list_queued = backend.jobs(status=JobStatus.QUEUED, limit=5)
+        job_list_queued = backend.jobs(status=JobStatus.QUEUED, limit=5,
+                                       start_datetime=self.last_month)
         if before_status is JobStatus.QUEUED and job.status() is JobStatus.QUEUED:
             self.assertIn(job.job_id(), [queued_job.job_id() for queued_job in job_list_queued],
                           "job {} is queued but not retrieved when filtering for queued jobs."
@@ -331,7 +335,8 @@ class TestIBMQJob(JobTestCase):
             time.sleep(0.5)
 
         before_status = job._status
-        job_list_running = self.sim_backend.jobs(status=JobStatus.RUNNING, limit=5)
+        job_list_running = self.sim_backend.jobs(status=JobStatus.RUNNING, limit=5,
+                                                 start_datetime=self.last_month)
         if before_status is JobStatus.RUNNING and job.status() is JobStatus.RUNNING:
             self.assertIn(job.job_id(), [rjob.job_id() for rjob in job_list_running])
 
@@ -408,7 +413,8 @@ class TestIBMQJob(JobTestCase):
                      'status': 'COMPLETED'}
 
         job_list = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
-                                              limit=2, skip=0, db_filter=my_filter)
+                                              limit=2, skip=0, db_filter=my_filter,
+                                              start_datetime=self.last_month)
         self.assertTrue(job_list)
 
         for job in job_list:
@@ -420,7 +426,7 @@ class TestIBMQJob(JobTestCase):
 
     def test_pagination_filter(self):
         """Test db_filter that could conflict with pagination."""
-        jobs = self.sim_backend.jobs(limit=25)
+        jobs = self.sim_backend.jobs(limit=25, start_datetime=self.last_month)
         job = jobs[3]
         job_utc = local_to_utc(job.creation_date()).isoformat()
 
@@ -442,10 +448,12 @@ class TestIBMQJob(JobTestCase):
         """Test retrieving jobs with different orders."""
         job = self.sim_backend.run(self.bell, validate_qobj=True)
         job.wait_for_final_state()
-        newest_jobs = self.sim_backend.jobs(limit=10, status=JobStatus.DONE, descending=True)
+        newest_jobs = self.sim_backend.jobs(
+            limit=10, status=JobStatus.DONE, descending=True, start_datetime=self.last_month)
         self.assertIn(job.job_id(), [rjob.job_id() for rjob in newest_jobs])
 
-        oldest_jobs = self.sim_backend.jobs(limit=10, status=JobStatus.DONE, descending=False)
+        oldest_jobs = self.sim_backend.jobs(
+            limit=10, status=JobStatus.DONE, descending=False, start_datetime=self.last_month)
         self.assertNotIn(job.job_id(), [rjob.job_id() for rjob in oldest_jobs])
 
     def test_double_submit_fails(self):
@@ -495,7 +503,8 @@ class TestIBMQJob(JobTestCase):
             self.assertTrue(isinstance(new_job.backend(), IBMQRetiredBackend))
             self.assertNotEqual(new_job.backend().name(), 'unknown')
 
-            new_job2 = self.provider.backend.jobs(db_filter={'id': self.sim_job.job_id()})[0]
+            new_job2 = self.provider.backend.jobs(
+                db_filter={'id': self.sim_job.job_id()}, start_datetime=self.last_month)[0]
             self.assertTrue(isinstance(new_job2.backend(), IBMQRetiredBackend))
             self.assertNotEqual(new_job2.backend().name(), 'unknown')
         finally:

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -49,6 +49,7 @@ class TestIBMQJobAttributes(JobTestCase):
         cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
         cls.bell = transpile(ReferenceCircuits.bell(), cls.sim_backend)
         cls.sim_job = cls.sim_backend.run(cls.bell, validate_qobj=True)
+        cls.last_week = datetime.now() - timedelta(days=7)
 
     def setUp(self):
         """Initial test setup."""
@@ -90,16 +91,18 @@ class TestIBMQJobAttributes(JobTestCase):
 
         # Check using partial matching.
         job_name_partial = job_name[8:]
-        retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
-                                                    job_name=job_name_partial)
+        retrieved_jobs = self.provider.backend.jobs(
+            backend_name=self.sim_backend.name(), job_name=job_name_partial,
+            start_datetime=self.last_week)
         self.assertGreaterEqual(len(retrieved_jobs), 1)
         retrieved_job_ids = {job.job_id() for job in retrieved_jobs}
         self.assertIn(job_id, retrieved_job_ids)
 
         # Check using regular expressions.
         job_name_regex = '^{}$'.format(job_name)
-        retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
-                                                    job_name=job_name_regex)
+        retrieved_jobs = self.provider.backend.jobs(
+            backend_name=self.sim_backend.name(), job_name=job_name_regex,
+            start_datetime=self.last_week)
         self.assertEqual(len(retrieved_jobs), 1)
         self.assertEqual(job_id, retrieved_jobs[0].job_id())
 
@@ -133,8 +136,9 @@ class TestIBMQJobAttributes(JobTestCase):
             job = self.sim_backend.run(self.bell, job_name=job_name, validate_qobj=True)
             job_ids.add(job.job_id())
 
-        retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
-                                                    job_name=job_name)
+        retrieved_jobs = self.provider.backend.jobs(
+            backend_name=self.sim_backend.name(), job_name=job_name,
+            start_datetime=self.last_week)
 
         self.assertEqual(len(retrieved_jobs), 2,
                          "More than 2 jobs retrieved: {}".format(retrieved_jobs))
@@ -194,7 +198,8 @@ class TestIBMQJobAttributes(JobTestCase):
         if 'COMPLETED' not in self.sim_job.time_per_step():
             self.sim_job.refresh()
 
-        rjob = self.provider.backend.jobs(db_filter={'id': self.sim_job.job_id()})[0]
+        rjob = self.provider.backend.jobs(
+            db_filter={'id': self.sim_job.job_id()}, start_datetime=self.last_week)[0]
         self.assertFalse(rjob._time_per_step)
         rjob.refresh()
         self.assertEqual(rjob._time_per_step, self.sim_job._time_per_step)
@@ -229,7 +234,8 @@ class TestIBMQJobAttributes(JobTestCase):
                             'between the start date time {} and end date time {}'
                             .format(step, time_data, start_datetime, end_datetime))
 
-        rjob = self.provider.backend.jobs(db_filter={'id': job.job_id()})[0]
+        rjob = self.provider.backend.jobs(
+            db_filter={'id': job.job_id()}, start_datetime=self.last_week)[0]
         self.assertTrue(rjob.time_per_step())
 
     def test_new_job_attributes(self):
@@ -302,7 +308,8 @@ class TestIBMQJobAttributes(JobTestCase):
         job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
         job = self.sim_backend.run(self.bell, job_tags=job_tags, validate_qobj=True)
 
-        rjobs = self.sim_backend.jobs(job_tags=['phantom_tag'])
+        rjobs = self.sim_backend.jobs(
+            job_tags=['phantom_tag'], start_datetime=self.last_week)
         self.assertEqual(len(rjobs), 0,
                          "Expected job {}, got {}".format(job.job_id(), rjobs))
 
@@ -310,7 +317,7 @@ class TestIBMQJobAttributes(JobTestCase):
         tags_to_check = [job_tags, job_tags[1:2], job_tags[0:1]+['phantom_tag']]
         for tags in tags_to_check:
             with self.subTest(tags=tags):
-                rjobs = self.sim_backend.jobs(job_tags=tags)
+                rjobs = self.sim_backend.jobs(job_tags=tags, start_datetime=self.last_week)
                 self.assertEqual(len(rjobs), 1,
                                  "Expected job {}, got {}".format(job.job_id(), rjobs))
                 self.assertEqual(rjobs[0].job_id(), job.job_id())
@@ -324,14 +331,16 @@ class TestIBMQJobAttributes(JobTestCase):
 
         no_rjobs_tags = [job_tags[0:1]+['phantom_tags'], ['phantom_tag']]
         for tags in no_rjobs_tags:
-            rjobs = self.sim_backend.jobs(job_tags=tags, job_tags_operator="AND")
+            rjobs = self.sim_backend.jobs(
+                job_tags=tags, job_tags_operator="AND", start_datetime=self.last_week)
             self.assertEqual(len(rjobs), 0,
                              "Expected job {}, got {}".format(job.job_id(), rjobs))
 
         has_rjobs_tags = [job_tags, job_tags[1:3]]
         for tags in has_rjobs_tags:
             with self.subTest(tags=tags):
-                rjobs = self.sim_backend.jobs(job_tags=tags, job_tags_operator="AND")
+                rjobs = self.sim_backend.jobs(
+                    job_tags=tags, job_tags_operator="AND", start_datetime=self.last_week)
                 self.assertEqual(len(rjobs), 1,
                                  "Expected job {}, got {}".format(job.job_id(), rjobs))
                 self.assertEqual(rjobs[0].job_id(), job.job_id())

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -17,6 +17,7 @@ import time
 from inspect import getfullargspec, isfunction
 import uuid
 from concurrent.futures import wait
+from datetime import datetime, timedelta
 
 from qiskit import QuantumCircuit
 from qiskit.result import Result
@@ -47,6 +48,7 @@ class TestIBMQJobManager(IBMQTestCase):
         super().setUpClass()
         cls.provider = provider
         cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.last_week = datetime.now() - timedelta(days=7)
 
     def setUp(self):
         """Initial test setup."""
@@ -260,7 +262,7 @@ class TestIBMQJobManager(IBMQTestCase):
         while JobStatus.INITIALIZING in job_set.statuses():
             time.sleep(1)
 
-        rjobs = self.provider.backend.jobs(job_tags=job_tags)
+        rjobs = self.provider.backend.jobs(job_tags=job_tags, start_datetime=self.last_week)
         self.assertEqual({job.job_id() for job in job_set.jobs()},
                          {rjob.job_id() for rjob in rjobs},
                          "Unexpected jobs retrieved. Job tag used was {}".format(job_tags))

--- a/test/ibmq/test_jupyter.py
+++ b/test/ibmq/test_jupyter.py
@@ -13,6 +13,7 @@
 """Tests for Jupyter tools."""
 
 from unittest import mock
+from datetime import datetime, timedelta
 
 from qiskit import transpile
 from qiskit.test.reference_circuits import ReferenceCircuits
@@ -77,6 +78,7 @@ class TestBackendInfo(IBMQTestCase):
         """Test jobs tab."""
         def _limit_jobs(**kwargs):
             kwargs['limit'] = 5
+            kwargs['start_datetime'] = datetime.now() - timedelta(days=7)
             return original_backend_jobs(**kwargs)
 
         for backend in self.backends:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Tests that query for jobs have been failing in CI. The API thinks it's due to the number of jobs the CI account has, and that the queries don't have any filters other than `limit`. This PR adds the `start_datetime` filter to all job queries to bypass this issue. It also deletes some duplicate tests from `test_account_client` to reduce the number of tests. 


### Details and comments


