### PR TITLE
Check parallel simulator jobs only if few pending jobs

### DIFF
--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -105,7 +105,7 @@ class TestIBMQJob(IBMQTestCase):
                 self.log.info('%s %s %s %s', job.status(), job.status() is JobStatus.RUNNING,
                               check, job.job_id())
             self.log.info('-  %s', str(time.time() - start_time))
-            if time.time() - start_time > timeout:
+            if time.time() - start_time > timeout and self.sim_backend.status().pending_jobs <= 5:
                 raise TimeoutError('Failed to see multiple running jobs after '
                                    '{0} seconds.'.format(timeout))
             time.sleep(0.2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`test_run_multiple_simulator` submits multiple jobs to the simulator and raises an error if they aren't all running within 30 minutes. This test consistently fails if the simulator has a long queue of jobs. This PR changes the code so that an error is raised only if the simulator has few than 5 pending jobs.


### Details and comments


