### PR TITLE
Allow noise model for backend.run()

### DIFF
--- a/.github/workflows/cron-other.yml
+++ b/.github/workflows/cron-other.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -U git+https://github.com/Qiskit/qiskit-aer.git
           pip install -c constraints.txt -e .
       - name: Run Tests
         run: make test1

--- a/.github/workflows/cron-slow.yml
+++ b/.github/workflows/cron-slow.yml
@@ -64,5 +64,6 @@ jobs:
           pip install -U -c constraints.txt -r requirements-dev.txt
           pip install -c constraints.txt -e .
           pip install -U git+https://github.com/Qiskit/qiskit-terra.git
+          pip install -U git+https://github.com/Qiskit/qiskit-aer.git
       - name: Run Tests
         run: make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -U git+https://github.com/Qiskit/qiskit-aer.git
           pip install -c constraints.txt -e .
       - name: Run Tests
         run: make test

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -803,7 +803,12 @@ class IBMQSimulator(IBMQBackend):
                           "run() method. For example: backend.run(circs, shots=2048).",
                           DeprecationWarning, stacklevel=2)
         backend_options = backend_options or {}
-        run_config = copy.copy(backend_options)
+        run_config = copy.deepcopy(backend_options)
+        if noise_model:
+            try:
+                noise_model = noise_model.to_dict()
+            except AttributeError:
+                pass
         run_config.update(kwargs)
         return super().run(circuits, job_name=job_name, job_share_level=job_share_level,
                            job_tags=job_tags, experiment_id=experiment_id,

--- a/releasenotes/notes/noise-model-serialization-29101caa4e797c36.yaml
+++ b/releasenotes/notes/noise-model-serialization-29101caa4e797c36.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the issue wherein passing in a noise model when sending a job to
+    an IBMQ simulator would raise a ``TypeError``. Fixes
+    `#894 <https://github.com/Qiskit/qiskit-ibmq-provider/issues/894>`_

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,4 @@ scipy>=1.0
 nbformat>=4.4.0
 nbconvert>=5.3.1
 qiskit_rng
+qiskit-aer

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -18,10 +18,10 @@ import copy
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import transpile, assemble
 from qiskit.test.reference_circuits import ReferenceCircuits
-from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
+from qiskit.providers.aer.noise import NoiseModel
 
 from ..ibmqtestcase import IBMQTestCase
-from ..decorators import requires_provider
+from ..decorators import requires_provider, requires_device
 
 
 class TestIbmqQasmSimulator(IBMQTestCase):
@@ -149,3 +149,12 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         backend.run(circ, method='my_method', header={'test': 'circuits'})
         qobj = assemble(circ, backend=backend, method='my_method', header={'test': 'qobj'})
         backend.run(qobj)
+
+    @requires_device
+    def test_simulator_with_noise_model(self, backend):
+        """Test using simulator with a noise model."""
+        noise_model = NoiseModel.from_backend(backend)
+        result = self.sim_backend.run(
+            transpile(ReferenceCircuits.bell(), backend=self.sim_backend),
+            noise_model=noise_model).result()
+        self.assertTrue(result)

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -125,7 +125,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
                              f"qobj header={qobj.header}")
             return mock.MagicMock()
 
-        backend = copy.copy(self.sim_backend)
+        backend = copy.deepcopy(self.sim_backend)
         backend._configuration._data['simulation_method'] = 'extended_stabilizer'
         backend._submit_job = _new_submit
 
@@ -141,7 +141,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
             self.assertEqual(qobj.config.method, 'my_method', f"qobj header={qobj.header}")
             return mock.MagicMock()
 
-        backend = copy.copy(self.sim_backend)
+        backend = copy.deepcopy(self.sim_backend)
         backend._configuration._data['simulation_method'] = 'extended_stabilizer'
         backend._submit_job = _new_submit
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #894. When we switched to v2 provider, the code that serializes noise model got dropped, causing `backend.run()` with a noise model to fail with `TypeError`. This PR reintroduced the code. 

The current `qiskit-aer` doesn't recognize the v2 provider `Backend`, so the CI will need to install from the master branch until it's released. 


### Details and comments


