### PR TITLE
Deprecate qobj validation

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -192,9 +192,8 @@ class IBMQBackend(Backend):
                 If the job share level is not specified, the job is not shared at any level.
             job_tags: Tags to be assigned to the job. The tags can subsequently be used
                 as a filter in the :meth:`jobs()` function call.
-            validate_qobj: If ``True``, run JSON schema validation against the
-                submitted payload. Only applicable if a Qobj is passed in. This
-                keyword is deprecated.
+            validate_qobj: DEPRECATED. If ``True``, run JSON schema validation against the
+                submitted payload. Only applicable if a Qobj is passed in.
 
             The following arguments are NOT applicable if a Qobj is passed in.
 
@@ -751,8 +750,8 @@ class IBMQSimulator(IBMQBackend):
                 global level (see :meth:`IBMQBackend.run()<IBMQBackend.run>` for more details).
             job_tags: Tags to be assigned to the jobs. The tags can subsequently be used
                 as a filter in the :meth:`IBMQBackend.jobs()<IBMQBackend.jobs>` method.
-            validate_qobj: If ``True``, run JSON schema validation against the
-                submitted payload
+            validate_qobj: DEPRECATED. If ``True``, run JSON schema validation against the
+                submitted payload.
             backend_options: DEPRECATED dictionary of backend options for the execution.
             noise_model: Noise model.
             kwargs: Additional runtime configuration options. They take

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -148,7 +148,7 @@ class IBMQBackend(Backend):
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
-            validate_qobj: bool = False,
+            validate_qobj: bool = None,
             header: Optional[Dict] = None,
             shots: Optional[int] = None,
             memory: Optional[bool] = None,
@@ -193,7 +193,8 @@ class IBMQBackend(Backend):
             job_tags: Tags to be assigned to the job. The tags can subsequently be used
                 as a filter in the :meth:`jobs()` function call.
             validate_qobj: If ``True``, run JSON schema validation against the
-                submitted payload. Only applicable if a Qobj is passed in.
+                submitted payload. Only applicable if a Qobj is passed in. This
+                keyword is deprecated.
 
             The following arguments are NOT applicable if a Qobj is passed in.
 
@@ -280,8 +281,14 @@ class IBMQBackend(Backend):
                 **run_config)
             qobj = assemble(circuits, self, **run_config_dict)
 
-        if validate_qobj:
-            validate_qobj_against_schema(qobj)
+        if validate_qobj is not None:
+            warnings.warn("The `validate_qobj` keyword is deprecated and will"
+                          "be removed in a future release. "
+                          "You can pull the schemas from the Qiskit/ibmq-schemas "
+                          "repo and directly validate your payloads with that.",
+                          DeprecationWarning, stacklevel=3)
+            if validate_qobj:
+                validate_qobj_against_schema(qobj)
         return self._submit_job(qobj, job_name, api_job_share_level, job_tags)
 
     def _get_run_config(self, **kwargs: Any) -> Dict:

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -281,7 +281,7 @@ class IBMQBackend(Backend):
             qobj = assemble(circuits, self, **run_config_dict)
 
         if validate_qobj is not None:
-            warnings.warn("The `validate_qobj` keyword is deprecated and will"
+            warnings.warn("The `validate_qobj` keyword is deprecated and will "
                           "be removed in a future release. "
                           "You can pull the schemas from the Qiskit/ibmq-schemas "
                           "repo and directly validate your payloads with that.",

--- a/test/ibmq/test_basic_server_paths.py
+++ b/test/ibmq/test_basic_server_paths.py
@@ -110,7 +110,7 @@ class TestBasicServerPaths(IBMQTestCase):
         transpiled = transpile(circs, backend)
         for _ in range(max_retry):
             try:
-                job = backend.run(transpiled, validate_qobj=True)
+                job = backend.run(transpiled)
                 return job
             except IBMQBackendJobLimitError as err:
                 limit_error = err

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -156,7 +156,7 @@ class TestIBMQBackend(IBMQTestCase):
         backend.set_options(qubit_lo_freq=[4.9e9, 5.0e9],
                             meas_lo_freq=[6.5e9, 6.6e9],
                             meas_level=2)
-        job = backend.run(get_pulse_schedule(backend), validate_qobj=True, meas_level=1, foo='foo')
+        job = backend.run(get_pulse_schedule(backend), meas_level=1, foo='foo')
         qobj = backend.retrieve_job(job.job_id()).qobj()  # Use retrieved Qobj.
         self.assertEqual(qobj.config.shots, 2048)
         # Qobj config freq is in GHz.
@@ -172,7 +172,7 @@ class TestIBMQBackend(IBMQTestCase):
         backend = provider.get_backend('ibmq_qasm_simulator')
         backend.options.shots = 2048
         backend.set_options(memory=True)
-        job = backend.run(ReferenceCircuits.bell(), validate_qobj=True, shots=1024, foo='foo')
+        job = backend.run(ReferenceCircuits.bell(), shots=1024, foo='foo')
         qobj = backend.retrieve_job(job.job_id()).qobj()
         self.assertEqual(qobj.config.shots, 1024)
         self.assertTrue(qobj.config.memory)

--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -98,7 +98,7 @@ class TestIBMQIntegration(IBMQTestCase):
         qc_extra.measure(qubit_reg, clbit_reg)
         circs = transpile([qc, qc_extra], backend=self.sim_backend,
                           seed_transpiler=self.seed)
-        job = self.sim_backend.run(circs, validate_qobj=True)
+        job = self.sim_backend.run(circs)
         result = job.result()
         self.assertIsInstance(result, Result)
 

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -282,7 +282,7 @@ class TestIBMQJob(JobTestCase):
         active_job_statuses = {api_status_to_job_status(status) for status in ApiJobStatus
                                if status not in API_JOB_FINAL_STATES}
 
-        job = backend.run(transpile(ReferenceCircuits.bell(), backend), validate_qobj=True)
+        job = backend.run(transpile(ReferenceCircuits.bell(), backend))
 
         active_jobs = backend.active_jobs()
         if not job.in_final_state():    # Job is still active.
@@ -299,7 +299,7 @@ class TestIBMQJob(JobTestCase):
     def test_retrieve_jobs_queued(self):
         """Test retrieving jobs that are queued."""
         backend = most_busy_backend(self.provider)
-        job = backend.run(transpile(ReferenceCircuits.bell(), backend), validate_qobj=True)
+        job = backend.run(transpile(ReferenceCircuits.bell(), backend))
 
         # Wait for the job to queue, run, or reach a final state.
         leave_states = list(JOB_FINAL_STATES) + [JobStatus.QUEUED, JobStatus.RUNNING]
@@ -323,7 +323,7 @@ class TestIBMQJob(JobTestCase):
 
     def test_retrieve_jobs_running(self):
         """Test retrieving jobs that are running."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
 
         # Wait for the job to run, or reach a final state.
         leave_states = list(JOB_FINAL_STATES) + [JobStatus.RUNNING]
@@ -400,7 +400,7 @@ class TestIBMQJob(JobTestCase):
         qc = QuantumCircuit(3, 3)
         qc.h(0)
         qc.measure([0, 1, 2], [0, 1, 2])
-        job = self.sim_backend.run(transpile(qc, backend=self.sim_backend), validate_qobj=True)
+        job = self.sim_backend.run(transpile(qc, backend=self.sim_backend))
         job.wait_for_final_state()
 
         my_filter = {'backend.name': self.sim_backend.name(),
@@ -440,7 +440,7 @@ class TestIBMQJob(JobTestCase):
 
     def test_retrieve_jobs_order(self):
         """Test retrieving jobs with different orders."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
         job.wait_for_final_state()
         newest_jobs = self.sim_backend.jobs(limit=10, status=JobStatus.DONE, descending=True)
         self.assertIn(job.job_id(), [rjob.job_id() for rjob in newest_jobs])
@@ -481,7 +481,7 @@ class TestIBMQJob(JobTestCase):
         excited_sched = x | measure
         schedules = [ground_sched, excited_sched]
 
-        job = backend.run(schedules, validate_qobj=True, meas_level=1, shots=256)
+        job = backend.run(schedules, meas_level=1, shots=256)
         job.wait_for_final_state(wait=300, callback=self.simple_job_callback)
         self.assertTrue(job.done(), "Job {} didn't complete successfully.".format(job.job_id()))
         self.assertIsNotNone(job.result(), "Job {} has no result.".format(job.job_id()))
@@ -557,7 +557,7 @@ class TestIBMQJob(JobTestCase):
                 # Put callback data in a dictionary to make it mutable.
                 callback_info = {'called': False, 'last call time': 0.0, 'last data': {}}
                 cancel_event = Event()
-                job = backend.run(transpile(qc, backend=backend), validate_qobj=True)
+                job = backend.run(transpile(qc, backend=backend))
                 # Cancel the job after a while.
                 Thread(target=job_canceller, args=(job, cancel_event, 60), daemon=True).start()
                 try:
@@ -614,7 +614,7 @@ class TestIBMQJob(JobTestCase):
     def test_job_backend_options(self):
         """Test job backend options."""
         run_config = {'shots': 2048, 'memory': True}
-        job = self.sim_backend.run(self.bell, validate_qobj=True, **run_config)
+        job = self.sim_backend.run(self.bell, **run_config)
         self.assertLessEqual(run_config.items(), job.backend_options().items())
 
     def test_job_header(self):

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -48,7 +48,7 @@ class TestIBMQJobAttributes(JobTestCase):
         cls.provider = provider
         cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
         cls.bell = transpile(ReferenceCircuits.bell(), cls.sim_backend)
-        cls.sim_job = cls.sim_backend.run(cls.bell, validate_qobj=True)
+        cls.sim_job = cls.sim_backend.run(cls.bell)
 
     def setUp(self):
         """Initial test setup."""
@@ -75,7 +75,7 @@ class TestIBMQJobAttributes(JobTestCase):
 
         job_properties = [None]
         large_qx = get_large_circuit(backend=backend)
-        job = backend.run(transpile(large_qx, backend=backend), validate_qobj=True)
+        job = backend.run(transpile(large_qx, backend=backend))
         job.wait_for_final_state(wait=None, callback=_job_callback)
         self.assertIsNotNone(job_properties[0])
 
@@ -83,7 +83,7 @@ class TestIBMQJobAttributes(JobTestCase):
         """Test using job names on a simulator."""
         # Use a unique job name
         job_name = str(time.time()).replace('.', '')
-        job = self.sim_backend.run(self.bell, job_name=job_name, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_name=job_name)
         job_id = job.job_id()
         rjob = self.provider.backend.retrieve_job(job_id)
         self.assertEqual(rjob.name(), job_name)
@@ -107,7 +107,7 @@ class TestIBMQJobAttributes(JobTestCase):
         """Test changing the name associated with a job."""
         # Use a unique job name
         initial_job_name = str(time.time()).replace('.', '')
-        job = self.sim_backend.run(self.bell, job_name=initial_job_name, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_name=initial_job_name)
 
         new_names_to_test = [
             '',  # empty string as name.
@@ -130,7 +130,7 @@ class TestIBMQJobAttributes(JobTestCase):
         job_name = str(time.time()).replace('.', '')
         job_ids = set()
         for _ in range(2):
-            job = self.sim_backend.run(self.bell, job_name=job_name, validate_qobj=True)
+            job = self.sim_backend.run(self.bell, job_name=job_name)
             job_ids.add(job.job_id())
 
         retrieved_jobs = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
@@ -203,7 +203,7 @@ class TestIBMQJobAttributes(JobTestCase):
         """Test retrieving creation date, while ensuring it is in local time."""
         # datetime, before running the job, in local time.
         start_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) - timedelta(seconds=1)
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
         job.result()
         # datetime, after the job is done running, in local time.
         end_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) + timedelta(seconds=1)
@@ -217,7 +217,7 @@ class TestIBMQJobAttributes(JobTestCase):
         """Test retrieving time per step, while ensuring the date times are in local time."""
         # datetime, before running the job, in local time.
         start_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) - timedelta(seconds=1)
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
         job.result()
         # datetime, after the job is done running, in local time.
         end_datetime = datetime.now().replace(tzinfo=tz.tzlocal()) + timedelta(seconds=1)
@@ -242,7 +242,7 @@ class TestIBMQJobAttributes(JobTestCase):
         original_submit = self.sim_backend._api_client.job_submit
         with mock.patch.object(AccountClient, 'job_submit',
                                side_effect=_mocked__api_job_submit):
-            job = self.sim_backend.run(self.bell, validate_qobj=True)
+            job = self.sim_backend.run(self.bell)
 
         self.assertEqual(job.batman_, 'bruce')
 
@@ -251,7 +251,7 @@ class TestIBMQJobAttributes(JobTestCase):
         # Find the most busy backend.
         backend = most_busy_backend(self.provider)
         leave_states = list(JOB_FINAL_STATES) + [JobStatus.RUNNING]
-        job = backend.run(self.bell, validate_qobj=True)
+        job = backend.run(self.bell)
         queue_info = None
         for _ in range(20):
             queue_info = job.queue_info()
@@ -284,13 +284,12 @@ class TestIBMQJobAttributes(JobTestCase):
     def test_invalid_job_share_level(self):
         """Test setting a non existent share level for a job."""
         with self.assertRaises(IBMQBackendValueError) as context_manager:
-            self.sim_backend.run(self.bell, job_share_level='invalid_job_share_level',
-                                 validate_qobj=True)
+            self.sim_backend.run(self.bell, job_share_level='invalid_job_share_level')
         self.assertIn('not a valid job share', context_manager.exception.message)
 
     def test_share_job_in_project(self):
         """Test successfully sharing a job within a shareable project."""
-        job = self.sim_backend.run(self.bell, job_share_level='project', validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_share_level='project')
 
         retrieved_job = self.sim_backend.retrieve_job(job.job_id())
         self.assertEqual(retrieved_job.share_level(), 'project',
@@ -300,7 +299,7 @@ class TestIBMQJobAttributes(JobTestCase):
         """Test using job tags with an or operator."""
         # Use a unique tag.
         job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
-        job = self.sim_backend.run(self.bell, job_tags=job_tags, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=job_tags)
 
         rjobs = self.sim_backend.jobs(job_tags=['phantom_tag'])
         self.assertEqual(len(rjobs), 0,
@@ -320,7 +319,7 @@ class TestIBMQJobAttributes(JobTestCase):
         """Test using job tags with an and operator."""
         # Use a unique tag.
         job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
-        job = self.sim_backend.run(self.bell, job_tags=job_tags, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=job_tags)
 
         no_rjobs_tags = [job_tags[0:1]+['phantom_tags'], ['phantom_tag']]
         for tags in no_rjobs_tags:
@@ -340,7 +339,7 @@ class TestIBMQJobAttributes(JobTestCase):
     def test_job_tags_replace(self):
         """Test updating job tags by replacing a job's existing tags."""
         initial_job_tags = [uuid.uuid4().hex]
-        job = self.sim_backend.run(self.bell, job_tags=initial_job_tags, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=initial_job_tags)
 
         tags_to_replace_subtests = [
             [],  # empty tags.
@@ -355,7 +354,7 @@ class TestIBMQJobAttributes(JobTestCase):
     def test_job_tags_add(self):
         """Test updating job tags by adding to a job's existing tags."""
         initial_job_tags = [uuid.uuid4().hex]
-        job = self.sim_backend.run(self.bell, job_tags=initial_job_tags, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=initial_job_tags)
 
         tags_to_add_subtests = [
             [],  # empty tags.
@@ -370,7 +369,7 @@ class TestIBMQJobAttributes(JobTestCase):
     def test_job_tags_remove(self):
         """Test updating job tags by removing from a job's existing tags."""
         initial_job_tags = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
-        job = self.sim_backend.run(self.bell, job_tags=initial_job_tags, validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=initial_job_tags)
 
         tags_to_remove_subtests = [
             [],
@@ -393,7 +392,7 @@ class TestIBMQJobAttributes(JobTestCase):
 
     def test_job_tags_replace_and_remove(self):
         """Test updating job tags by replacing and removing tags."""
-        job = self.sim_backend.run(self.bell, job_tags=[uuid.uuid4().hex], validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=[uuid.uuid4().hex])
 
         replacement_tags = [uuid.uuid4().hex, uuid.uuid4().hex]
         # Remove the first tag in `replacement_tags`
@@ -408,7 +407,7 @@ class TestIBMQJobAttributes(JobTestCase):
 
     def test_job_tags_all_parameters(self):
         """Test updating job tags by replacing, adding, and removing tags."""
-        job = self.sim_backend.run(self.bell, job_tags=[uuid.uuid4().hex], validate_qobj=True)
+        job = self.sim_backend.run(self.bell, job_tags=[uuid.uuid4().hex])
 
         replacement_tags = [uuid.uuid4().hex, uuid.uuid4().hex]
         additional_tags = [uuid.uuid4().hex, uuid.uuid4().hex]

--- a/test/ibmq/test_ibmq_job_states.py
+++ b/test/ibmq/test_ibmq_job_states.py
@@ -400,7 +400,7 @@ class TestIBMQJobStates(JobTestCase):
         """Creates a new ``IBMQJob`` running with the provided API object."""
         backend = IBMQBackend(mock.Mock(), mock.Mock(), mock.Mock(), api_client=api)
         self._current_api = api
-        self._current_qjob = backend.run(qobj=FakeQobj(), validate_qobj=True)
+        self._current_qjob = backend.run(qobj=FakeQobj())
         self._current_qjob.refresh = mock.Mock()
         return self._current_qjob
 

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -94,7 +94,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
         # TODO Use circuit metadata for individual header when terra PR-5270 is released.
         # qobj.experiments[0].header.some_field = 'extra info'
 
-        job = backend.run(circuits, validate_qobj=True, qobj_header=custom_qobj_header)
+        job = backend.run(circuits, qobj_header=custom_qobj_header)
         result = job.result()
         self.assertTrue(custom_qobj_header.items() <= job.header().items())
         self.assertTrue(custom_qobj_header.items() <= result.header.to_dict().items())

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -39,7 +39,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         qc.measure(qr[0], cr[0])
         circs = transpile(qc, backend=self.sim_backend, seed_transpiler=73846087)
         shots = 1024
-        job = self.sim_backend.run(circs, validate_qobj=True, shots=shots)
+        job = self.sim_backend.run(circs, shots=shots)
         result = job.result()
         counts = result.get_counts(qc)
         target = {'0': shots / 2, '1': shots / 2}
@@ -61,7 +61,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         qcr2.measure(qr[1], cr[1])
         shots = 1024
         circs = transpile([qcr1, qcr2], backend=self.sim_backend, seed_transpiler=73846087)
-        job = self.sim_backend.run(circs, validate_qobj=True, shots=shots)
+        job = self.sim_backend.run(circs, shots=shots)
         result = job.result()
         counts1 = result.get_counts(qcr1)
         counts2 = result.get_counts(qcr2)
@@ -91,7 +91,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         qcr2.measure(qr2[0], cr2[0])
         qcr2.measure(qr2[1], cr2[1])
         circs = transpile([qcr1, qcr2], self.sim_backend, seed_transpiler=8458)
-        job = self.sim_backend.run(circs, validate_qobj=True, shots=1024)
+        job = self.sim_backend.run(circs, shots=1024)
         result = job.result()
         result1 = result.get_counts(qcr1)
         result2 = result.get_counts(qcr2)

--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -41,7 +41,7 @@ class TestSerialization(IBMQTestCase):
 
     def test_qasm_qobj(self):
         """Test serializing qasm qobj data."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
         rqobj = self.sim_backend.retrieve_job(job.job_id()).qobj()
 
         self.assertEqual(_array_to_list(job.qobj().to_dict()), rqobj.to_dict())
@@ -61,7 +61,7 @@ class TestSerialization(IBMQTestCase):
         measure = inst_map.get('measure', range(config.n_qubits)) << x.duration
         schedules = x | measure
 
-        job = backend.run(schedules, validate_qobj=True, meas_level=1, shots=256)
+        job = backend.run(schedules, meas_level=1, shots=256)
         rqobj = backend.retrieve_job(job.job_id()).qobj()
 
         # Convert numpy arrays to lists since they now get converted right
@@ -111,7 +111,7 @@ class TestSerialization(IBMQTestCase):
 
     def test_qasm_job_result(self):
         """Test deserializing a QASM job result."""
-        result = self.sim_backend.run(self.bell, validate_qobj=True).result()
+        result = self.sim_backend.run(self.bell).result()
 
         self._verify_data(result.to_dict(), ())
 

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -60,7 +60,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
     def test_websockets_simulator(self):
         """Test checking status of a job via websockets for a simulator."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True, shots=1)
+        job = self.sim_backend.run(self.bell, shots=1)
 
         # Manually disable the non-websocket polling.
         job._api_client._job_final_status_polling = self._job_final_status_polling
@@ -84,7 +84,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
     def test_websockets_job_final_state(self):
         """Test checking status of a job in a final state via websockets."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
 
         job._wait_for_completion()
 
@@ -99,7 +99,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
     def test_websockets_retry_bad_url(self):
         """Test http retry after websocket error due to an invalid URL."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
 
         saved_websocket_url = job._api_client.client_ws.websocket_url
         try:
@@ -119,7 +119,7 @@ class TestWebsocketIntegration(IBMQTestCase):
                            type_='authentication', data='phantom_token'))
     def test_websockets_retry_bad_auth(self, _):
         """Test http retry after websocket error due to a failed authentication."""
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
 
         with mock.patch.object(AccountClient, 'job_status',
                                side_effect=job._api_client.job_status) as mocked_wait:
@@ -136,7 +136,7 @@ class TestWebsocketIntegration(IBMQTestCase):
             job._job_id = saved_job_id
             return saved_job_status(saved_job_id)
 
-        job = self.sim_backend.run(self.bell, validate_qobj=True)
+        job = self.sim_backend.run(self.bell)
 
         # Save the originals.
         saved_job_id = job._job_id
@@ -169,7 +169,7 @@ class TestWebsocketIntegration(IBMQTestCase):
 
         def _run_job_get_result(q):
             """Run a job and get its result."""
-            job = self.sim_backend.run(self.bell, validate_qobj=True)
+            job = self.sim_backend.run(self.bell)
             # Manually disable the non-websocket polling.
             job._api_client._job_final_status_polling = self._job_final_status_polling
             job._wait_for_completion()

--- a/test/utils.py
+++ b/test/utils.py
@@ -146,7 +146,7 @@ def submit_job_bad_shots(backend: IBMQBackend) -> IBMQJob:
     """
     qobj = bell_in_qobj(backend=backend)
     qobj.config.shots = 10000  # Modify the number of shots to be an invalid amount.
-    job_to_fail = backend.run(qobj, validate_qobj=True)
+    job_to_fail = backend.run(qobj)
     return job_to_fail
 
 
@@ -162,7 +162,7 @@ def submit_job_one_bad_instr(backend: IBMQBackend) -> IBMQJob:
     qc_new = transpile(ReferenceCircuits.bell(), backend)
     qobj = assemble([qc_new]*2, backend=backend)
     qobj.experiments[1].instructions[1].name = 'bad_instruction'
-    job = backend.run(qobj, validate_qobj=True)
+    job = backend.run(qobj)
     return job
 
 
@@ -176,7 +176,7 @@ def submit_and_cancel(backend: IBMQBackend) -> IBMQJob:
         Cancelled job.
     """
     qobj = bell_in_qobj(backend=backend)
-    job = backend.run(qobj, validate_qobj=True)
+    job = backend.run(qobj)
     cancel_job(job, True)
     return job
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #800. 

Deprecate `validate_qobj` in `backend.run()`. The Qobj JSON schema has been moved to a separate repo, so validation can no longer be done easily. Since the default for `validate_qobj` is False, and Qobj is validated in IQX regardless, we can just deprecate it now and remove later.


### Details and comments


