### PR TITLE
Fix IBMQJobFailureError exception message

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -280,7 +280,7 @@ class IBMQJob(Job):
             if not partial or not self._result or not self._result.results:
                 error_message = self.error_message()
                 if '\n' in error_message:
-                    error_message = ". Use job.error_message() to get more details"
+                    error_message = ". Use the error_message() method to get more details"
                 else:
                     error_message = ": " + error_message
                 raise IBMQJobFailureError(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #850. 

When `IBMQJobFailureError` is raised, the exception message currently says "use job.error_message() to get more details" (if the error message is multi-line, otherwise it's included in the exception). The intent for `job.error_message()` is to act as an example showing `error_message()` being a job method, as most users don't interact with `IBMQJob` directly. However, it caused confusing to users who don't declare their variable as `job`. 

An alternative is to include multi-line error message in the exception itself. The downside is that it doesn't format well as an exception message, and the error message could be very large (1 line per experiment). 


### Details and comments


