### PR TITLE
Don't use ibmq_vigo in tutorial

### DIFF
--- a/docs/tutorials/1_the_ibmq_account.ipynb
+++ b/docs/tutorials/1_the_ibmq_account.ipynb
@@ -801,7 +801,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_vigo') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 17,
@@ -810,7 +810,7 @@
     }
    ],
    "source": [
-    "provider.backend.ibmq_vigo"
+    "provider.backend.ibmq_16_melbourne"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The tutorial currently uses `ibmq_vigo` in an example. `ibmq_vigo` has been retired, causing the tutorial CI to fail. This PR changes the example to use `ibmq_16_melbourne` instead.


### Details and comments


