### PR TITLE
Reservation scheduling mode now visible to all

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -673,8 +673,8 @@ class IBMQBackend(Backend):
         If start_datetime and/or end_datetime is specified, reservations with
         time slots that overlap with the specified time window will be returned.
 
-        Some of the reservation information, such as scheduling mode, is only
-        available if you are the owner of the reservation.
+        Some of the reservation information is only available if you are the
+        owner of the reservation.
 
         Args:
             start_datetime: Filter by the given start date/time, in local timezone.

--- a/releasenotes/notes/reservation-mode-39261553acef4454.yaml
+++ b/releasenotes/notes/reservation-mode-39261553acef4454.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The :meth:`qiskit.providers.ibmq.IBMQBackend.reservations` method
+    now always returns the reservation scheduling modes even for
+    reservations that you don't own.

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -106,18 +106,18 @@ class TestIBMQBackend(IBMQTestCase):
 
         reserv = reservations[0]
         self.assertGreater(reserv.duration, 0)
+        self.assertTrue(reserv.mode)
         before_start = reserv.start_datetime - timedelta(seconds=30)
-        # after_start = reserv.start_datetime + timedelta(seconds=30)
+        after_start = reserv.start_datetime + timedelta(seconds=30)
         before_end = reserv.end_datetime - timedelta(seconds=30)
         after_end = reserv.end_datetime + timedelta(seconds=30)
 
         # Each tuple contains the start datetime, end datetime, whether a
         # reservation should be found, and the description.
-        # TODO re-enable sub test 3 after API is updated.
         sub_tests = [
             (before_start, after_end, True, 'before start, after end'),
             (before_start, before_end, True, 'before start, before end'),
-            # (after_start, before_end, True, 'after start, before end'),
+            (after_start, before_end, True, 'after start, before end'),
             (before_start, None, True, 'before start, None'),
             (None, after_end, True, 'None, after end'),
             (before_start, before_start, False, 'before start, before start'),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #795. 
The scheduling mode for a reservation is now visible to all and not just to the owner. This PR updates the related docstrings and test. 


### Details and comments


