### PR TITLE
Support filtering experiments by hub/group/project

### DIFF
--- a/qiskit/providers/ibmq/api/clients/experiment.py
+++ b/qiskit/providers/ibmq/api/clients/experiment.py
@@ -50,7 +50,10 @@ class ExperimentClient(BaseClient):
             experiment_type: Optional[str] = None,
             start_time: Optional[List] = None,
             device_components: Optional[List[str]] = None,
-            tags: Optional[List[str]] = None
+            tags: Optional[List[str]] = None,
+            hub: Optional[str] = None,
+            group: Optional[str] = None,
+            project: Optional[str] = None
     ) -> Dict:
         """Retrieve experiments, with optional filtering.
 
@@ -62,12 +65,16 @@ class ExperimentClient(BaseClient):
             start_time: A list of timestamps used to filter by experiment start time.
             device_components: A list of device components used for filtering.
             tags: Tags used for filtering.
+            hub: Filter by hub.
+            group: Filter by hub and group.
+            project: Filter by hub, group, and project.
 
         Returns:
             A list of experiments and the marker, if applicable.
         """
         resp = self.base_api.experiments(
-            limit, marker, backend_name, experiment_type, start_time, device_components, tags)
+            limit, marker, backend_name, experiment_type, start_time, device_components, tags,
+            hub, group, project)
         return resp
 
     def experiment_get(self, experiment_id: str) -> Dict:

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -154,7 +154,10 @@ class Api(RestAdapterBase):
             experiment_type: Optional[str] = None,
             start_time: Optional[List] = None,
             device_components: Optional[List[str]] = None,
-            tags: Optional[List[str]] = None
+            tags: Optional[List[str]] = None,
+            hub: Optional[str] = None,
+            group: Optional[str] = None,
+            project: Optional[str] = None
     ) -> Dict:
         """Return experiment data.
 
@@ -166,6 +169,9 @@ class Api(RestAdapterBase):
             start_time: A list of timestamps used to filter by experiment start time.
             device_components: A list of device components used for filtering.
             tags: Tags used for filtering.
+            hub: Filter by hub.
+            group: Filter by hub and group.
+            project: Filter by hub, group, and project.
 
         Returns:
             JSON response.
@@ -186,6 +192,12 @@ class Api(RestAdapterBase):
             params['limit'] = limit
         if marker:
             params['marker'] = marker
+        if hub:
+            params['hub_id'] = hub
+        if group:
+            params['group_id'] = group
+        if project:
+            params['project_id'] = project
         return self.session.get(url, params=params).json()
 
     def experiment_devices(self) -> Dict:

--- a/qiskit/providers/ibmq/experiment/experiment.py
+++ b/qiskit/providers/ibmq/experiment/experiment.py
@@ -70,7 +70,7 @@ class Experiment:
             project: The project to which this experiment belongs. If not specified the
                 project from the provider is used.
             share_level: The level at which the experiment is shared. This determines who can
-                access the experiment, including changing its data. This defaults to "private"
+                view the experiment (but not update it). This defaults to "private"
                 for new experiments. Possible values include:
 
                 - private: The experiment is only visible to its owner (default)

--- a/releasenotes/notes/experiments-hgp-88b2416769125e38.yaml
+++ b/releasenotes/notes/experiments-hgp-88b2416769125e38.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The method
+    :meth:`qiskit.providers.ibmq.experiment.ExperimentService.experiments`
+    now accepts ``hub``, ``group``, and ``project`` as filtering keywords.

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -91,7 +91,7 @@ class TestExperiment(IBMQTestCase):
         """Test retrieving experiments."""
         self.assertTrue(self.experiments, "No experiments found.")
         providers = ['/'.join([provider.credentials.hub, provider.credentials.group,
-                              provider.credentials.project]) for provider in IBMQ.providers()]
+                               provider.credentials.project]) for provider in IBMQ.providers()]
         for exp in self.experiments:
             self.assertTrue(isinstance(exp, Experiment))
             self.assertTrue(exp.uuid, "{} does not have an uuid!".format(exp))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Part of #848. Adds support for filtering experiments by hub/group/project. `public` experiment filtering will be done when the API support for `!public` is available. 


### Details and comments


