### PR TITLE
add line_discipline kwarg to job_monitor

### DIFF
--- a/qiskit/providers/ibmq/job/job_monitor.py
+++ b/qiskit/providers/ibmq/job/job_monitor.py
@@ -24,7 +24,8 @@ from ..utils.converters import duration_difference
 def _text_checker(job: IBMQJob,
                   interval: float,
                   _interval_set: bool = False,
-                  output: TextIO = sys.stdout) -> None:
+                  output: TextIO = sys.stdout,
+                  line_discipline: string = '\r') -> None:
     """A text-based job status checker.
 
     Args:
@@ -33,6 +34,8 @@ def _text_checker(job: IBMQJob,
         _interval_set: Was interval time set by user?
         output: The file like object to write status messages to.
             By default this is sys.stdout.
+        line_discipline (string): character emitted at start of a line of job monitor output,
+            This defaults to \\r.
 
     """
     status = job.status()
@@ -41,7 +44,7 @@ def _text_checker(job: IBMQJob,
     msg_len = len(msg)
     prev_time_str = ''
 
-    print('\r%s: %s' % ('Job Status', msg), end='', file=output)
+    print('%s%s: %s' % (line_discipline, 'Job Status', msg), end='', file=output)
     while status.name not in ['DONE', 'CANCELLED', 'ERROR']:
         time.sleep(interval)
         status = job.status()
@@ -87,7 +90,7 @@ def _text_checker(job: IBMQJob,
             msg_len = len(msg)
 
         if msg != prev_msg:
-            print('\r%s: %s' % ('Job Status', msg), end='', file=output)
+            print('%s%s: %s' % (line_discipline, 'Job Status', msg), end='', file=output)
             prev_msg = msg
 
     print('', file=output)
@@ -95,7 +98,8 @@ def _text_checker(job: IBMQJob,
 
 def job_monitor(job: IBMQJob,
                 interval: Optional[float] = None,
-                output: TextIO = sys.stdout) -> None:
+                output: TextIO = sys.stdout,
+                line_discipline: string = '\r') -> None:
     """Monitor the status of an ``IBMQJob`` instance.
 
     Args:
@@ -103,6 +107,8 @@ def job_monitor(job: IBMQJob,
         interval: Time interval between status queries.
         output: The file like object to write status messages to.
             By default this is sys.stdout.
+        line_discipline (string): character emitted at start of a line of job monitor output,
+            This defaults to \\r.
     """
     if interval is None:
         _interval_set = False
@@ -111,4 +117,4 @@ def job_monitor(job: IBMQJob,
         _interval_set = True
 
     _text_checker(job, interval, _interval_set,
-                  output=output)
+                  output=output, line_discipline=line_discipline)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This updates job_monitor to reflect the new line_discipline kwarg that was added to qiskit-terra


### Details and comments
this new feature does not change the behavior of job_monitor by default, it only allows to optionally customize the way it prints each line. This is an important feature to have for my own work where I am integrating Qiskit into this realtime visual programming environment, and it may also be useful for others too.
More details about this implementation can be found on the original qiskit-terra [PR](https://github.com/Qiskit/qiskit-terra/pull/5691) and [issue](https://github.com/Qiskit/qiskit-terra/issues/5690)



this fixes #883 
