### PR TITLE
Skip paused backends in least_busy()

### DIFF
--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -144,7 +144,8 @@ def least_busy(
         candidates = []
         now = datetime.now()
         for back in backends:
-            if not back.status().operational:
+            backend_status = back.status()
+            if not backend_status.operational or backend_status.status_msg != 'active':
                 continue
             if reservation_lookahead and isinstance(back, IBMQBackend):
                 end_time = now + timedelta(minutes=reservation_lookahead)

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -437,6 +437,10 @@ class IBMQBackend(Backend):
     def status(self) -> BackendStatus:
         """Return the backend status.
 
+        Note:
+            If a backend is operational but has a ``status_msg`` of ``internal``,
+            then the backend is accepting jobs but not processing them.
+
         Returns:
             The status of the backend.
 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -438,7 +438,8 @@ class IBMQBackend(Backend):
         """Return the backend status.
 
         Note:
-            If a backend is operational but has a ``status_msg`` of ``internal``,
+            If the returned :class:`~qiskit.providers.models.BackendStatus`
+            instance has ``operational=True`` but ``status_msg="internal"``,
             then the backend is accepting jobs but not processing them.
 
         Returns:

--- a/releasenotes/notes/least_busy-paused-backend-6e2fcc12558a6217.yaml
+++ b/releasenotes/notes/least_busy-paused-backend-6e2fcc12558a6217.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The :func:`~qiskit.providers.ibmq.least_busy` function now skips backends
+    that are operational but ``paused``, meaning they are accepting but not
+    processing jobs.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Today `least_busy()` only checks whether a backend is operational. When a backend is `paused`, it's still accepting jobs and thus marked as operational but is no longer processing jobs. This PR changes `least_busy` behavior to skip paused backends since they can be paused for an extended period of time. 


### Details and comments


