### PR TITLE
Stop hard coding gate names in backend monitor

### DIFF
--- a/docs/tutorials/1_the_ibmq_account.ipynb
+++ b/docs/tutorials/1_the_ibmq_account.ipynb
@@ -232,10 +232,10 @@
        " <IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmq_vigo') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_london') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_burlington') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_essex') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>]"
+       " <IBMQBackend('ibmq_valencia') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_athens') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>]"
       ]
      },
      "execution_count": 4,
@@ -309,10 +309,10 @@
        " <IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmq_vigo') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_london') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_burlington') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_essex') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>]"
+       " <IBMQBackend('ibmq_valencia') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_athens') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>]"
       ]
      },
      "execution_count": 6,
@@ -328,7 +328,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or, only those backends that are real devices, have more than 10 qubits, and are operational"
+    "You can also filter by the minimum number of qubits the backends must have:"
    ]
   },
   {
@@ -353,9 +353,7 @@
     }
    ],
    "source": [
-    "provider.backends(filters=lambda x: x.configuration().n_qubits >= 10\n",
-    "                                    and not x.configuration().simulator\n",
-    "                                    and x.status().operational==True)"
+    "provider.backends(min_num_qubits=10, simulator=False, operational=True)"
    ]
   },
   {
@@ -376,22 +374,19 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<IBMQBackend('ibmq_london') from IBMQ(hub='ibm-q', group='open', project='main')>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ibmq_ourense\n"
+     ]
     }
    ],
    "source": [
     "from qiskit.providers.ibmq import least_busy\n",
     "\n",
-    "small_devices = provider.backends(filters=lambda x: x.configuration().n_qubits == 5\n",
-    "                                   and not x.configuration().simulator)\n",
-    "least_busy(small_devices)"
+    "small_devices = provider.backends(min_num_qubits=5, simulator=False, operational=True)\n",
+    "backend = least_busy(small_devices)\n",
+    "print(backend)"
    ]
   },
   {
@@ -513,7 +508,7 @@
     {
      "data": {
       "text/plain": [
-       "'ibmq_london'"
+       "'ibmq_ourense'"
       ]
      },
      "execution_count": 11,
@@ -538,7 +533,11 @@
     {
      "data": {
       "text/plain": [
-       "BackendStatus(backend_name='ibmq_london', backend_version='1.1.0', operational=True, pending_jobs=13, status_msg='active')"
+       "{'backend_name': 'ibmq_ourense',\n",
+       " 'backend_version': '1.3.4',\n",
+       " 'operational': True,\n",
+       " 'pending_jobs': 3,\n",
+       " 'status_msg': 'active'}"
       ]
      },
      "execution_count": 12,
@@ -547,7 +546,7 @@
     }
    ],
    "source": [
-    "backend.status()"
+    "backend.status().to_dict()"
    ]
   },
   {
@@ -573,7 +572,79 @@
     {
      "data": {
       "text/plain": [
-       "QasmBackendConfiguration(allow_object_storage=True, allow_q_circuit=False, allow_q_object=True, backend_name='ibmq_london', backend_version='1.1.0', basis_gates=['u1', 'u2', 'u3', 'cx', 'id'], conditional=False, coupling_map=[[0, 1], [1, 0], [1, 2], [1, 3], [2, 1], [3, 1], [3, 4], [4, 3]], credits_required=True, description='5 qubit device London', gates=[GateConfig(coupling_map=[[0], [1], [2], [3], [4]], name='id', parameters=[], qasm_def='gate id q { U(0,0,0) q; }'), GateConfig(coupling_map=[[0], [1], [2], [3], [4]], name='u1', parameters=['lambda'], qasm_def='gate u1(lambda) q { U(0,0,lambda) q; }'), GateConfig(coupling_map=[[0], [1], [2], [3], [4]], name='u2', parameters=['phi', 'lambda'], qasm_def='gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }'), GateConfig(coupling_map=[[0], [1], [2], [3], [4]], name='u3', parameters=['theta', 'phi', 'lambda'], qasm_def='gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }'), GateConfig(coupling_map=[[0, 1], [1, 0], [1, 2], [1, 3], [2, 1], [3, 1], [3, 4], [4, 3]], name='cx', parameters=[], qasm_def='gate cx q1,q2 { CX q1,q2; }')], local=False, max_experiments=75, max_shots=8192, memory=True, n_qubits=5, n_registers=1, online_date=datetime.datetime(2019, 9, 13, 4, 0, tzinfo=datetime.timezone.utc), open_pulse=False, quantum_volume=16, sample_name='Giraffe', simulator=False, url='None')"
+       "{'backend_name': 'ibmq_ourense',\n",
+       " 'backend_version': '1.3.4',\n",
+       " 'n_qubits': 5,\n",
+       " 'basis_gates': ['id', 'u1', 'u2', 'u3', 'cx'],\n",
+       " 'gates': [{'name': 'id',\n",
+       "   'parameters': [],\n",
+       "   'qasm_def': 'gate id q { U(0,0,0) q; }',\n",
+       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+       "  {'name': 'u1',\n",
+       "   'parameters': ['lambda'],\n",
+       "   'qasm_def': 'gate u1(lambda) q { U(0,0,lambda) q; }',\n",
+       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+       "  {'name': 'u2',\n",
+       "   'parameters': ['phi', 'lambda'],\n",
+       "   'qasm_def': 'gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }',\n",
+       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+       "  {'name': 'u3',\n",
+       "   'parameters': ['theta', 'phi', 'lambda'],\n",
+       "   'qasm_def': 'gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }',\n",
+       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+       "  {'name': 'cx',\n",
+       "   'parameters': [],\n",
+       "   'qasm_def': 'gate cx q1,q2 { CX q1,q2; }',\n",
+       "   'coupling_map': [[0, 1],\n",
+       "    [1, 0],\n",
+       "    [1, 2],\n",
+       "    [1, 3],\n",
+       "    [2, 1],\n",
+       "    [3, 1],\n",
+       "    [3, 4],\n",
+       "    [4, 3]]}],\n",
+       " 'local': False,\n",
+       " 'simulator': False,\n",
+       " 'conditional': False,\n",
+       " 'open_pulse': False,\n",
+       " 'memory': True,\n",
+       " 'max_shots': 8192,\n",
+       " 'coupling_map': [[0, 1],\n",
+       "  [1, 0],\n",
+       "  [1, 2],\n",
+       "  [1, 3],\n",
+       "  [2, 1],\n",
+       "  [3, 1],\n",
+       "  [3, 4],\n",
+       "  [4, 3]],\n",
+       " 'dynamic_reprate_enabled': True,\n",
+       " 'supported_instructions': ['cx',\n",
+       "  'id',\n",
+       "  'delay',\n",
+       "  'measure',\n",
+       "  'reset',\n",
+       "  'rz',\n",
+       "  'sx',\n",
+       "  'u1',\n",
+       "  'u2',\n",
+       "  'u3',\n",
+       "  'x'],\n",
+       " 'rep_delay_range': [0.0, 500.0],\n",
+       " 'default_rep_delay': 250.0,\n",
+       " 'max_experiments': 75,\n",
+       " 'sample_name': 'Giraffe',\n",
+       " 'n_registers': 1,\n",
+       " 'credits_required': True,\n",
+       " 'online_date': datetime.datetime(2019, 7, 3, 4, 0, tzinfo=tzutc()),\n",
+       " 'description': '5 qubit device Ourense',\n",
+       " 'allow_q_object': True,\n",
+       " 'dt': 2.222222222222222e-19,\n",
+       " 'dtm': 2.222222222222222e-19,\n",
+       " 'meas_map': [[0, 1, 2, 3, 4]],\n",
+       " 'multi_meas_enabled': False,\n",
+       " 'quantum_volume': 8,\n",
+       " 'url': 'None',\n",
+       " 'allow_object_storage': True}"
       ]
      },
      "execution_count": 13,
@@ -582,7 +653,7 @@
     }
    ],
    "source": [
-    "backend.configuration()"
+    "backend.configuration().to_dict()"
    ]
   },
   {
@@ -596,7 +667,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The backend properties contain data that was measured and reported. Let’s see what kind of information is reported for qubit 0."
+    "The backend properties contain data that was measured and reported. Let’s see what kind of information is reported for qubit 0.\n",
+    "\n",
+    "**Note:** The following example displays the properties of the `SX` gate. Each backend may have different basis gates which may not contain `SX`. "
    ]
   },
   {
@@ -614,11 +687,11 @@
      "output_type": "stream",
      "text": [
       "Qubit 0 has a \n",
-      "  - T1 time of 51.02535497467796 microseconds\n",
-      "  - T2 time of 64.94034230870064 microseconds\n",
-      "  - U2 gate error of 0.0004548221745549926\n",
-      "  - U2 gate duration of 35.555555555555564 nanoseconds\n",
-      "  - resonant frequency of 5.253962087591581 GHz\n"
+      "  - T1 time of 0.000118798578854076 microseconds\n",
+      "  - T2 time of 8.30176098567665e-05 microseconds\n",
+      "  - SX gate error of 0.0003355394204181594\n",
+      "  - SX gate duration of 35.55555555555556 nanoseconds\n",
+      "  - resonant frequency of 4.820326782885405 GHz\n"
      ]
     }
    ],
@@ -633,18 +706,12 @@
     "    ns = 1e9\n",
     "    GHz = 1e-9\n",
     "\n",
-    "    print(\"Qubit {0} has a \\n\"\n",
-    "          \"  - T1 time of {1} microseconds\\n\"\n",
-    "          \"  - T2 time of {2} microseconds\\n\"\n",
-    "          \"  - U2 gate error of {3}\\n\"\n",
-    "          \"  - U2 gate duration of {4} nanoseconds\\n\"\n",
-    "          \"  - resonant frequency of {5} GHz\".format(\n",
-    "              qubit,\n",
-    "              properties.t1(qubit) * us,\n",
-    "              properties.t2(qubit) * us,\n",
-    "              properties.gate_error('u2', qubit),\n",
-    "              properties.gate_length('u2', qubit) * ns,\n",
-    "              properties.frequency(qubit) * GHz))\n",
+    "    print(f\"Qubit {qubit} has a \\n\"\n",
+    "          f\"  - T1 time of {properties.t1(qubit)} microseconds\\n\"\n",
+    "          f\"  - T2 time of {properties.t2(qubit)} microseconds\\n\"\n",
+    "          f\"  - SX gate error of {properties.gate_error('sx', qubit)}\\n\"\n",
+    "          f\"  - SX gate duration of {properties.gate_length('sx', qubit)*ns} nanoseconds\\n\"\n",
+    "          f\"  - resonant frequency of {properties.frequency(qubit) * GHz} GHz\")\n",
     "\n",
     "describe_qubit(0, props)"
    ]
@@ -670,11 +737,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5e6c0084b3616d0012fc9681 JobStatus.DONE\n",
-      "5e6c00826234450011f85c1a JobStatus.DONE\n",
-      "5e6c0080796a7e00116a1993 JobStatus.DONE\n",
-      "5e6c007d796a7e00116a1991 JobStatus.DONE\n",
-      "5e6bfb71d9955f00196216f7 JobStatus.DONE\n"
+      "5fb48d2ae4314600192a1c2c JobStatus.DONE\n",
+      "5fb48ce2c76d75001a2089a1 JobStatus.DONE\n",
+      "5fb48ce103cb100019752e28 JobStatus.DONE\n",
+      "5fb48c0de4314600192a1c1c JobStatus.DONE\n",
+      "5fb48b8d130b8000199af33b JobStatus.DONE\n"
      ]
     }
    ],
@@ -762,11 +829,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5e6c0084b3616d0012fc9681 JobStatus.DONE\n",
-      "5e6c00826234450011f85c1a JobStatus.DONE\n",
-      "5e6c0080796a7e00116a1993 JobStatus.DONE\n",
-      "5e6c007d796a7e00116a1991 JobStatus.DONE\n",
-      "5e6bfb71d9955f00196216f7 JobStatus.DONE\n"
+      "5fdccad1c01fec001a47e018 JobStatus.QUEUED\n",
+      "5fdcc5fad4445500193f0072 JobStatus.DONE\n",
+      "5fdcc5f923da0f001acf6f67 JobStatus.DONE\n",
+      "5fdcc5f9d4445500193f0071 JobStatus.DONE\n",
+      "5fdcc41b23da0f001acf6f44 JobStatus.DONE\n"
      ]
     }
    ],
@@ -843,7 +910,7 @@
     {
      "data": {
       "text/plain": [
-       "<qiskit.circuit.instructionset.InstructionSet at 0x140df8a90>"
+       "<qiskit.circuit.instructionset.InstructionSet at 0x14338efd0>"
       ]
      },
      "execution_count": 21,
@@ -882,7 +949,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, you can map the circuit yourself using the transpile function, package it using assemble, and then send it from the backend instance itself:"
+    "Alternatively, you can map the circuit yourself using the transpile function and then send it from the backend instance:"
    ]
   },
   {
@@ -892,8 +959,7 @@
    "outputs": [],
    "source": [
     "mapped_circuit = transpile(circuit, backend=backend)\n",
-    "qobj = assemble(mapped_circuit, backend=backend, shots=1024)\n",
-    "job = backend.run(qobj)"
+    "job = backend.run(mapped_circuit, shots=1024)"
    ]
   },
   {
@@ -916,7 +982,7 @@
     {
      "data": {
       "text/plain": [
-       "<JobStatus.QUEUED: 'job is queued'>"
+       "<JobStatus.VALIDATING: 'job is being validated'>"
       ]
      },
      "execution_count": 24,
@@ -948,7 +1014,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_london') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 25,
@@ -981,7 +1047,7 @@
     {
      "data": {
       "text/plain": [
-       "'5e7a74587ced2300119955ad'"
+       "'5fdccb1ad4445500193f00db'"
       ]
      },
      "execution_count": 26,
@@ -1014,7 +1080,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'00001': 24, '00010': 15, '00011': 536, '00000': 449}\n"
+      "{'000': 24, '001': 53, '010': 28, '011': 56, '100': 26, '101': 801, '110': 13, '111': 23}\n"
      ]
     }
    ],
@@ -1044,7 +1110,7 @@
     {
      "data": {
       "text/plain": [
-       "'2020-03-24T20:58:06.318000Z'"
+       "datetime.datetime(2020, 12, 18, 10, 30, 34, 565000, tzinfo=tzlocal())"
       ]
      },
      "execution_count": 28,
@@ -1119,7 +1185,7 @@
      "output_type": "stream",
      "text": [
       "Job set name: foo\n",
-      "          ID: 5fa68392e6714bb2acdec298a522a0e3-1585083519668288\n",
+      "          ID: 2fa120072a5c4e36b8d8962447e0a735-1608305475658714\n",
       "        tags: []\n",
       "Summary report:\n",
       "       Total jobs: 1\n",
@@ -1167,7 +1233,7 @@
      "output_type": "stream",
      "text": [
       "Job set name: bar\n",
-      "          ID: 7b49c80519844e31aa5ce42b6e58a810-1585083523758528\n",
+      "          ID: a2f2bb71c2ca49d19c93e3582c0b42a1-1608305475723409\n",
       "        tags: []\n",
       "Summary report:\n",
       "       Total jobs: 2\n",
@@ -1239,7 +1305,7 @@
      "output_type": "stream",
      "text": [
       "Job set name: bar\n",
-      "          ID: 7b49c80519844e31aa5ce42b6e58a810-1585083523758528\n",
+      "          ID: a2f2bb71c2ca49d19c93e3582c0b42a1-1608305475723409\n",
       "        tags: []\n",
       "Summary report:\n",
       "       Total jobs: 2\n",
@@ -1328,8 +1394,8 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.15.0</td></tr><tr><td>Terra</td><td>0.12.0</td></tr><tr><td>Aer</td><td>0.4.0</td></tr><tr><td>Ignis</td><td>0.2.0</td></tr><tr><td>Aqua</td><td>0.6.4</td></tr><tr><td>IBM Q Provider</td><td>0.5.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.6.7 (v3.6.7:6ec5cf24b7, Oct 20 2018, 03:02:14) \n",
-       "[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Tue Mar 24 16:59:02 2020 EDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.23.1</td></tr><tr><td>Terra</td><td>0.16.1</td></tr><tr><td>Aer</td><td>0.7.1</td></tr><tr><td>Ignis</td><td>0.5.1</td></tr><tr><td>Aqua</td><td>0.8.1</td></tr><tr><td>IBM Q Provider</td><td>0.12.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.6.5 (default, Jul 15 2020, 16:10:25) \n",
+       "[GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.32.62)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Dec 18 10:31:22 2020 EST</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1382,7 +1448,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.5"
   },
   "varInspector": {
    "cols": {

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -129,7 +129,7 @@ class IBMQBackendService:
 
         if min_num_qubits:
             backends = list(filter(
-                lambda b: b.configuration().n_qubits > min_num_qubits, backends))
+                lambda b: b.configuration().n_qubits >= min_num_qubits, backends))
 
         return filter_backends(backends, filters=filters, **kwargs)
 

--- a/qiskit/providers/ibmq/jupyter/qubits_widget.py
+++ b/qiskit/providers/ibmq/jupyter/qubits_widget.py
@@ -29,9 +29,8 @@ def qubits_tab(backend: Union[IBMQBackend, FakeBackend]) -> wid.VBox:
     Returns:
         A widget containing qubit information.
     """
-    props = backend.properties().to_dict()
-
-    update_date = props['last_update_date']
+    props = backend.properties()
+    update_date = props.last_update_date
     date_str = update_date.strftime("%a %d %B %Y at %H:%M %Z")
     header_html = "<div><font style='font-weight:bold'>{key}</font>: {value}</div>"
     header_html = header_html.format(key='last_update_date',
@@ -54,43 +53,43 @@ tr:nth-child(even) {background-color: #f6f6f6 !important;}
 </style>"""
 
     qubit_html += "<tr><th></th><th>Frequency</th><th>T1</th><th>T2</th>"
-    qubit_html += "<th>U1 error</th><th>U2 error</th><th>U3 error</th>"
-    qubit_html += "<th>Readout error</th></tr>"
     qubit_footer = "</table>"
 
-    for qub in range(len(props['qubits'])):
-        name = 'Q%s' % qub
-        qubit_data = props['qubits'][qub]
-        gate_data = [g for g in props['gates'] if g['qubits'] == [qub]]
-        t1_info = qubit_data[0]
-        t2_info = qubit_data[1]
-        freq_info = qubit_data[2]
-        readout_info = qubit_data[3]
+    gate_error_title = ""
 
-        freq = str(round(freq_info['value'], 3))+' '+freq_info['unit']
-        T1 = str(round(t1_info['value'],
-                       3))+' ' + t1_info['unit']
-        T2 = str(round(t2_info['value'],
-                       3))+' ' + t2_info['unit']
+    for index, qubit_data in enumerate(props.qubits):
+        name = 'Q%s' % index
+        gate_data = [gate for gate in props.gates if gate.qubits == [index]]
 
+        cali_data = dict.fromkeys(['T1', 'T2', 'frequency', 'readout_error'], 'Unknown')
+        for nduv in qubit_data:
+            if nduv.name == 'readout_error':
+                cali_data[nduv.name] = str(round(nduv.value*100, 3))
+            elif nduv.name in cali_data.keys():
+                cali_data[nduv.name] = str(round(nduv.value, 3)) + ' ' + nduv.unit
+
+        gate_names = []
+        gate_error = []
         for gd in gate_data:
-            if gd['gate'] == 'u1':
-                U1 = str(round(gd['parameters'][0]['value']*100, 3))
-                break
+            if gd.gate == 'id':
+                continue
+            for gd_param in gd.parameters:
+                if gd_param.name == 'gate_error':
+                    gate_names.append(gd.gate)
+                    gate_error.append(str(round(gd_param.value*100, 3)))
 
-        for gd in gate_data:
-            if gd['gate'] == 'u2':
-                U2 = str(round(gd['parameters'][0]['value']*100, 3))
-                break
-        for gd in gate_data:
-            if gd['gate'] == 'u3':
-                U3 = str(round(gd['parameters'][0]['value']*100, 3))
-                break
+        if not gate_error_title:
+            for gname in gate_names:
+                gate_error_title += f"<th>{gname}</th>"
+            qubit_html += gate_error_title + "<th>Readout error (e-2)</th></tr>"
 
-        readout_error = round(readout_info['value']*100, 3)
-        qubit_html += "<tr><td><font style='font-weight:bold'>%s</font></td><td>%s</td>"
-        qubit_html += "<td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>"
-        qubit_html = qubit_html % (name, freq, T1, T2, U1, U2, U3, readout_error)
+        qubit_html += f"<tr><td><font style='font-weight:bold'>{name}</font></td>"
+        qubit_html += f"<td>{cali_data['frequency']}</td>" \
+                      f"<td>{cali_data['T1']}</td><td>{cali_data['T2']}</td>"
+        for gerror in gate_error:
+            qubit_html += f"<td>{gerror}</td>"
+        qubit_html += f"<td>{cali_data['readout_error']}</td>"
+
     qubit_html += qubit_footer
 
     qubit_widget = wid.HTML(value=qubit_html, layout=wid.Layout(width='100%'))

--- a/qiskit/providers/ibmq/jupyter/qubits_widget.py
+++ b/qiskit/providers/ibmq/jupyter/qubits_widget.py
@@ -71,7 +71,7 @@ tr:nth-child(even) {background-color: #f6f6f6 !important;}
         gate_names = []
         gate_error = []
         for gd in gate_data:
-            if gd.gate == 'id':
+            if gd.gate in ['rz', 'id']:
                 continue
             for gd_param in gd.parameters:
                 if gd_param.name == 'gate_error':

--- a/qiskit/providers/ibmq/jupyter/qubits_widget.py
+++ b/qiskit/providers/ibmq/jupyter/qubits_widget.py
@@ -75,13 +75,13 @@ tr:nth-child(even) {background-color: #f6f6f6 !important;}
                 continue
             for gd_param in gd.parameters:
                 if gd_param.name == 'gate_error':
-                    gate_names.append(gd.gate)
+                    gate_names.append(gd.gate.upper())
                     gate_error.append(str(round(gd_param.value*100, 3)))
 
         if not gate_error_title:
             for gname in gate_names:
                 gate_error_title += f"<th>{gname}</th>"
-            qubit_html += gate_error_title + "<th>Readout error (e-2)</th></tr>"
+            qubit_html += gate_error_title + "<th>Readout error</th></tr>"
 
         qubit_html += f"<tr><td><font style='font-weight:bold'>{name}</font></td>"
         qubit_html += f"<td>{cali_data['frequency']}</td>" \

--- a/releasenotes/notes/jupyter-gates-c0daee55cd6625d0.yaml
+++ b/releasenotes/notes/jupyter-gates-c0daee55cd6625d0.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the issue wherein using Jupyter backend widget would fail if the
+    backend's basis gates do not include the traditional u1, u2, and u3.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ matplotlib>=2.1
 jupyter
 plotly>=4.4
 ipyvuetify>=1.1
+ipyvue>=1.4.1
 ipython>=5.0.0
 seaborn>=0.9.0
 pyperclip>=1.7

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ setup(
     extras_require={'visualization': ['matplotlib>=2.1', 'ipywidgets>=7.3.0',
                                       "seaborn>=0.9.0", "plotly>=4.4",
                                       "ipyvuetify>=1.1", "pyperclip>=1.7",
-                                      "ipython>=5.0.0", "traitlets!=5.0.5"]},
+                                      "ipython>=5.0.0", "traitlets!=5.0.5",
+                                      "ipyvue>=1.4.1"]},
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-ibmq-provider/issues",
         "Documentation": "https://qiskit.org/documentation/",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #844. 

A number of IBMQ backends now have different basis gates than the traditional u1,u2,u3. The backend Jupyter magic, however, has those gates hard coded. This PR iterates through the gate data and uses their actual names instead. 

In addition, `iqx_dashboard` would below up with 
```
TypeError: `NoneType` object is not iterable
```
when using older version of `ipyvue`. This PR also changes the required version to >=1.4.1


### Details and comments


