### PR TITLE
Deprecate setting client version

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -162,7 +162,7 @@ class IBMQJob(Job):
             self._get_status_position(status, kwargs.pop('info_queue', None))
         self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
         self._share_level = share_level
-        self.client_version = client_info
+        self._set_client_version(client_info)
         self._experiment_id = experiment_id
         self._set_result(result)
 
@@ -187,10 +187,10 @@ class IBMQJob(Job):
             IBMQJobApiError: If an unexpected error occurred when retrieving
                 job information from the server.
         """
-        warnings.warn("The ``job.qobj()`` method is deprecated and will "
+        warnings.warn("The ``IBMQJob.qobj()`` method is deprecated and will "
                       "be removed in a future release. You can now pass circuits "
-                      "to ``backend.run()`` and use ``job.circuits()``, "
-                      "``job.backend_options()``, and ``job.header()`` to retrieve "
+                      "to ``IBMQBackend.run()`` and use ``IBMQJob.circuits()``, "
+                      "``IBMQJob.backend_options()``, and ``IBMQJob.header()`` to retrieve "
                       "circuits, run configuration, and Qobj header, respectively.",
                       DeprecationWarning, stacklevel=2)
         return self._get_qobj()
@@ -698,6 +698,17 @@ class IBMQJob(Job):
         Args:
             data: Client version.
         """
+        warnings.warn("The ``IBMQJob.client_version()`` method is deprecated and will "
+                      "be removed in a future release.",
+                      DeprecationWarning, stacklevel=2)
+        self._set_client_version(data)
+
+    def _set_client_version(self, data: Dict[str, str]) -> None:
+        """Set client version.
+
+        Args:
+            data: Client version.
+        """
         if data:
             if data.get('name', '').startswith('qiskit'):
                 self._client_version = dict(
@@ -767,7 +778,7 @@ class IBMQJob(Job):
         self._status, self._queue_info = \
             self._get_status_position(self._api_status, api_response.pop('info_queue', None))
         self._share_level = api_response.pop('share_level', 'none')
-        self.client_version = api_response.pop('client_info', None)
+        self._set_client_version(api_response.pop('client_info', None))
         self._set_result(api_response.pop('result', None))
         self._experiment_id = api_response.pop('experiment_id', None)
 

--- a/releasenotes/notes/deprecate-client-version-171398513e13aa23.yaml
+++ b/releasenotes/notes/deprecate-client-version-171398513e13aa23.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    Setting of the :class:`~qiskit.providers.ibmq.job.IBMQJob`
+    ``client_version`` attribute has been deprecated. You can, however, continue
+    to read the value of attribute.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR deprecates setting the `client_version` job attribute since any updates are not actually reflected on the server.


### Details and comments


