### PR TITLE
Add service methods

### DIFF
--- a/qiskit/providers/ibmq/experiment/experimentservice.py
+++ b/qiskit/providers/ibmq/experiment/experimentservice.py
@@ -335,7 +335,7 @@ class ExperimentService:
         if quality:
             for op, qual in quality:
                 if isinstance(qual, ResultQuality):
-                    qual = qual.value
+                    qual = qual.value  # type: ignore[assignment]
                 qual_str = qual if op == 'eq' else "{}:{}".format(op, qual)
                 qualit_list.append(qual_str)
         results = []

--- a/releasenotes/notes/provider-services-47cd2b3d037c3dfe.yaml
+++ b/releasenotes/notes/provider-services-47cd2b3d037c3dfe.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    You can now use the two new methods,
+    :meth:`qiskit.providers.ibmq.AccountProvider.services` and
+    :meth:`qiskit.providers.ibmq.AccountProvider.service` to find out what
+    services are available to your account and get an instance of a
+    particular service.

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2017, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,12 +15,15 @@
 from datetime import datetime
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.providers.exceptions import QiskitBackendNotFoundError
-from qiskit.providers.ibmq.accountprovider import AccountProvider
-from qiskit.providers.ibmq.ibmqbackend import IBMQSimulator, IBMQBackend
 from qiskit.test import providers, slow_test
 from qiskit.compiler import transpile
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.models.backendproperties import BackendProperties
+from qiskit.providers.ibmq.accountprovider import AccountProvider
+from qiskit.providers.ibmq.ibmqbackend import IBMQSimulator, IBMQBackend
+from qiskit.providers.ibmq.ibmqbackendservice import IBMQBackendService
+from qiskit.providers.ibmq.experiment.experimentservice import ExperimentService
+from qiskit.providers.ibmq.random.ibmqrandomservice import IBMQRandomService
 
 from ..decorators import requires_provider, requires_device
 from ..ibmqtestcase import IBMQTestCase
@@ -158,3 +161,18 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
                              if isinstance(getattr(self.provider.backends, back), IBMQBackend)}
         backends = {back.name().lower() for back in self.provider._backends.values()}
         self.assertEqual(provider_backends, backends)
+
+    def test_provider_services(self):
+        """Test provider services."""
+        services = self.provider.services()
+        self.assertIn('backend', services)
+        self.assertIsInstance(services['backend'], IBMQBackendService)
+        self.assertIsInstance(self.provider.service('backend'), IBMQBackendService)
+        self.assertIsInstance(self.provider.backend, IBMQBackendService)
+
+        if 'experiment' in services:
+            self.assertIsInstance(self.provider.service('experiment'), ExperimentService)
+            self.assertIsInstance(self.provider.experiment, ExperimentService)
+        if 'random' in services:
+            self.assertIsInstance(self.provider.service('random'), IBMQRandomService)
+            self.assertIsInstance(self.provider.random, IBMQRandomService)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add `service()` and `services()` methods to `AccountProvider`. This allows users to query for a particular service before trying to use it.


### Details and comments


