### PR TITLE
Rework test_wait_for_final_state

### DIFF
--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -254,7 +254,7 @@ class BaseFakeAccountClient:
         while status not in API_JOB_FINAL_STATES:
             time.sleep(0.5)
             status = job.status()
-            if 'status_queue' in _kwargs:
+            if _kwargs.get('status_queue', None):
                 data = {'status': status.value}
                 if status is ApiJobStatus.QUEUED:
                     data['infoQueue'] = {'status': 'PENDING_IN_QUEUE',

--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -254,6 +254,12 @@ class BaseFakeAccountClient:
         while status not in API_JOB_FINAL_STATES:
             time.sleep(0.5)
             status = job.status()
+            if 'status_queue' in _kwargs:
+                data = {'status': status.value}
+                if status is ApiJobStatus.QUEUED:
+                    data['infoQueue'] = {'status': 'PENDING_IN_QUEUE',
+                                         'position': 1}
+                _kwargs['status_queue'].put(data)
         return self.job_status(job_id)
 
     def job_properties(self, *_args, **_kwargs):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`test_wait_for_final_state` occasionally fails if the job finishes before the callback function can be invoked.  This PR reworks that test to use `FakeAccountClient` to inject artificial delays and status transitions. It also adds a new websocket test case to ensure job status is added to the status queue (since that path is no longer exercised by `test_wait_for_final_state`). 


### Details and comments


