### PR TITLE
Update terra execute function import

### DIFF
--- a/test/ibmq/test_ibmq_integration.py
+++ b/test/ibmq/test_ibmq_integration.py
@@ -14,9 +14,8 @@
 
 import time
 
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, execute
 from qiskit.result import Result
-from qiskit.execute import execute
 from qiskit.compiler import transpile
 from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.providers.ibmq.job.exceptions import IBMQJobApiError


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Qiskit terra Qiskit/qiskit-terra#5620 renamed the `qiskit.execute` module to `qiskit.execute_function`. This PR updates `test_ibmq_integration` to import `execute` from `qiskit` instead of `qiskit.execute`.


### Details and comments


