### PR TITLE
Skip test_convert_complex for old terra

### DIFF
--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -12,7 +12,7 @@
 
 """Test serializing and deserializing data sent to the server."""
 
-from unittest import SkipTest
+from unittest import SkipTest, skipIf
 from typing import Any, Dict, Optional
 
 import dateutil.parser
@@ -22,6 +22,7 @@ from qiskit.providers.ibmq import least_busy
 from qiskit import transpile, schedule, QuantumCircuit
 from qiskit.providers.ibmq.utils.json_encoder import IQXJsonEncoder
 from qiskit.circuit import Parameter
+from qiskit.version import VERSION as terra_version
 
 from ..decorators import requires_provider
 from ..utils import cancel_job
@@ -163,6 +164,7 @@ class TestSerialization(IBMQTestCase):
                 suspect_keys = {ckey for ckey in suspect_keys if not ckey.startswith(gkey)}
         self.assertFalse(suspect_keys)
 
+    @skipIf(terra_version < '0.17', "Need Terra >= 0.17")
     def test_convert_complex(self):
         """Verify that real and complex ParameterExpressions are supported."""
         param = Parameter('test')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#879 added a `test_convert_complex` to test complex numbers in `ParameterExpressions`. Support for complex numbers in `ParameterExpressions`, however, has not been released in qiskit-terra. Most of the CI runs use the current version of terra instead of the master branch. This PR skips the test unless terra 0.17 is installed. 

### Details and comments


