### PR TITLE
Avoid retrieving deleted jobs in test

### DIFF
--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -203,7 +203,7 @@ class TestIBMQBackendService(IBMQTestCase):
 
     def test_deprecated_service(self):
         """Test deprecated backend service module."""
-        ref_job = self.provider.backend.jobs(limit=10, start_datetime=self.last_week)[-1]
+        ref_job = self.provider.backend.jobs(limit=10, end_datetime=self.last_week)[-1]
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", category=DeprecationWarning)
@@ -214,6 +214,6 @@ class TestIBMQBackendService(IBMQTestCase):
             warnings.simplefilter("always", category=DeprecationWarning)
             _ = self.provider.backends.ibmq_qasm_simulator
             self.provider.backends.retrieve_job(ref_job.job_id())
-            self.provider.backends.jobs(limit=1, start_datetime=self.last_week)
+            self.provider.backends.jobs(limit=1, end_datetime=self.last_week)
             self.provider.backends.my_reservations()
             self.assertGreaterEqual(len(w), 1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#846 started deleting test jobs at the end of the tests. `test_deprecated_service` failed in [this run](https://github.com/Qiskit/qiskit-ibmq-provider/actions/runs/477640138) because it was retrieving jobs that were deleted by another test. This PR changes the logic to retrieve older jobs instead. 


### Details and comments


