### PR TITLE
Add experiment ID to IBMQJob

### DIFF
--- a/qiskit/providers/ibmq/api/clients/account.py
+++ b/qiskit/providers/ibmq/api/clients/account.py
@@ -183,7 +183,8 @@ class AccountClient(BaseClient):
             qobj_dict: Dict[str, Any],
             job_name: Optional[str] = None,
             job_share_level: Optional[ApiJobShareLevel] = None,
-            job_tags: Optional[List[str]] = None
+            job_tags: Optional[List[str]] = None,
+            experiment_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Submit a ``Qobj`` to the backend.
 
@@ -193,6 +194,7 @@ class AccountClient(BaseClient):
             job_name: Custom name to be assigned to the job.
             job_share_level: Level the job should be shared at.
             job_tags: Tags to be assigned to the job.
+            experiment_id: Used to add a job to an experiment.
 
         Returns:
             Job data.
@@ -208,7 +210,8 @@ class AccountClient(BaseClient):
             backend_name,
             job_name=job_name,
             job_share_level=_job_share_level,
-            job_tags=job_tags)
+            job_tags=job_tags,
+            experiment_id=experiment_id)
 
         # Get the upload URL.
         job_id = job_info['id']

--- a/qiskit/providers/ibmq/api/rest/account.py
+++ b/qiskit/providers/ibmq/api/rest/account.py
@@ -134,7 +134,8 @@ class Account(RestAdapterBase):
             backend_name: str,
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
-            job_tags: Optional[List[str]] = None
+            job_tags: Optional[List[str]] = None,
+            experiment_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Create a job instance on the remote server.
 
@@ -143,6 +144,7 @@ class Account(RestAdapterBase):
             job_name: Custom name to be assigned to the job.
             job_share_level: Level the job should be shared at.
             job_tags: Tags to be assigned to the job.
+            experiment_id: Used to add a job to an experiment.
 
         Returns:
             JSON response.
@@ -162,6 +164,9 @@ class Account(RestAdapterBase):
 
         if job_tags:
             payload['tags'] = job_tags
+
+        if experiment_id:
+            payload['experimentTag'] = experiment_id
 
         return self.session.post(url, json=payload).json()
 

--- a/qiskit/providers/ibmq/api/rest/utils/data_mapper.py
+++ b/qiskit/providers/ibmq/api/rest/utils/data_mapper.py
@@ -34,7 +34,8 @@ def map_job_response(data: Dict[str, Any]) -> Dict[str, Any]:
         'qObjectResult': 'result',
         'timePerStep': 'time_per_step',
         'shots': '_api_shots',
-        'runMode': 'run_mode'
+        'runMode': 'run_mode',
+        'experimentTag': 'experiment_id'
     }
     info_queue = map_info_queue(data.pop('infoQueue', {}))
     dict_to_identifier(data, field_map)

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -148,6 +148,7 @@ class IBMQBackend(Backend):
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
+            experiment_id: Optional[str] = None,
             validate_qobj: bool = None,
             header: Optional[Dict] = None,
             shots: Optional[int] = None,
@@ -194,6 +195,8 @@ class IBMQBackend(Backend):
                 If the job share level is not specified, the job is not shared at any level.
             job_tags: Tags to be assigned to the job. The tags can subsequently be used
                 as a filter in the :meth:`jobs()` function call.
+            experiment_id: Used to add a job to an "experiment", which is a collection
+                of jobs and additional metadata.
             validate_qobj: DEPRECATED. If ``True``, run JSON schema validation against the
                 submitted payload. Only applicable if a Qobj is passed in.
 
@@ -300,7 +303,7 @@ class IBMQBackend(Backend):
                           DeprecationWarning, stacklevel=3)
             if validate_qobj:
                 validate_qobj_against_schema(qobj)
-        return self._submit_job(qobj, job_name, api_job_share_level, job_tags)
+        return self._submit_job(qobj, job_name, api_job_share_level, job_tags, experiment_id)
 
     def _get_run_config(self, **kwargs: Any) -> Dict:
         """Return the consolidated runtime configuration."""
@@ -318,7 +321,8 @@ class IBMQBackend(Backend):
             qobj: Union[QasmQobj, PulseQobj],
             job_name: Optional[str] = None,
             job_share_level: Optional[ApiJobShareLevel] = None,
-            job_tags: Optional[List[str]] = None
+            job_tags: Optional[List[str]] = None,
+            experiment_id: Optional[str] = None
     ) -> IBMQJob:
         """Submit the Qobj to the backend.
 
@@ -330,6 +334,7 @@ class IBMQBackend(Backend):
                 Job names do not need to be unique.
             job_share_level: Level the job should be shared at.
             job_tags: Tags to be assigned to the job.
+            experiment_id: Used to add a job to an experiment.
 
         Returns:
             The job to be executed.
@@ -354,7 +359,8 @@ class IBMQBackend(Backend):
                 qobj_dict=qobj_dict,
                 job_name=job_name,
                 job_share_level=job_share_level,
-                job_tags=job_tags)
+                job_tags=job_tags,
+                experiment_id=experiment_id)
         except ApiError as ex:
             if 'Error code: 3458' in str(ex):
                 raise IBMQBackendJobLimitError('Error submitting job: {}'.format(str(ex))) from ex
@@ -739,6 +745,7 @@ class IBMQSimulator(IBMQBackend):
             job_name: Optional[str] = None,
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
+            experiment_id: Optional[str] = None,
             validate_qobj: bool = None,
             backend_options: Optional[Dict] = None,
             noise_model: Any = None,
@@ -760,6 +767,8 @@ class IBMQSimulator(IBMQBackend):
                 global level (see :meth:`IBMQBackend.run()<IBMQBackend.run>` for more details).
             job_tags: Tags to be assigned to the jobs. The tags can subsequently be used
                 as a filter in the :meth:`IBMQBackend.jobs()<IBMQBackend.jobs>` method.
+            experiment_id: Used to add a job to an "experiment", which is a collection
+                of jobs and additional metadata.
             validate_qobj: DEPRECATED. If ``True``, run JSON schema validation against the
                 submitted payload.
             backend_options: DEPRECATED dictionary of backend options for the execution.
@@ -781,7 +790,8 @@ class IBMQSimulator(IBMQBackend):
         run_config = copy.copy(backend_options)
         run_config.update(kwargs)
         return super().run(circuits, job_name=job_name, job_share_level=job_share_level,
-                           job_tags=job_tags, validate_qobj=validate_qobj,
+                           job_tags=job_tags, experiment_id=experiment_id,
+                           validate_qobj=validate_qobj,
                            noise_model=noise_model, **run_config)
 
 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -560,6 +560,7 @@ class IBMQBackend(Backend):
             end_datetime: Optional[python_datetime] = None,
             job_tags: Optional[List[str]] = None,
             job_tags_operator: Optional[str] = "OR",
+            experiment_id: Optional[str] = None,
             descending: bool = True,
             db_filter: Optional[Dict[str, Any]] = None
     ) -> List[IBMQJob]:
@@ -595,6 +596,7 @@ class IBMQBackend(Backend):
                       specified in ``job_tags`` to be included.
                     * If "OR" is specified, then a job only needs to have any
                       of the tags specified in ``job_tags`` to be included.
+            experiment_id: Filter by job experiment ID.
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (newest first). If ``False``, return in ascending order.
             db_filter: A `loopback-based filter
@@ -618,9 +620,10 @@ class IBMQBackend(Backend):
             IBMQBackendValueError: If a keyword value is not recognized.
         """
         return self._provider.backend.jobs(
-            limit, skip, self.name(), status,
-            job_name, start_datetime, end_datetime, job_tags, job_tags_operator,
-            descending, db_filter)
+            limit=limit, skip=skip, backend_name=self.name(), status=status,
+            job_name=job_name, start_datetime=start_datetime, end_datetime=end_datetime,
+            job_tags=job_tags, job_tags_operator=job_tags_operator,
+            experiment_id=experiment_id, descending=descending, db_filter=db_filter)
 
     def active_jobs(self, limit: int = 10) -> List[IBMQJob]:
         """Return the unfinished jobs submitted to this backend.

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -144,6 +144,7 @@ class IBMQBackendService:
             end_datetime: Optional[datetime] = None,
             job_tags: Optional[List[str]] = None,
             job_tags_operator: Optional[str] = "OR",
+            experiment_id: Optional[str] = None,
             descending: bool = True,
             db_filter: Optional[Dict[str, Any]] = None
     ) -> List[IBMQJob]:
@@ -179,6 +180,7 @@ class IBMQBackendService:
                       specified in ``job_tags`` to be included.
                     * If "OR" is specified, then a job only needs to have any
                       of the tags specified in ``job_tags`` to be included.
+            experiment_id: Filter by job experiment ID.
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             db_filter: A `loopback-based filter
@@ -236,6 +238,9 @@ class IBMQBackendService:
                 raise IBMQBackendValueError(
                     '"{}" is not a valid job_tags_operator value. '
                     'Valid values are "AND" and "OR"'.format(job_tags_operator))
+
+        if experiment_id:
+            api_filter['experimentTag'] = experiment_id
 
         if db_filter:
             # Rather than overriding the logical operators `and`/`or`, first

--- a/releasenotes/notes/experiment-id-992ca29382e460d6.yaml
+++ b/releasenotes/notes/experiment-id-992ca29382e460d6.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    You can now assign an ``experiment_id`` to a job when submitting it using
+    :meth:`qiskit.providers.ibmq.IBMQBackend.run`. You can use this new field
+    to group together a collection of jobs that belong to the same experiment.
+    The :meth:`qiskit.providers.ibmq.IBMQBackendService.jobs` method was also
+    updated to allow filtering by ``experiment_id``.

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -463,3 +463,16 @@ class TestIBMQJobAttributes(IBMQTestCase):
         """Test job client version information."""
         self.assertIsNotNone(self.sim_job.result().client_version)
         self.assertIsNotNone(self.sim_job.client_version)
+
+    def test_experiment_id(self):
+        """Test job experiment id."""
+        exp_id = uuid.uuid4().hex
+        job = self.sim_backend.run(self.bell, experiment_id=exp_id)
+        self.assertEqual(job.experiment_id, exp_id)
+        rjob = self.provider.backend.retrieve_job(job.job_id())
+        self.assertEqual(rjob.experiment_id, exp_id)
+        rjobs = self.provider.backend.jobs(experiment_id=exp_id)
+        for rjob in rjobs:
+            self.assertEqual(rjob.experiment_id, exp_id,
+                             f"Job {rjob.job_id()} has experiment ID {rjob.experiment_id} "
+                             f"instead of {exp_id}")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR allow an experiment ID to be assigned to a job. An experiment is a collection of jobs and metadata. Adding the `experiment_id` field to a job allows a user to cross reference experiments and their jobs.


### Details and comments


