### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     env:
       QE_TOKEN: ${{ secrets.QE_TOKEN }}
       QE_URL: https://auth.quantum-computing.ibm.com/api
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["windows-latest", "ubuntu-latest"]
     env:
       QE_TOKEN: ${{ secrets.QE_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["windows-latest", "ubuntu-latest"]
     env:
       QE_TOKEN: ${{ secrets.QE_TOKEN }}
@@ -142,7 +142,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["windows-latest", "ubuntu-latest"]
     env:
       QE_TOKEN: ${{ secrets.QE_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U -c constraints.txt -r requirements-dev.txt
           pip install -c constraints.txt -e .
+        if: matrix.python-version != 3.9
+      - name: Install Deps (py39)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -c constraints,txt -U git+https://github.com/Qiskit/qiskit-terra
+          pip install -c constraints.txt -e .
+        if: matrix.python-version == 3.9
       - name: Run Tests
         run: make test
   lint:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U -c constraints.txt -r requirements-dev.txt
-          pip install -c constraints,txt -U git+https://github.com/Qiskit/qiskit-terra
+          pip install -c constraints.txt -U git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt -e .
         if: matrix.python-version == 3.9
       - name: Run Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     env:
       QE_TOKEN: ${{ secrets.QE_TOKEN }}

--- a/releasenotes/notes/add-python3.9-aa545158de52b755.yaml
+++ b/releasenotes/notes/add-python3.9-aa545158de52b755.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Python 3.9 support has been added in this release. You can now run Qiskit
+    IBMQ provider using Python 3.9.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum api ibmq",

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -91,7 +91,7 @@ class TestWebsocketClientMock(IBMQTestCase):
             warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             # Manually cancel any pending asyncio tasks.
-            if sys.version_info[0:2] == (3, 6):
+            if sys.version_info[0:2] < (3, 9):
                 pending = asyncio.Task.all_tasks()
             else:
                 pending = asyncio.all_tasks()

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -94,7 +94,7 @@ class TestWebsocketClientMock(IBMQTestCase):
             if sys.version_info[0:2] < (3, 9):
                 pending = asyncio.Task.all_tasks()
             else:
-                pending = asyncio.all_tasks()
+                pending = asyncio.all_tasks(loop)
         for task in pending:
             task.cancel()
             try:

--- a/test/ibmq/websocket/test_websocket.py
+++ b/test/ibmq/websocket/test_websocket.py
@@ -91,7 +91,10 @@ class TestWebsocketClientMock(IBMQTestCase):
             warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             # Manually cancel any pending asyncio tasks.
-            pending = asyncio.Task.all_tasks()
+            if sys.version_info[0:2] == (3, 6):
+                pending = asyncio.Task.all_tasks()
+            else:
+                pending = asyncio.all_tasks()
         for task in pending:
             task.cancel()
             try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py36, py37, lint, docs
+envlist = py36, py37, py38, py39, lint, docs
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python 3.9.0 was released on 10-05-2020, this commits marks the support
of Python 3.9 in qiskit-ibmq-provider. It adds the supported python
version in the package metadata and updates the CI configuration to run
test jobs on Python 3.9.

### Details and comments


