### PR TITLE
Ignore mypy 0.800 ExperimentService assignment error

### DIFF
--- a/qiskit/providers/ibmq/experiment/experimentservice.py
+++ b/qiskit/providers/ibmq/experiment/experimentservice.py
@@ -335,7 +335,7 @@ class ExperimentService:
         if quality:
             for op, qual in quality:
                 if isinstance(qual, ResultQuality):
-                    qual = qual.value
+                    qual = qual.value  # type: ignore[assignment]
                 qual_str = qual if op == 'eq' else "{}:{}".format(op, qual)
                 qualit_list.append(qual_str)
         results = []


### PR DESCRIPTION

### Summary

It appears the recent mypy 0.800 release is failing on a latent
line in the ExperimentService due to some confusing Union on the
experiment quality value since quality can be a list of strings
or ResultQuality enums. This just ignores the mypy error.

### Details and comments

Closes #867
