### PR TITLE
Move test_websocket.py to test3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ test:
 	python -m unittest -v
 
 test1:
-	python -m unittest -v test/ibmq/test_ibmq_backend.py test/ibmq/test_account_client.py test/ibmq/test_ibmq_job_states.py test/ibmq/test_tutorials.py test/ibmq/test_basic_server_paths.py test/ibmq/test_ibmq_factory.py test/ibmq/test_proxies.py test/ibmq/test_experiment.py test/ibmq/test_ibmq_integration.py test/ibmq/test_ibmq_logger.py test/ibmq/test_filter_backends.py test/ibmq/test_registration.py test/ibmq/websocket/test_websocket.py
+	python -m unittest -v test/ibmq/test_ibmq_backend.py test/ibmq/test_account_client.py test/ibmq/test_ibmq_job_states.py test/ibmq/test_tutorials.py test/ibmq/test_basic_server_paths.py test/ibmq/test_ibmq_factory.py test/ibmq/test_proxies.py test/ibmq/test_experiment.py test/ibmq/test_ibmq_integration.py test/ibmq/test_ibmq_logger.py test/ibmq/test_filter_backends.py test/ibmq/test_registration.py
 
 test2:
 	python -m unittest -v test/ibmq/test_ibmq_qasm_simulator.py test/ibmq/test_serialization.py test/ibmq/test_jupyter.py test/ibmq/test_ibmq_jobmanager.py test/ibmq/test_random.py test/ibmq/test_ibmq_provider.py test/ibmq/websocket/test_websocket_integration.py
 
 test3:
-	python -m unittest -v test/ibmq/test_ibmq_job_attributes.py test/ibmq/test_ibmq_job.py
+	python -m unittest -v test/ibmq/test_ibmq_job_attributes.py test/ibmq/test_ibmq_job.py test/ibmq/websocket/test_websocket.py


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`test_websocket` in `test2` has been failing consistently during nightly cron due to the `ConnectionResetError`. This PR moves the suite to `test3` to spread the load and avoid the error.


### Details and comments


