### PR TITLE
Add traceback in warning messages

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -166,8 +166,7 @@ class AccountProvider(Provider):
                 logger.warning("An error occurred when retrieving backend "
                                "information. Some backends might not be available.")
                 continue
-            if raw_config['backend_name'] == 'ibmqx2':
-                raw_config['online_date'] = 'foo'
+
             try:
                 decode_backend_configuration(raw_config)
                 if raw_config.get('open_pulse', False):

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -15,6 +15,7 @@
 import logging
 from typing import Dict, List, Optional, Any, Callable
 from collections import OrderedDict
+import traceback
 
 from qiskit.providers import ProviderV1 as Provider  # type: ignore[attr-defined]
 from qiskit.providers.models import (QasmBackendConfiguration,
@@ -165,7 +166,8 @@ class AccountProvider(Provider):
                 logger.warning("An error occurred when retrieving backend "
                                "information. Some backends might not be available.")
                 continue
-
+            if raw_config['backend_name'] == 'ibmqx2':
+                raw_config['online_date'] = 'foo'
             try:
                 decode_backend_configuration(raw_config)
                 if raw_config.get('open_pulse', False):
@@ -178,12 +180,12 @@ class AccountProvider(Provider):
                     provider=self,
                     credentials=self.credentials,
                     api_client=self._api_client)
-            except Exception as ex:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 logger.warning(
                     'Remote backend "%s" for provider %s could not be instantiated due to an '
-                    'invalid config: %s: %s',
+                    'invalid config: %s',
                     raw_config.get('backend_name', raw_config.get('name', 'unknown')),
-                    repr(self), type(ex).__name__, ex)
+                    repr(self), traceback.format_exc())
 
         return ret
 

--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -282,7 +282,7 @@ class RetrySession(Session):
                     message += ". {}, Error code: {}.".format(
                         error_json['message'], error_json['code'])
                     logger.debug("Response uber-trace-id: %s", ex.response.headers['uber-trace-id'])
-                except (ValueError, KeyError):
+                except Exception:  # pylint: disable=broad-except
                     # the response did not contain the expected json.
                     message += ". {}".format(ex.response.text)
 

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -15,6 +15,7 @@
 import logging
 from typing import Dict, List, Union, Callable, Optional, Any
 from collections import OrderedDict
+import traceback
 
 from .accountprovider import AccountProvider
 from .api.clients import AuthClient, VersionClient
@@ -472,7 +473,7 @@ class IBMQFactory:
                 provider = AccountProvider(provider_credentials,
                                            auth_client.current_access_token())
                 self._providers[provider_credentials.unique_id()] = provider
-            except Exception as ex:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 # Catch-all for errors instantiating the provider.
                 logger.warning('Unable to instantiate provider for %s: %s',
-                               hub_info, ex)
+                               hub_info, traceback.format_exc())

--- a/releasenotes/notes/server-response-error-80918120ed2b1f06.yaml
+++ b/releasenotes/notes/server-response-error-80918120ed2b1f06.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the issue wherein a ``TypeError`` is raised if the server returns
+    an error code but the response data is not in the expected format.

--- a/test/http_server.py
+++ b/test/http_server.py
@@ -21,17 +21,20 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 class BaseHandler(BaseHTTPRequestHandler):
     """Base request handler for testing."""
 
+    good_response = {}
+    error_response = {}
+
     def _get_code(self):
         """Get the status code to be returned."""
         return 200
 
     def _get_response_data(self):
         """Get the response data to be returned."""
-        return {}
+        return self.good_response
 
     def _get_error_data(self):
         """Get the error data to be returned."""
-        return {}
+        return self.error_response
 
     def _respond(self):
         """Respond to the client."""
@@ -62,7 +65,6 @@ class BaseHandler(BaseHTTPRequestHandler):
 class ServerErrorOnceHandler(BaseHandler):
     """Request handler that returns a server error once then a good response."""
 
-    valid_data = {}
     bad_status_given = {}
 
     def _get_code(self):
@@ -72,23 +74,13 @@ class ServerErrorOnceHandler(BaseHandler):
         self.bad_status_given[self.path] = True
         return 504
 
-    def _get_response_data(self):
-        """Return valid response data."""
-        return self.valid_data
-
 
 class ClientErrorHandler(BaseHandler):
     """Request handler that returns a client error."""
 
-    error_response = {}
-
     def _get_code(self):
         """Return 400."""
         return 400
-
-    def _get_error_data(self):
-        """Return valid response data."""
-        return self.error_response
 
 
 class SimpleServer:
@@ -98,14 +90,12 @@ class SimpleServer:
     PORT = 8123
     URL = "http://{}:{}".format(IP_ADDRESS, PORT)
 
-    def __init__(self, handler_class: BaseHandler, valid_data: Optional[Dict] = None):
+    def __init__(self, handler_class: BaseHandler):
         """SimpleServer constructor.
 
         Args:
             handler_class: Request handler class.
-            valid_data: Data to be returned for a valid request.
         """
-        setattr(handler_class, 'valid_data', valid_data)
         self.httpd = HTTPServer((self.IP_ADDRESS, self.PORT), handler_class)
         self.server = threading.Thread(target=self.httpd.serve_forever, daemon=True)
 
@@ -122,3 +112,7 @@ class SimpleServer:
     def set_error_response(self, error_response: Dict):
         """Set the error response."""
         setattr(self.httpd.RequestHandlerClass, 'error_response', error_response)
+
+    def set_good_response(self, response: Dict):
+        """Set good response."""
+        setattr(self.httpd.RequestHandlerClass, 'good_response', response)

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -146,9 +146,9 @@ class TestAccountClient(IBMQTestCase):
         self.fake_server.start()
         client.account_api.session.base_url = SimpleServer.URL
 
-        sub_tests = [{'Error': 'Bad client input'},
+        sub_tests = [{'error': 'Bad client input'},
                      {},
-                     {'Bad request': 'Bad client input'},
+                     {'bad request': 'Bad client input'},
                      'Bad client input']
 
         for err_resp in sub_tests:

--- a/test/ibmq/test_account_client.py
+++ b/test/ibmq/test_account_client.py
@@ -133,7 +133,8 @@ class TestAccountClient(IBMQTestCase):
         valid_data = {'id': 'fake_id',
                       'objectStorageInfo': {'uploadUrl': SimpleServer.URL},
                       'job': {'id': 'fake_id'}}
-        self.fake_server = SimpleServer(handler_class=ServerErrorOnceHandler, valid_data=valid_data)
+        self.fake_server = SimpleServer(handler_class=ServerErrorOnceHandler)
+        self.fake_server.set_good_response(valid_data)
         self.fake_server.start()
         client.account_api.session.base_url = SimpleServer.URL
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #882.

In #882, the request failed with a response that contained the keyword `error` but was not in the IBMQ `{error: {'message': xxx, 'code': xxx}}` format. This caused `session.py` to blow up. Furthermore, the warning message issued by `IBMQFactory` was very unclear and therefore made debugging quite difficult. 

This PR makes the following changes:
- Add traceback in the warning messages issues by `IBMQFactory` when a provider couldn't be initialized
- Add traceback in the warning messages issues by `AccountProvider` when a backend couldn't be initialized
- Catch broad exception in session when attempting to parse the error response.


### Details and comments


