### PR TITLE
Support filtering experiments by owner

### DIFF
--- a/qiskit/providers/ibmq/api/clients/experiment.py
+++ b/qiskit/providers/ibmq/api/clients/experiment.py
@@ -55,7 +55,9 @@ class ExperimentClient(BaseClient):
             group: Optional[str] = None,
             project: Optional[str] = None,
             exclude_public: Optional[bool] = False,
-            public_only: Optional[bool] = False
+            public_only: Optional[bool] = False,
+            exclude_mine: Optional[bool] = False,
+            mine_only: Optional[bool] = False
     ) -> Dict:
         """Retrieve experiments, with optional filtering.
 
@@ -72,13 +74,15 @@ class ExperimentClient(BaseClient):
             project: Filter by hub, group, and project.
             exclude_public: Whether or not to exclude experiments with a public share level.
             public_only: Whether or not to only return experiments with a public share level.
+            exclude_mine: Whether or not to exclude experiments where I am the owner.
+            mine_only: Whether or not to only return experiments where I am the owner.
 
         Returns:
             A list of experiments and the marker, if applicable.
         """
         resp = self.base_api.experiments(
             limit, marker, backend_name, experiment_type, start_time, device_components, tags,
-            hub, group, project, exclude_public, public_only)
+            hub, group, project, exclude_public, public_only, exclude_mine, mine_only)
         return resp
 
     def experiment_get(self, experiment_id: str) -> Dict:

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -159,7 +159,9 @@ class Api(RestAdapterBase):
             group: Optional[str] = None,
             project: Optional[str] = None,
             exclude_public: Optional[bool] = False,
-            public_only: Optional[bool] = False
+            public_only: Optional[bool] = False,
+            exclude_mine: Optional[bool] = False,
+            mine_only: Optional[bool] = False
     ) -> Dict:
         """Return experiment data.
 
@@ -176,6 +178,8 @@ class Api(RestAdapterBase):
             project: Filter by hub, group, and project.
             exclude_public: Whether or not to exclude experiments with a public share level.
             public_only: Whether or not to only return experiments with a public share level.
+            exclude_mine: Whether or not to exclude experiments where I am the owner.
+            mine_only: Whether or not to only return experiments where I am the owner.
 
         Returns:
             JSON response.
@@ -206,6 +210,10 @@ class Api(RestAdapterBase):
             params['visibility'] = '!public'
         elif public_only:
             params['visibility'] = 'public'
+        if exclude_mine:
+            params['owner'] = '!me'
+        elif mine_only:
+            params['owner'] = 'me'
         return self.session.get(url, params=params).json()
 
     def experiment_devices(self) -> Dict:

--- a/qiskit/providers/ibmq/experiment/experimentservice.py
+++ b/qiskit/providers/ibmq/experiment/experimentservice.py
@@ -109,7 +109,9 @@ class ExperimentService:
             group: Optional[str] = None,
             project: Optional[str] = None,
             exclude_public: Optional[bool] = False,
-            public_only: Optional[bool] = False
+            public_only: Optional[bool] = False,
+            exclude_mine: Optional[bool] = False,
+            mine_only: Optional[bool] = False
     ) -> List[Experiment]:
         """Retrieve all experiments, with optional filtering.
 
@@ -149,6 +151,10 @@ class ExperimentService:
             public_only: If ``True``, only experiments with ``share_level=public``
                 (that is, experiments visible to all users) will be returned.
                 Cannot be ``True`` if `exclude_public` is ``True``.
+            exclude_mine: If ``True``, experiments where I am the owner will not be returned.
+                Cannot be ``True`` if `mine_only` is ``True``.
+            mine_only: If ``True``, only experiments where I am the owner will be returned.
+                Cannot be ``True`` if `exclude_mine` is ``True``.
 
         Returns:
             A list of experiments.
@@ -187,13 +193,16 @@ class ExperimentService:
         if exclude_public and public_only:
             raise ValueError('exclude_public and public_only cannot both be True')
 
+        if exclude_mine and mine_only:
+            raise ValueError('exclude_mine and mine_only cannot both be True')
+
         experiments = []
         marker = None
         while limit is None or limit > 0:
             raw_data = self._api_client.experiments(
                 limit, marker, backend_name, type, start_time_filters,
                 device_components, tags_filter, hub, group, project,
-                exclude_public, public_only)
+                exclude_public, public_only, exclude_mine, mine_only)
             marker = raw_data.get('marker')
             for exp in raw_data['experiments']:
                 experiments.append(Experiment.from_remote_data(self._provider, exp))

--- a/releasenotes/notes/experiments-owner-filters-770ff0db6d1174b6.yaml
+++ b/releasenotes/notes/experiments-owner-filters-770ff0db6d1174b6.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The method
+    :meth:`qiskit.providers.ibmq.experimentservice.ExperimentService.experiments`
+    now accepts ``exclude_mine`` and ``mine_only`` as filtering keywords.

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -304,7 +304,7 @@ class TestExperiment(IBMQTestCase):
         not_mine_experiment_uuids = []
         for experiment in not_my_experiments:
             self.assertNotEqual(
-                experiment.owner, my_exp.owner,
+                experiment.owner, my_exp.owner,  # pylint: disable=no-member
                 'Experiment should not be returned with exclude_mine filter: %s' %
                 experiment)
             not_mine_experiment_uuids.append(experiment.uuid)
@@ -325,7 +325,7 @@ class TestExperiment(IBMQTestCase):
         my_experiment_uuids = []
         for experiment in my_experiments:
             self.assertEqual(
-                experiment.owner, my_exp.owner,
+                experiment.owner, my_exp.owner,  # pylint: disable=no-member
                 'Only my experiments should be returned with mine_only filter: %s' %
                 experiment)
             my_experiment_uuids.append(experiment.uuid)

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -305,7 +305,7 @@ class TestExperiment(IBMQTestCase):
         for experiment in not_my_experiments:
             self.assertNotEqual(
                 experiment.owner, my_exp.owner,  # pylint: disable=no-member
-                'Experiment should not be returned with exclude_mine filter: %s' %
+                'My experiment should not be returned with exclude_mine filter: %s' %
                 experiment)
             not_mine_experiment_uuids.append(experiment.uuid)
         self.assertNotIn(

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -310,7 +310,7 @@ class TestExperiment(IBMQTestCase):
             not_mine_experiment_uuids.append(experiment.uuid)
         self.assertNotIn(
             my_exp.uuid, not_mine_experiment_uuids,
-            'Not my experiment returned with exclude_mine filter: %s' %
+            'My experiment returned with exclude_mine filter: %s' %
             my_exp)
 
     def test_experiments_with_mine_only(self):


### PR DESCRIPTION

### Summary

This adds the `exclude_mine` and `mine_only` filters
to list experiments that I do or do not own.

### Details and comments

Closes #863