### PR TITLE
[WIP] Replace job manager with backend.run()

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -392,7 +392,6 @@ class IBMQBackend(Backend):
                 experiment_id=experiment_id)
         except ApiError as ex:
             if 'Error code: 3458' in str(ex):
-                print(f">>>>>>  IBMQBackend raising job limit error")
                 raise IBMQBackendJobLimitError('Error submitting job: {}'.format(str(ex))) from ex
             raise IBMQBackendApiError('Error submitting job: {}'.format(str(ex))) from ex
 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -392,6 +392,7 @@ class IBMQBackend(Backend):
                 experiment_id=experiment_id)
         except ApiError as ex:
             if 'Error code: 3458' in str(ex):
+                print(f">>>>>>  IBMQBackend raising job limit error")
                 raise IBMQBackendJobLimitError('Error submitting job: {}'.format(str(ex))) from ex
             raise IBMQBackendApiError('Error submitting job: {}'.format(str(ex))) from ex
 
@@ -592,6 +593,7 @@ class IBMQBackend(Backend):
             job_tags_operator: Optional[str] = "OR",
             experiment_id: Optional[str] = None,
             descending: bool = True,
+            ignore_composite_jobs: bool = False,
             db_filter: Optional[Dict[str, Any]] = None
     ) -> List[IBMQJob]:
         """Return the jobs submitted to this backend, subject to optional filtering.
@@ -629,6 +631,9 @@ class IBMQBackend(Backend):
             experiment_id: Filter by job experiment ID.
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (newest first). If ``False``, return in ascending order.
+            ignore_composite_jobs: If ``True``, sub-jobs of a single
+                :class:`~qiskit.providers.ibmq.job.IBMQCompositeJob` will be
+                returned as individual jobs instead of merged together.
             db_filter: A `loopback-based filter
                 <https://loopback.io/doc/en/lb2/Querying-data.html>`_.
                 This is an interface to a database ``where`` filter. Some
@@ -653,7 +658,8 @@ class IBMQBackend(Backend):
             limit=limit, skip=skip, backend_name=self.name(), status=status,
             job_name=job_name, start_datetime=start_datetime, end_datetime=end_datetime,
             job_tags=job_tags, job_tags_operator=job_tags_operator,
-            experiment_id=experiment_id, descending=descending, db_filter=db_filter)
+            experiment_id=experiment_id, descending=descending,
+            ignore_composite_jobs=ignore_composite_jobs, db_filter=db_filter)
 
     def active_jobs(self, limit: int = 10) -> List[IBMQJob]:
         """Return the unfinished jobs submitted to this backend.

--- a/qiskit/providers/ibmq/ibmqbackendservice.py
+++ b/qiskit/providers/ibmq/ibmqbackendservice.py
@@ -339,9 +339,7 @@ class IBMQBackendService:
             if composite_job_id and not ignore_composite_jobs:
                 if composite_job_id[0] not in composit_ids:
                     composit_ids.add(composite_job_id[0])
-                    print(f">>>>>>> IBMQBackendservice.jobs() retriving composite job")
                     job_list.append(self.retrieve_job(composite_job_id[0]))
-                    print(f">>>>>>> IBMQBackendservice.jobs() got composite job")
             else:
                 job_list.append(job)
 
@@ -595,7 +593,6 @@ class IBMQBackendService:
                  from the server.
         """
         if job_id.startswith(IBMQCompositeJob._id_prefix):
-            print(f">>>>>> IBMQBackendService.retrieve_job: getting subjobs for job {job_id}")
             job_responses = self._get_jobs(api_filter={'tags': job_id}, limit=None)
             sub_jobs = []
             for job_info in job_responses:
@@ -605,7 +602,6 @@ class IBMQBackendService:
 
             if not sub_jobs:
                 raise IBMQJobNotFoundError(f"Job {job_id} not found.")
-            print(f">>>>>> IBMQBackendService.retrieve_job: returning composite job subjobs")
             return IBMQCompositeJob.from_jobs(job_id=job_id, jobs=sub_jobs,
                                               api_client=self._provider._api_client)
 

--- a/qiskit/providers/ibmq/job/__init__.py
+++ b/qiskit/providers/ibmq/job/__init__.py
@@ -26,6 +26,8 @@ Classes
     :toctree: ../stubs/
 
     IBMQJob
+    IBMQCircuitJob
+    IBMQCompositeJob
     QueueInfo
 
 Functions
@@ -49,6 +51,8 @@ Exception
 """
 
 from .ibmqjob import IBMQJob
+from .ibmq_circuit_job import IBMQCircuitJob
+from .ibmq_composite_job import IBMQCompositeJob
 from .queueinfo import QueueInfo
 from .exceptions import (IBMQJobError, IBMQJobApiError, IBMQJobFailureError,
                          IBMQJobInvalidStateError, IBMQJobTimeoutError)

--- a/qiskit/providers/ibmq/job/exceptions.py
+++ b/qiskit/providers/ibmq/job/exceptions.py
@@ -40,3 +40,8 @@ class IBMQJobInvalidStateError(IBMQJobError):
 class IBMQJobTimeoutError(JobTimeoutError, IBMQJobError):
     """Errors raised when a job operation times out."""
     pass
+
+
+class IBMQJobNotFoundError(IBMQJobError):
+    """Errors raised when a job cannot be found."""
+    pass

--- a/qiskit/providers/ibmq/job/ibmq_circuit_job.py
+++ b/qiskit/providers/ibmq/job/ibmq_circuit_job.py
@@ -1,0 +1,1056 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""IBM Quantum Experience job."""
+
+import logging
+from typing import Dict, Optional, Tuple, Any, List, Callable, Union
+from datetime import datetime
+from concurrent import futures
+from threading import Event
+from queue import Empty
+import dateutil.parser
+
+from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
+from qiskit.providers.models import BackendProperties
+from qiskit.qobj import QasmQobj, PulseQobj
+from qiskit.result import Result
+from qiskit.providers.ibmq import ibmqbackend  # pylint: disable=unused-import
+from qiskit.assembler.disassemble import disassemble
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.pulse import Schedule
+
+from ..apiconstants import ApiJobStatus, ApiJobKind
+from ..api.clients import AccountClient
+from ..api.exceptions import ApiError, UserTimeoutExceededError
+from ..utils.utils import RefreshQueue, validate_job_tags, api_status_to_job_status
+from ..utils.qobj_utils import dict_to_qobj
+from ..utils.json_decoder import decode_backend_properties, decode_result
+from ..utils.converters import utc_to_local, utc_to_local_all
+from .exceptions import (IBMQJobApiError, IBMQJobFailureError,
+                         IBMQJobTimeoutError, IBMQJobInvalidStateError)
+from .queueinfo import QueueInfo
+from .utils import build_error_report, api_to_job_error, get_cancel_status
+from .ibmqjob import IBMQJob
+
+logger = logging.getLogger(__name__)
+
+
+class IBMQCircuitJob(IBMQJob):
+    """Representation of a job that executes on an IBM Quantum Experience backend.
+
+    The job may be executed on a simulator or a real device. A new ``IBMQCircuitJob``
+    instance is returned when you call
+    :meth:`IBMQBackend.run()<qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run()>`
+    to submit a job to a particular backend.
+
+    If the job is successfully submitted, you can inspect the job's status by
+    calling :meth:`status()`. Job status can be one of the
+    :class:`~qiskit.providers.JobStatus` members.
+    For example::
+
+        from qiskit.providers.jobstatus import JobStatus
+
+        job = backend.run(...)
+
+        try:
+            job_status = job.status()  # Query the backend server for job status.
+            if job_status is JobStatus.RUNNING:
+                print("The job is still running")
+        except IBMQJobApiError as ex:
+            print("Something wrong happened!: {}".format(ex))
+
+    Note:
+        An error may occur when querying the remote server to get job information.
+        The most common errors are temporary network failures
+        and server errors, in which case an
+        :class:`~qiskit.providers.ibmq.job.IBMQJobApiError`
+        is raised. These errors usually clear quickly, so retrying the operation is
+        likely to succeed.
+
+    Some of the methods in this class are blocking, which means control may
+    not be returned immediately. :meth:`result()` is an example
+    of a blocking method::
+
+        job = backend.run(...)
+
+        try:
+            job_result = job.result()  # It will block until the job finishes.
+            print("The job finished with result {}".format(job_result))
+        except JobError as ex:
+            print("Something wrong happened!: {}".format(ex))
+
+    Job information retrieved from the server is attached to the ``IBMQCircuitJob``
+    instance as attributes. Given that Qiskit and the server can be updated
+    independently, some of these attributes might be deprecated or experimental.
+    Supported attributes can be retrieved via methods. For example, you
+    can use :meth:`creation_date()` to retrieve the job creation date,
+    which is a supported attribute.
+    """
+
+    _data = {}  # type: Dict
+
+    _executor = futures.ThreadPoolExecutor()
+    """Threads used for asynchronous processing."""
+
+    def __init__(
+            self,
+            backend: 'ibmqbackend.IBMQBackend',
+            api_client: AccountClient,
+            job_id: str,
+            creation_date: str,
+            status: str,
+            kind: Optional[str] = None,
+            name: Optional[str] = None,
+            time_per_step: Optional[dict] = None,
+            result: Optional[dict] = None,
+            qobj: Optional[Union[dict, QasmQobj, PulseQobj]] = None,
+            error: Optional[dict] = None,
+            tags: Optional[List[str]] = None,
+            run_mode: Optional[str] = None,
+            share_level: Optional[str] = None,
+            client_info: Optional[Dict[str, str]] = None,
+            experiment_id: Optional[str] = None,
+            **kwargs: Any
+    ) -> None:
+        """IBMQCircuitJob constructor.
+
+        Args:
+            backend: The backend instance used to run this job.
+            api_client: Object for connecting to the server.
+            job_id: Job ID.
+            creation_date: Job creation date.
+            status: Job status returned by the server.
+            kind: Job type.
+            name: Job name.
+            time_per_step: Time spent for each processing step.
+            result: Job result.
+            qobj: Qobj for this job.
+            error: Job error.
+            tags: Job tags.
+            run_mode: Scheduling mode the job runs in.
+            share_level: Level the job can be shared with.
+            client_info: Client version.
+            experiment_id: ID of the experiment this job is part of.
+            kwargs: Additional job attributes.
+        """
+        super().__init__(backend=backend, api_client=api_client, job_id=job_id,
+                         name=name, share_level=share_level, tags=tags,
+                         experiment_id=experiment_id)
+        self._creation_date = dateutil.parser.isoparse(creation_date)
+        self._api_status = status
+        self._kind = ApiJobKind(kind) if kind else None
+        self._time_per_step = time_per_step
+        if isinstance(qobj, dict):
+            qobj = dict_to_qobj(qobj)
+        self._qobj = qobj
+        self._error = error
+        self._run_mode = run_mode
+        self._status, self._queue_info = \
+            self._get_status_position(status, kwargs.pop('info_queue', None))
+        self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
+        self.client_version = client_info
+        self._set_result(result)
+
+        self._data = {}
+        for key, value in kwargs.items():
+            # Append suffix to key to avoid conflicts.
+            self._data[key + '_'] = value
+
+        # Properties used for caching.
+        self._cancelled = False
+        self._job_error_msg = None  # type: Optional[str]
+        self._refreshed = False
+
+    def properties(self) -> Optional[BackendProperties]:
+        """Return the backend properties for this job.
+
+        Returns:
+            The backend properties used for this job, or ``None`` if
+            properties are not available.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        with api_to_job_error():
+            properties = self._api_client.job_properties(job_id=self.job_id())
+
+        if not properties:
+            return None
+
+        decode_backend_properties(properties)
+        properties = utc_to_local_all(properties)
+        return BackendProperties.from_dict(properties)
+
+    def result(
+            self,
+            timeout: Optional[float] = None,
+            wait: float = 5,
+            partial: bool = False,
+            refresh: bool = False
+    ) -> Result:
+        """Return the result of the job.
+
+        Note:
+            Some IBM Quantum Experience job results can only be read once. A
+            second attempt to query the server for the same job will fail,
+            since the job has already been "consumed".
+
+            The first call to this method in an ``IBMQCircuitJob`` instance will
+            query the server and consume any available job results. Subsequent
+            calls to that instance's ``result()`` will also return the results, since
+            they are cached. However, attempting to retrieve the results again in
+            another instance or session might fail due to the job results
+            having been consumed.
+
+        Note:
+            When `partial=True`, this method will attempt to retrieve partial
+            results of failed jobs. In this case, precaution should
+            be taken when accessing individual experiments, as doing so might
+            cause an exception. The ``success`` attribute of the returned
+            :class:`~qiskit.result.Result` instance can be used to verify
+            whether it contains partial results.
+
+            For example, if one of the experiments in the job failed, trying to
+            get the counts of the unsuccessful experiment would raise an exception
+            since there are no counts to return::
+
+                try:
+                    counts = result.get_counts("failed_experiment")
+                except QiskitError:
+                    print("Experiment failed!")
+
+        If the job failed, you can use :meth:`error_message()` to get more information.
+
+        Args:
+            timeout: Number of seconds to wait for job.
+            wait: Time in seconds between queries.
+            partial: If ``True``, return partial results if possible.
+            refresh: If ``True``, re-query the server for the result. Otherwise
+                return the cached value.
+
+        Returns:
+            Job result.
+
+        Raises:
+            IBMQJobInvalidStateError: If the job was cancelled.
+            IBMQJobFailureError: If the job failed.
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        # pylint: disable=arguments-differ
+        if not self._wait_for_completion(timeout=timeout, wait=wait,
+                                         required_status=(JobStatus.DONE,)):
+            if self._status is JobStatus.CANCELLED:
+                raise IBMQJobInvalidStateError('Unable to retrieve result for job {}. '
+                                               'Job was cancelled.'.format(self.job_id()))
+            # Job failed.
+            if partial:
+                self._retrieve_result(refresh=refresh)
+            if not partial or not self._result or not self._result.results:
+                error_message = self.error_message()
+                if '\n' in error_message:
+                    error_message = ". Use the error_message() method to get more details"
+                else:
+                    error_message = ": " + error_message
+                raise IBMQJobFailureError(
+                    'Unable to retrieve result for job {}. Job has failed{}'.format(
+                        self.job_id(), error_message))
+        else:
+            self._retrieve_result(refresh=refresh)
+
+        return self._result
+
+    def cancel(self) -> bool:
+        """Attempt to cancel the job.
+
+        Note:
+            Depending on the state the job is in, it might be impossible to
+            cancel the job.
+
+        Returns:
+            ``True`` if the job is cancelled, else ``False``.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        try:
+            response = self._api_client.job_cancel(self.job_id())
+            self._cancelled = get_cancel_status(response)
+            logger.debug('Job %s cancel status is "%s". Response data: %s.',
+                         self.job_id(), self._cancelled, response)
+            return self._cancelled
+        except ApiError as error:
+            self._cancelled = False
+            raise IBMQJobApiError('Unexpected error when cancelling job {}: {}'
+                                  .format(self.job_id(), str(error))) from error
+
+    def update_name(self, name: str) -> str:
+        """Update the name associated with this job.
+
+        Args:
+            name: The new `name` for this job.
+
+        Returns:
+            The new name associated with this job.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server or updating the job name.
+            IBMQJobInvalidStateError: If the input job name is not a string.
+        """
+        if not isinstance(name, str):
+            raise IBMQJobInvalidStateError(
+                '"{}" of type "{}" is not a valid job name. '
+                'The job name needs to be a string.'.format(name, type(name)))
+
+        with api_to_job_error():
+            response = self._api_client.job_update_attribute(
+                job_id=self.job_id(), attr_name='name', attr_value=name)
+
+        # Get the name from the response and check if the update was successful.
+        updated_name = response.get('name', None)
+        if (updated_name is None) or (name != updated_name):
+            raise IBMQJobApiError('An unexpected error occurred when updating the '
+                                  'name for job {}. The name was not updated for '
+                                  'the job.'.format(self.job_id()))
+
+        # Cache updated name.
+        self._name = updated_name
+
+        return self._name
+
+    def update_tags(
+            self,
+            replacement_tags: Optional[List[str]] = None,
+            additional_tags: Optional[List[str]] = None,
+            removal_tags: Optional[List[str]] = None
+    ) -> List[str]:
+        """Update the tags associated with this job.
+
+        When multiple parameters are specified, the parameters are processed in the
+        following order:
+
+            1. replacement_tags
+            2. additional_tags
+            3. removal_tags
+
+        For example, if 'new_tag' is specified for both `additional_tags` and `removal_tags`,
+        then it is added and subsequently removed from the tags list, making it a "do nothing"
+        operation.
+
+        Note:
+            * Some tags, such as those starting with ``ibmq_jobset``, are used
+              internally by `ibmq-provider` and therefore cannot be modified.
+            * When removing tags, if the job does not have a specified tag, it
+              will be ignored.
+
+        Args:
+            replacement_tags: The tags that should replace the current tags
+                associated with this job.
+            additional_tags: The new tags that should be added to the current tags
+                associated with this job.
+            removal_tags: The tags that should be removed from the current tags
+                associated with this job.
+
+        Returns:
+            The new tags associated with this job.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server or updating the job tags.
+            IBMQJobInvalidStateError: If none of the input parameters are specified or
+                if any of the input parameters are invalid.
+        """
+        if (replacement_tags is None) and (additional_tags is None) and (removal_tags is None):
+            raise IBMQJobInvalidStateError(
+                'The tags cannot be updated since none of the parameters are specified.')
+
+        # Get the list of tags to update.
+        tags_to_update = self._get_tags_to_update(replacement_tags=replacement_tags,
+                                                  additional_tags=additional_tags,
+                                                  removal_tags=removal_tags)
+
+        with api_to_job_error():
+            response = self._api_client.job_update_attribute(
+                job_id=self.job_id(), attr_name='tags', attr_value=tags_to_update)
+
+        # Get the tags from the response and check if the update was successful.
+        updated_tags = response.get('tags', None)
+        if (updated_tags is None) or (set(updated_tags) != set(tags_to_update)):
+            raise IBMQJobApiError('An unexpected error occurred when updating the '
+                                  'tags for job {}. The tags were not updated for '
+                                  'the job.'.format(self.job_id()))
+
+        # Cache the updated tags.
+        self._tags = updated_tags
+
+        return self._tags
+
+    def _get_tags_to_update(self,
+                            replacement_tags: Optional[List[str]],
+                            additional_tags: Optional[List[str]],
+                            removal_tags: Optional[List[str]]) -> List[str]:
+        """Create the list of tags to update for this job.
+
+        Args:
+            replacement_tags: The tags that should replace the current tags
+                associated with this job.
+            additional_tags: The new tags that should be added to the current tags
+                associated with this job.
+            removal_tags: The tags that should be removed from the current tags
+                associated with this job.
+
+        Returns:
+            The new tags to associate with this job.
+
+        Raises:
+            IBMQJobInvalidStateError: If any of the input parameters are invalid.
+        """
+        # Tags prefix that denotes a job belongs to a jobset.
+        ibmq_jobset_prefix = 'ibmq_jobset_'
+
+        tags_to_update = set(self._tags or [])  # Get the current job tags.
+        if isinstance(replacement_tags, list):  # `replacement_tags` could be an empty list.
+            # Replace the current tags and re-add those associated with a job set.
+            validate_job_tags(replacement_tags, IBMQJobInvalidStateError)
+            tags_to_update = set(replacement_tags)
+            tags_to_update.update(
+                filter(lambda old_tag: old_tag.startswith(ibmq_jobset_prefix), self._tags))
+        if additional_tags:
+            # Add the specified tags to the tags to update.
+            validate_job_tags(additional_tags, IBMQJobInvalidStateError)
+            tags_to_update.update(additional_tags)
+        if removal_tags:
+            # Remove the specified tags, except those related to a job set,
+            # from the tags to update.
+            validate_job_tags(removal_tags, IBMQJobInvalidStateError)
+            for tag_to_remove in removal_tags:
+                if tag_to_remove.startswith(ibmq_jobset_prefix):
+                    logger.warning('The tag "%s" for job %s will not be removed, because '
+                                   'it is used internally by the ibmq-provider.',
+                                   tag_to_remove, self.job_id())
+                    continue
+                if tag_to_remove in tags_to_update:
+                    tags_to_update.remove(tag_to_remove)
+                else:
+                    logger.warning('The tag "%s" for job %s will not be removed, because it was '
+                                   'not found in the job tags to update %s',
+                                   tag_to_remove, self.job_id(), tags_to_update)
+
+        return list(tags_to_update)
+
+    def status(self) -> JobStatus:
+        """Query the server for the latest job status.
+
+        Note:
+            This method is not designed to be invoked repeatedly in a loop for
+            an extended period of time. Doing so may cause the server to reject
+            your request.
+            Use :meth:`wait_for_final_state()` if you want to wait for the job to finish.
+
+        Note:
+            If the job failed, you can use :meth:`error_message()` to get
+            more information.
+
+        Returns:
+            The status of the job.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        if self._status in JOB_FINAL_STATES:
+            return self._status
+
+        with api_to_job_error():
+            api_response = self._api_client.job_status(self.job_id())
+            self._api_status = api_response['status']
+            self._status, self._queue_info = self._get_status_position(
+                self._api_status, api_response.get('info_queue', None))
+
+        # Get all job attributes if the job is done.
+        if self._status in JOB_FINAL_STATES:
+            self.refresh()
+
+        return self._status
+
+    def error_message(self) -> Optional[str]:
+        """Provide details about the reason of failure.
+
+        Returns:
+            An error report if the job failed or ``None`` otherwise.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        if not self._wait_for_completion(required_status=(JobStatus.ERROR,)):
+            return None
+
+        if not self._job_error_msg:
+            # First try getting error messages from the result.
+            self._retrieve_result()
+
+        if not self._job_error_msg:
+            # Then try refreshing the job
+            if not self._error:
+                self.refresh()
+            if self._error:
+                self._job_error_msg = self._format_message_from_error(self._error)
+            elif self._api_status.startswith('ERROR'):
+                self._job_error_msg = self._api_status
+            else:
+                self._job_error_msg = "Unknown error."
+
+        return self._job_error_msg
+
+    def queue_position(self, refresh: bool = False) -> Optional[int]:
+        """Return the position of the job in the server queue.
+
+        Note:
+            The position returned is within the scope of the provider
+            and may differ from the global queue position.
+
+        Args:
+            refresh: If ``True``, re-query the server to get the latest value.
+                Otherwise return the cached value.
+
+        Returns:
+            Position in the queue or ``None`` if position is unknown or not applicable.
+        """
+        if refresh:
+            # Get latest position
+            self.status()
+
+        if self._queue_info:
+            return self._queue_info.position
+        return None
+
+    def queue_info(self) -> Optional[QueueInfo]:
+        """Return queue information for this job.
+
+        The queue information may include queue position, estimated start and
+        end time, and dynamic priorities for the hub, group, and project. See
+        :class:`QueueInfo` for more information.
+
+        Note:
+            The queue information is calculated after the job enters the queue.
+            Therefore, some or all of the information may not be immediately
+            available, and this method may return ``None``.
+
+        Returns:
+            A :class:`QueueInfo` instance that contains queue information for
+            this job, or ``None`` if queue information is unknown or not
+            applicable.
+        """
+        # Get latest queue information.
+        self.status()
+
+        # Return queue information only if it has any useful information.
+        if self._queue_info and any(
+                value is not None for attr, value in self._queue_info.__dict__.items()
+                if not attr.startswith('_') and attr != 'job_id'):
+            return self._queue_info
+        return None
+
+    def creation_date(self) -> datetime:
+        """Return job creation date, in local time.
+
+        Returns:
+            The job creation date as a datetime object, in local time.
+        """
+        creation_date_local_dt = utc_to_local(self._creation_date)
+        return creation_date_local_dt
+
+    def job_id(self) -> str:
+        """Return the job ID assigned by the server.
+
+        Returns:
+            Job ID.
+        """
+        return self._job_id
+
+    def share_level(self) -> str:
+        """Return the share level of the job.
+
+        The share level is one of ``global``, ``hub``, ``group``, ``project``, and ``none``.
+
+        Returns:
+            The share level of the job.
+        """
+        if not self._share_level and not self._refreshed:
+            self.refresh()
+        return self._share_level
+
+    def time_per_step(self) -> Optional[Dict]:
+        """Return the date and time information on each step of the job processing.
+
+        The output dictionary contains the date and time information on each
+        step of the job processing, in local time. The keys of the dictionary
+        are the names of the steps, and the values are the date and time data,
+        as a datetime object with local timezone info.
+        For example::
+
+            {'CREATING': datetime(2020, 2, 13, 15, 19, 25, 717000, tzinfo=tzlocal(),
+             'CREATED': datetime(2020, 2, 13, 15, 19, 26, 467000, tzinfo=tzlocal(),
+             'VALIDATING': datetime(2020, 2, 13, 15, 19, 26, 527000, tzinfo=tzlocal()}
+
+        Returns:
+            Date and time information on job processing steps, in local time,
+            or ``None`` if the information is not yet available.
+        """
+        if not self._time_per_step or self._status not in JOB_FINAL_STATES:
+            self.refresh()
+
+        # Note: By default, `None` should be returned if no time per step info is available.
+        time_per_step_local = None
+        if self._time_per_step:
+            time_per_step_local = {}
+            for step_name, time_data_utc in self._time_per_step.items():
+                time_per_step_local[step_name] = utc_to_local(time_data_utc)
+
+        return time_per_step_local
+
+    def scheduling_mode(self) -> Optional[str]:
+        """Return the scheduling mode the job is in.
+
+        The scheduling mode indicates how the job is scheduled to run. For example,
+        ``fairshare`` indicates the job is scheduled using a fairshare algorithm.
+
+        This information is only available if the job status is ``RUNNING`` or ``DONE``.
+
+        Returns:
+            The scheduling mode the job is in or ``None`` if the information
+            is not available.
+        """
+        if self._run_mode is None:
+            self.refresh()
+            if self._status in [JobStatus.RUNNING, JobStatus.DONE] and self._run_mode is None:
+                self._run_mode = "fairshare"
+
+        return self._run_mode
+
+    @property
+    def client_version(self) -> Dict[str, str]:
+        """Return version of the client used for this job.
+
+        Returns:
+            Client version in dictionary format, where the key is the name
+                of the client and the value is the version.
+        """
+        if not self._client_version and not self._refreshed:
+            self.refresh()
+        return self._client_version
+
+    @client_version.setter
+    def client_version(self, data: Dict[str, str]) -> None:
+        """Set client version.
+
+        Args:
+            data: Client version.
+        """
+        if data:
+            if data.get('name', '').startswith('qiskit'):
+                self._client_version = dict(
+                    zip(data['name'].split(','), data['version'].split(',')))
+            else:
+                self._client_version = \
+                    {data.get('name', 'unknown'): data.get('version', 'unknown')}
+        else:
+            self._client_version = {}
+
+    @property
+    def experiment_id(self) -> str:
+        """Return the experiment ID.
+
+        Returns:
+            ID of the experiment this job is part of.
+        """
+        if not self._experiment_id and not self._refreshed:
+            self.refresh()
+        return self._experiment_id
+
+    def refresh(self) -> None:
+        """Obtain the latest job information from the server.
+
+        This method may add additional attributes to this job instance, if new
+        information becomes available.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        with api_to_job_error():
+            api_response = self._api_client.job_get(self.job_id())
+
+        try:
+            api_response.pop('job_id')
+            self._creation_date = dateutil.parser.isoparse(api_response.pop('creation_date'))
+            self._api_status = api_response.pop('status')
+            if 'kind' in api_response:
+                self._kind = ApiJobKind(api_response.pop('kind'))
+            if 'qobj' in api_response:
+                self._qobj = dict_to_qobj(api_response.pop('qobj'))
+        except (KeyError, TypeError) as err:
+            raise IBMQJobApiError("Unexpected return value received "
+                                  "from the server: {}".format(err)) from err
+
+        self._name = api_response.pop('name', None)
+        self._time_per_step = api_response.pop('time_per_step', None)
+        self._error = api_response.pop('error', None)
+        self._tags = api_response.pop('tags', [])
+        self._run_mode = api_response.pop('run_mode', None)
+        self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
+        self._status, self._queue_info = \
+            self._get_status_position(self._api_status, api_response.pop('info_queue', None))
+        self._share_level = api_response.pop('share_level', 'none')
+        self.client_version = api_response.pop('client_info', None)
+        self._set_result(api_response.pop('result', None))
+        self._experiment_id = api_response.pop('experiment_id', None)
+
+        for key, value in api_response.items():
+            self._data[key + '_'] = value
+        self._refreshed = True
+
+    def circuits(self) -> List[Union[QuantumCircuit, Schedule]]:
+        """Return the circuits or pulse schedules for this job.
+
+        Returns:
+            The circuits or pulse schedules for this job. An empty list
+            is returned if the circuits cannot be retrieved (for example, if
+            the job uses an old format that is no longer supported).
+        """
+        qobj = self._get_qobj()
+        if not qobj:
+            return []
+        circuits, _, _ = disassemble(qobj)
+        return circuits
+
+    def backend_options(self) -> Dict[str, Any]:
+        """Return the backend configuration options used for this job.
+
+        Options that are not applicable to the job execution are not returned.
+        Some but not all of the options with default values are returned.
+        You can use :attr:`qiskit.providers.ibmq.IBMQBackend.options` to see
+        all backend options.
+
+        Returns:
+            Backend options used for this job. An empty dictionary
+            is returned if the options cannot be retrieved.
+        """
+        qobj = self._get_qobj()
+        if not qobj:
+            return {}
+        _, options, _ = disassemble(qobj)
+        return options
+
+    def header(self) -> Dict:
+        """Return the user header specified for this job.
+
+        Returns:
+            User header specified for this job. An empty dictionary
+            is returned if the header cannot be retrieved.
+        """
+        qobj = self._get_qobj()
+        if not qobj:
+            return {}
+        _, _, header = disassemble(qobj)
+        return header
+
+    def wait_for_final_state(
+            self,
+            timeout: Optional[float] = None,
+            wait: Optional[float] = None,
+            callback: Optional[Callable] = None
+    ) -> None:
+        """Wait until the job progresses to a final state such as ``DONE`` or ``ERROR``.
+
+        Args:
+            timeout: Seconds to wait for the job. If ``None``, wait indefinitely.
+            wait: Seconds to wait between invoking the callback function. If ``None``,
+                the callback function is invoked only if job status or queue position
+                has changed.
+            callback: Callback function invoked after each querying iteration.
+                The following positional arguments are provided to the callback function:
+
+                    * job_id: Job ID
+                    * job_status: Status of the job from the last query.
+                    * job: This ``IBMQCircuitJob`` instance.
+
+                In addition, the following keyword arguments are also provided:
+
+                    * queue_info: A :class:`QueueInfo` instance with job queue information,
+                      or ``None`` if queue information is unknown or not applicable.
+                      You can use the ``to_dict()`` method to convert the
+                      :class:`QueueInfo` instance to a dictionary, if desired.
+
+        Raises:
+            IBMQJobTimeoutError: if the job does not reach a final state before the
+                specified timeout.
+        """
+        exit_event = Event()
+        status_queue = RefreshQueue(maxsize=1)
+        future = None
+        if callback:
+            future = self._executor.submit(self._status_callback,
+                                           status_queue=status_queue,
+                                           exit_event=exit_event,
+                                           callback=callback,
+                                           wait=wait)
+        try:
+            self._wait_for_completion(timeout=timeout, status_queue=status_queue)
+        finally:
+            if future:
+                # Make sure the callback thread wakes up.
+                exit_event.set()
+                status_queue.notify_all()
+                future.result()
+
+    def _wait_for_completion(
+            self,
+            timeout: Optional[float] = None,
+            wait: float = 5,
+            required_status: Tuple[JobStatus] = JOB_FINAL_STATES,
+            status_queue: Optional[RefreshQueue] = None
+    ) -> bool:
+        """Wait until the job progress to a final state such as ``DONE`` or ``ERROR``.
+
+        Args:
+            timeout: Seconds to wait for job. If ``None``, wait indefinitely.
+            wait: Seconds between queries.
+            required_status: The final job status required.
+            status_queue: Queue used to share the latest status.
+
+        Returns:
+            ``True`` if the final job status matches one of the required states.
+
+        Raises:
+            IBMQJobTimeoutError: if the job does not return results before a
+                specified timeout.
+            IBMQJobApiError: if there was an error getting the job status
+                due to a network issue.
+        """
+        if self._status in JOB_FINAL_STATES:
+            return self._status in required_status
+
+        try:
+            status_response = self._api_client.job_final_status(
+                self.job_id(), timeout=timeout, wait=wait, status_queue=status_queue)
+        except UserTimeoutExceededError:
+            raise IBMQJobTimeoutError(
+                'Timeout while waiting for job {}.'.format(self._job_id)) from None
+        except ApiError as api_err:
+            logger.error('Maximum retries exceeded: '
+                         'Error checking job status due to a network error.')
+            raise IBMQJobApiError('Error checking job status due to a network '
+                                  'error: {}'.format(str(api_err))) from api_err
+
+        self._api_status = status_response['status']
+        self._status, self._queue_info = self._get_status_position(
+            self._api_status, status_response.get('info_queue', None))
+
+        # Get all job attributes when the job is done.
+        self.refresh()
+
+        return self._status in required_status
+
+    def _retrieve_result(self, refresh: bool = False) -> None:
+        """Retrieve the job result response.
+
+        Args:
+            refresh: If ``True``, re-query the server for the result.
+               Otherwise return the cached value.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        if self._api_status in (ApiJobStatus.ERROR_CREATING_JOB.value,
+                                ApiJobStatus.ERROR_VALIDATING_JOB.value,
+                                ApiJobStatus.ERROR_TRANSPILING_JOB.value):
+            # No results if job was never executed.
+            return
+
+        if not self._result or refresh:  # type: ignore[has-type]
+            try:
+                result_response = self._api_client.job_result(
+                    self.job_id(), self._use_object_storage)
+                self._set_result(result_response)
+                if self._status is JobStatus.ERROR:
+                    # Look for error message in result response.
+                    self._check_for_error_message(result_response)
+            except ApiError as err:
+                if self._status not in (JobStatus.ERROR, JobStatus.CANCELLED):
+                    raise IBMQJobApiError(
+                        'Unable to retrieve result for '
+                        'job {}: {}'.format(self.job_id(), str(err))) from err
+
+    def _set_result(self, raw_data: Optional[Dict]) -> None:
+        """Set the job result.
+
+        Args:
+            raw_data: Raw result data.
+
+        Raises:
+            IBMQJobInvalidStateError: If result is in an unsupported format.
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        if raw_data is None:
+            self._result = None
+            return
+        raw_data['client_version'] = self.client_version
+        decode_result(raw_data)
+        try:
+            self._result = Result.from_dict(raw_data)
+        except (KeyError, TypeError) as err:
+            if not self._kind:
+                raise IBMQJobInvalidStateError(
+                    'Unable to retrieve result for job {}. Job result '
+                    'is in an unsupported format.'.format(self.job_id())) from err
+            raise IBMQJobApiError(
+                'Unable to retrieve result for '
+                'job {}: {}'.format(self.job_id(), str(err))) from err
+
+    def _check_for_error_message(self, result_response: Dict[str, Any]) -> None:
+        """Retrieves the error message from the result response.
+
+        Args:
+            result_response: Dictionary of the result response.
+        """
+        if result_response.get('results', None):
+            # If individual errors given
+            self._job_error_msg = build_error_report(result_response['results'])
+        elif 'error' in result_response:
+            self._job_error_msg = self._format_message_from_error(result_response['error'])
+
+    def _format_message_from_error(self, error: Dict) -> str:
+        """Format message from the error field.
+
+        Args:
+            The error field.
+
+        Returns:
+            A formatted error message.
+
+        Raises:
+            IBMQJobApiError: If invalid data received from the server.
+        """
+        try:
+            return "{}. Error code: {}.".format(error['message'], error['code'])
+        except KeyError as ex:
+            raise IBMQJobApiError('Failed to get error message for job {}. Invalid error '
+                                  'data received: {}'.format(self.job_id(), error)) from ex
+
+    def _status_callback(
+            self,
+            status_queue: RefreshQueue,
+            exit_event: Event,
+            callback: Callable,
+            wait: Optional[float]
+    ) -> None:
+        """Invoke the callback function with the latest job status.
+
+        Args:
+            status_queue: Queue containing the latest status.
+            exit_event: Event used to notify this thread to quit.
+            callback: Callback function to invoke.
+            wait: Time between each callback function call. If ``None``,
+                the callback function is invoked only if job status or queue position
+                has changed.
+        """
+        status_response = None
+        last_data = (None, None)  # type: Tuple[Optional[JobStatus], Optional[QueueInfo]]
+
+        while not exit_event.is_set():
+            try:
+                if wait is None:
+                    status_response = status_queue.get(block=True)
+                else:
+                    exit_event.wait(wait)
+                    status_response = status_queue.get(block=False)
+            except Empty:
+                pass
+
+            if not status_response:
+                continue
+
+            try:
+                status, queue_info = self._get_status_position(
+                    status_response['status'], status_response.get('info_queue', None))
+            except IBMQJobApiError as ex:
+                logger.warning("Unexpected error when getting job status: %s", ex)
+                continue
+
+            if status in JOB_FINAL_STATES:
+                return
+            if wait is None:
+                if (status, queue_info) == last_data:
+                    continue
+                last_data = (status, queue_info)
+            logger.debug("Invoking callback function, job status=%s, queue_info=%s",
+                         status, queue_info)
+            callback(self.job_id(), status, self, queue_info=queue_info)
+
+    def _get_status_position(
+            self,
+            api_status: str,
+            api_info_queue: Optional[Dict] = None
+    ) -> Tuple[JobStatus, Optional[QueueInfo]]:
+        """Return the corresponding job status for the input server job status.
+
+        Args:
+            api_status: Server job status
+            api_info_queue: Job queue information from the server response.
+
+        Returns:
+            A tuple of job status and queue information (``None`` if not available).
+
+        Raises:
+             IBMQJobApiError: if unexpected return value received from the server.
+        """
+        queue_info = None
+        status = api_status_to_job_status(api_status)
+        if api_status == ApiJobStatus.QUEUED.value and api_info_queue:
+            queue_info = QueueInfo(job_id=self.job_id(), **api_info_queue)
+
+        if status is not JobStatus.QUEUED:
+            queue_info = None
+
+        return status, queue_info
+
+    def _get_qobj(self) -> Optional[Union[QasmQobj, PulseQobj]]:
+        """Return the Qobj for this job.
+
+        Returns:
+            The Qobj for this job, or ``None`` if the job does not have a Qobj.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when retrieving
+                job information from the server.
+        """
+        if not self._kind:
+            return None
+
+        if not self._qobj:
+            with api_to_job_error():
+                qobj = self._api_client.job_download_qobj(
+                    self.job_id(), self._use_object_storage)
+                self._qobj = dict_to_qobj(qobj)
+
+        return self._qobj
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute {} is not defined.'.format(name)) from None

--- a/qiskit/providers/ibmq/job/ibmq_circuit_job.py
+++ b/qiskit/providers/ibmq/job/ibmq_circuit_job.py
@@ -418,8 +418,8 @@ class IBMQCircuitJob(IBMQJob):
         Raises:
             IBMQJobInvalidStateError: If any of the input parameters are invalid.
         """
-        # Tags prefix that denotes a job belongs to a jobset.
-        ibmq_jobset_prefix = 'ibmq_jobset_'
+        # Tags prefix that denotes a job belongs to a jobset or composite job.
+        filter_tags = ('ibmq_jobset_', "ibmq_composite_job_")
 
         tags_to_update = set(self._tags or [])  # Get the current job tags.
         if isinstance(replacement_tags, list):  # `replacement_tags` could be an empty list.
@@ -427,7 +427,7 @@ class IBMQCircuitJob(IBMQJob):
             validate_job_tags(replacement_tags, IBMQJobInvalidStateError)
             tags_to_update = set(replacement_tags)
             tags_to_update.update(
-                filter(lambda old_tag: old_tag.startswith(ibmq_jobset_prefix), self._tags))
+                filter(lambda old_tag: old_tag.startswith(filter_tags), self._tags))
         if additional_tags:
             # Add the specified tags to the tags to update.
             validate_job_tags(additional_tags, IBMQJobInvalidStateError)
@@ -437,7 +437,7 @@ class IBMQCircuitJob(IBMQJob):
             # from the tags to update.
             validate_job_tags(removal_tags, IBMQJobInvalidStateError)
             for tag_to_remove in removal_tags:
-                if tag_to_remove.startswith(ibmq_jobset_prefix):
+                if tag_to_remove.startswith(filter_tags):
                     logger.warning('The tag "%s" for job %s will not be removed, because '
                                    'it is used internally by the ibmq-provider.',
                                    tag_to_remove, self.job_id())

--- a/qiskit/providers/ibmq/job/ibmq_composite_job.py
+++ b/qiskit/providers/ibmq/job/ibmq_composite_job.py
@@ -1,0 +1,1333 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""IBM Quantum Experience composite job."""
+
+import re
+import logging
+from typing import Dict, Optional, Tuple, Any, List, Callable, Union
+import warnings
+import uuid
+from datetime import datetime
+from concurrent import futures
+import queue
+from collections import defaultdict
+import threading
+import copy
+from functools import wraps
+
+from qiskit.compiler import assemble
+from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
+from qiskit.providers.models import BackendProperties
+from qiskit.qobj import QasmQobj, PulseQobj
+from qiskit.result import Result
+from qiskit.providers.ibmq import ibmqbackend  # pylint: disable=unused-import
+from qiskit.assembler.disassemble import disassemble
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.pulse import Schedule
+from qiskit.result.models import ExperimentResult
+
+from ..apiconstants import API_JOB_FINAL_STATES
+from ..api.clients import AccountClient
+from ..utils.utils import validate_job_tags, api_status_to_job_status
+from .exceptions import (IBMQJobApiError, IBMQJobFailureError, IBMQJobTimeoutError,
+                         IBMQJobInvalidStateError)
+from .queueinfo import QueueInfo
+from .utils import auto_retry, JOB_STATUS_TO_INT, JobStatusQueueInfo, last_job_stat_pos
+from .ibmqjob import IBMQJob
+from .ibmq_circuit_job import IBMQCircuitJob
+from ..exceptions import IBMQBackendJobLimitError
+
+logger = logging.getLogger(__name__)
+
+
+def _requires_submit(func):  # type: ignore
+    """Decorator used by ``IBMQCompositeJob`` to wait for all jobs to be submitted."""
+
+    @wraps(func)
+    def _wrapper(self, *args, **kwargs):  # type: ignore
+        futures.wait(self._job_submit_futures)
+        self._move_jobs_from_queue()
+        return func(self, *args, **kwargs)
+
+    return _wrapper
+
+
+class IBMQCompositeJob(IBMQJob):
+    """Representation of a set of jobs that execute on an IBM Quantum Experience backend.
+
+    An ``IBMQCompositeJob`` instance is returned when you call
+    :meth:`IBMQBackend.run()<qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run()>`
+    to submit a list of circuits whose length exceeds the maximum allowed by
+    the backend or by the ``max_circuits_per_job`` parameter.
+
+    This ``IBMQCompositeJob`` instance manages all the sub-jobs for you and can
+    be used like a traditional job instance. For example, you can continue to
+    use methods like :meth:`status()` and :meth:`result()` to get the job
+    status and result, respectively.
+
+    You can also retrieve a previously executed ``IBMQCompositeJob`` using the
+    :meth:`~qiskit.providers.ibmq.IBMQBackend.retrieve_job` and
+    :meth:`~qiskit.providers.ibmq.IBMQBackend.jobs` methods, like you would with
+    traditional jobs.
+
+    ``IBMQCompositeJob`` also allows you to re-run failed jobs, using the
+    :meth:`rerun-failed()` method. This method will re-submit all failed or
+    cancelled sub-jobs. Any circuits that failed to be submitted (e.g. due to
+    server error) will only be re-submitted if the circuits are known. That is,
+    if this ``IBMQCompositeJob`` was returned by
+    :meth:`qiskit.providers.ibmq.IBMQBackend.run` and not retrieved from the server.
+
+    Some of the methods in this class are blocking, which means control may
+    not be returned immediately. :meth:`result()` is an example
+    of a blocking method, and control will return only after all sub-jobs finish.
+
+    ``IBMQCompositeJob`` uses job tags to identify sub-jobs. It is therefore
+    important to preserve these tags. All tags used internally by ``IBMQCompositeJob``
+    start with ``ibmq_composite_job_``.
+    """
+
+    _tag_prefix = "ibmq_composite_job_"
+    _id_prefix = _tag_prefix + "id_"
+    _id_suffix = "_"
+    _index_prefix = _tag_prefix + "indexes:"
+    _index_tag = _index_prefix + "{job_index}:{total}:{start_index}:{end_index}"
+    _index_pattern = re.compile(rf"{_index_prefix}(?P<job_index>\d+):(?P<total>\d+):"
+                                r"(?P<start_index>\d+):(?P<end_index>\d+)")
+
+    _executor = futures.ThreadPoolExecutor()
+    """Threads used for asynchronous processing."""
+
+    def __init__(
+            self,
+            backend: 'ibmqbackend.IBMQBackend',
+            api_client: AccountClient,
+            job_id: Optional[str] = None,
+            creation_date: Optional[datetime] = None,
+            jobs: Optional[List[IBMQCircuitJob]] = None,
+            circuits_list: Optional[List[Union[List[QuantumCircuit], List[Schedule]]]] = None,
+            run_config: Optional[Dict] = None,
+            name: Optional[str] = None,
+            share_level: Optional[str] = None,
+            tags: Optional[List[str]] = None,
+            experiment_id: Optional[str] = None,
+            client_version: Optional[Dict] = None
+    ) -> None:
+        """IBMQCompositeJob constructor.
+
+        Args:
+            backend: The backend instance used to run this job.
+            api_client: Object for connecting to the server.
+            job_id: Job ID.
+            creation_date: Job creation date.
+            jobs: A list of sub-jobs.
+            circuits_list: Circuits for this job.
+            run_config: Runtime configuration for this job.
+            name: Job name.
+            share_level: Level the job can be shared with.
+            tags: Job tags.
+            experiment_id: ID of the experiment this job is part of.
+            client_version: Client used for the job.
+        """
+        if jobs is None and circuits_list is None:
+            raise IBMQJobInvalidStateError('"jobs" and "circuits_list" cannot both be None.')
+
+        self._job_id = job_id or self._id_prefix + uuid.uuid4().hex + self._id_suffix
+        tags = tags or []
+        filtered_tags = [tag for tag in tags if not tag.startswith(self._tag_prefix)]
+        super().__init__(backend=backend, api_client=api_client, job_id=self._job_id,
+                         name=name, share_level=share_level, tags=filtered_tags,
+                         experiment_id=experiment_id)
+        self._client_version = client_version
+        self._status = JobStatus.INITIALIZING
+        self._creation_date = creation_date
+
+        # Properties used for job submit.
+        self._jobs = jobs or []
+        self._jobs_queue = queue.Queue()
+        self._job_submit_futures = []
+        self._job_submit_error_queue = queue.Queue()
+        self._job_submit_errors = []
+        self._job_submit_events = []
+
+        # Properties used for caching.
+        self._user_cancelled = False
+        self._job_error_msg = None  # type: Optional[str]
+        self._properties = None
+        self._queue_info = None
+        self._qobj = None
+        self._circuit_indexes = []  # type: List[Tuple[int, int]]
+        self._result = None
+        self._circuits = None
+
+        # Properties used for wait_for_final_state callback.
+        self._callback_lock = threading.Lock()
+        self._user_callback = None
+        self._last_reported = (None, None)  # type: Tuple[Optional[JobStatus], Optional[int]]
+        self._job_statuses = {}
+
+        if circuits_list is not None:
+            self._circuits = [circ for sublist in circuits_list for circ in sublist]
+            self._submit_circuits(circuits_list, run_config)
+        else:
+            # Validate the jobs.
+            job_indexes = set()
+            for job in self._jobs:
+                job_idx, start, end = \
+                    self._find_circuit_indexes(job, ['start_index', 'end_index', 'job_index'])
+                self._circuit_indexes.append((start, end))
+                job_indexes.add(job_idx)
+            self._circuit_indexes.sort()
+            missing = set(range(self._find_circuit_indexes(jobs[0], ['total'])[0])) - job_indexes
+            if len(missing) > 0:
+                raise IBMQJobInvalidStateError(
+                    f"Composite job {self.job_id()} is missing jobs at indexes {missing}.")
+
+    @classmethod
+    def from_jobs(
+            cls,
+            job_id: str,
+            jobs: List[IBMQCircuitJob],
+            api_client: AccountClient
+    ) -> 'IBMQCompositeJob':
+        """Return an instance of this class.
+
+        The input job ID is used to query for sub-job information from the server.
+
+        Args:
+            job_id: Job ID.
+            jobs: A list of subjobs that belong to this composite job.
+            api_client: Client to use to communicate with the server.
+
+        Returns:
+            An instance of this class.
+        """
+        ref_job = jobs[0]
+        return cls(backend=ref_job.backend(),
+                   api_client=api_client,
+                   job_id=job_id,
+                   creation_date=ref_job.creation_date(),
+                   jobs=jobs,
+                   circuits_list=None,
+                   run_config=None,
+                   name=ref_job.name(),
+                   share_level=ref_job.share_level(),
+                   tags=ref_job.tags(),
+                   experiment_id=ref_job.experiment_id,
+                   client_version=ref_job.client_version)
+
+    def _submit_circuits(
+            self,
+            circuit_lists: List[Union[List[QuantumCircuit], List[Schedule]]],
+            run_config: Dict
+    ) -> None:
+        """Assemble and submit circuits.
+
+        Args:
+            circuit_lists: List of circuits to submit.
+            run_config: Configuration used for assembling.
+        """
+        # Assemble all circuits first before submitting them with threads to
+        # avoid conflicts with terra assembler.
+        exp_index = 0
+        qobjs = []
+        logger.debug("Assembling all circuits.")
+        for circs in circuit_lists:
+            qobjs.append((assemble(circs, backend=self.backend(), **run_config),
+                          exp_index,  # start index
+                          exp_index+len(circs)-1))  # end index
+            exp_index += len(circs)
+            self._job_submit_events.append(threading.Event())
+
+        self._job_submit_events[0].set()
+        for idx, item in enumerate(qobjs):
+            qobj, start_index, end_index = item
+            if self._qobj is None:
+                self._qobj = qobj
+            else:
+                self._qobj.experiments.extend(qobj.experiments)
+            self._circuit_indexes.append((start_index, end_index))
+            self._job_submit_futures.append(
+                self._executor.submit(self._async_submit, qobj=qobj, start_index=start_index,
+                                      end_index=end_index, job_index=idx,
+                                      total=len(circuit_lists)))
+
+    def _async_submit(
+            self,
+            qobj: Union[QasmQobj, PulseQobj],
+            start_index: int,
+            end_index: int,
+            job_index: int,
+            total: int
+    ) -> None:
+        """Submit a Qobj asynchronously.
+
+        Args:
+            qobj: Qobj to run.
+            start_index: Starting index of the circuits in the Qobj.
+            end_index: Ending index of the circuits in the Qobj.
+            job_index: Job index.
+            total: Total number of jobs.
+        """
+        tags = self._tags.copy()
+        tags.append(self._index_tag.format(
+            job_index=job_index, total=total, start_index=start_index, end_index=end_index))
+        tags.append(self.job_id())
+        job = None
+        logger.debug(f"Submitting job for circuits {start_index}-{end_index}.")
+        self._job_submit_events[job_index].wait()
+        try:
+            while job is None:
+                if self._user_cancelled:
+                    return  # Abandon submit if user cancelled.
+                try:
+                    print(f">>>>>> submitting job")
+                    job = auto_retry(self.backend()._submit_job,
+                                     qobj=qobj, job_name=self._name,
+                                     job_share_level=self._share_level,
+                                     job_tags=tags, experiment_id=self._experiment_id)
+                except IBMQBackendJobLimitError:
+                    final_states = [state.value for state in API_JOB_FINAL_STATES]
+                    oldest_running = self.backend().jobs(
+                        limit=1, descending=False, db_filter={"status": {"nin": final_states}})
+                    if oldest_running:
+                        oldest_running = oldest_running[0]
+                        logger.warning("Job limit reached, waiting for job %s to finish "
+                                       "before submitting the next one.",
+                                       oldest_running.job_id())
+                        try:
+                            # Set a timeout in case the job is stuck.
+                            oldest_running.wait_for_final_state(timeout=300)
+                        except Exception as err:  # pylint: disable=broad-except
+                            # Don't kill the submit if unable to wait for old job.
+                            logger.debug("An error occurred while waiting for "
+                                         "job %s to finish: %s", oldest_running.job_id(), err)
+                except Exception as err:  # pylint: disable=broad-except
+                    self._job_submit_error_queue.put(
+                        {'start_index': start_index,
+                         'end_index': end_index,
+                         'job_index': job_index,
+                         'error': err})
+                    raise
+
+            if self._user_cancelled:
+                job.cancel()
+            self._jobs_queue.put_nowait(job)
+            print(f">>>>> job put in the queue")
+            logger.debug(f"Job {job.job_id()} for circuits {start_index}-{end_index} submitted.")
+        finally:
+            if job_index != total:
+                self._job_submit_events[job_index+1].set()  # Wake up the next submit.
+
+    @_requires_submit
+    def properties(self) -> Optional[Union[List[BackendProperties], BackendProperties]]:
+        """Return the backend properties for this job.
+
+        Note:
+            This method blocks until all sub-jobs are submitted.
+
+        Returns:
+            The backend properties used for this job, or ``None`` if
+            properties are not available. A list of backend properties is
+            returned if the sub-jobs used different properties.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        if self._properties is None:
+            self._properties = []
+            properties_ts = []
+            for job in self._jobs:
+                props = job.properties()
+                if props.last_update_date not in properties_ts:
+                    self._properties.append(props)
+                    properties_ts.append(props.last_update_date)
+
+        if not self._properties:
+            return None
+        if len(self._properties) == 1:
+            return self._properties[0]
+        return self._properties
+
+    def result(
+            self,
+            timeout: Optional[float] = None,
+            wait: float = 5,
+            partial: bool = False,
+            refresh: bool = False
+    ) -> Result:
+        """Return the result of the job.
+
+        Note:
+            This method blocks until all sub-jobs finish.
+
+        Note:
+            Some IBM Quantum Experience job results can only be read once. A
+            second attempt to query the server for the same job will fail,
+            since the job has already been "consumed".
+
+            The first call to this method in an ``IBMQCompositeJob`` instance will
+            query the server and consume any available job results. Subsequent
+            calls to that instance's ``result()`` will also return the results, since
+            they are cached. However, attempting to retrieve the results again in
+            another instance or session might fail due to the job results
+            having been consumed.
+
+        Note:
+            When `partial=True`, this method will attempt to retrieve partial
+            results of failed jobs. In this case, precaution should
+            be taken when accessing individual experiments, as doing so might
+            cause an exception. The ``success`` attribute of the returned
+            :class:`~qiskit.result.Result` instance can be used to verify
+            whether it contains partial results.
+
+            For example, if one of the circuits in the job failed, trying to
+            get the counts of the unsuccessful circuit would raise an exception
+            since there are no counts to return::
+
+                try:
+                    counts = result.get_counts("failed_circuit")
+                except QiskitError:
+                    print("Circuit execution failed!")
+
+        If the job failed, you can use :meth:`error_message()` to get more information.
+
+        Args:
+            timeout: Number of seconds to wait for job.
+            wait: Time in seconds between queries.
+            partial: If ``True``, return partial results if possible.
+            refresh: If ``True``, re-query the server for the result. Otherwise
+                return the cached value.
+
+        Returns:
+            Job result.
+
+        Raises:
+            IBMQJobInvalidStateError: If the job was cancelled.
+            IBMQJobFailureError: If the job failed.
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        # pylint: disable=arguments-differ
+        self.wait_for_final_state(wait=wait, timeout=timeout)
+        if self._status == JobStatus.DONE or partial:
+            self._result = self._gather_results(refresh=refresh)
+            if self._result is not None:
+                return self._result
+
+        if self._status is JobStatus.CANCELLED:
+            raise IBMQJobInvalidStateError('Unable to retrieve result for job {}. '
+                                           'Job was cancelled.'.format(self.job_id()))
+        print(f">>>>>> self._status={self._status}")
+        error_message = self.error_message()
+        if '\n' in error_message:
+            error_message = ". Use the error_message() method to get more details."
+        else:
+            error_message = ": " + error_message
+        raise IBMQJobFailureError(
+            'Unable to retrieve result for job {}. Job has failed{}'.format(
+                self.job_id(), error_message))
+
+    def cancel(self) -> bool:
+        """Attempt to cancel the job.
+
+        Note:
+            Depending on the state the job is in, it might be impossible to
+            cancel the job.
+
+        Returns:
+            ``True`` if the job is cancelled, else ``False``.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        self._user_cancelled = True
+        for event in self._job_submit_events:
+            event.set()  # Wake up all pending job submits.
+        all_cancelled = []
+        self._move_jobs_from_queue()
+        for job in self._jobs:
+            try:
+                all_cancelled.append(job.cancel())
+            except IBMQJobApiError as err:
+                if 'Error code: 3209' not in str(err):
+                    raise
+
+        return all(all_cancelled)
+
+    @_requires_submit
+    def update_name(self, name: str) -> str:
+        """Update the name associated with this job.
+
+        Note:
+            This method blocks until all sub-jobs are submitted.
+
+        Args:
+            name: The new `name` for this job.
+
+        Returns:
+            The new name associated with this job.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server or updating the job name.
+            IBMQJobInvalidStateError: If the input job name is not a string.
+        """
+        if not isinstance(name, str):
+            raise IBMQJobInvalidStateError(
+                '"{}" of type "{}" is not a valid job name. '
+                'The job name needs to be a string.'.format(name, type(name)))
+
+        self._name = name
+        for job in self._jobs:
+            auto_retry(job.update_name, name)
+
+        return self._name
+
+    @_requires_submit
+    def update_tags(
+            self,
+            replacement_tags: Optional[List[str]] = None,
+            additional_tags: Optional[List[str]] = None,
+            removal_tags: Optional[List[str]] = None
+    ) -> List[str]:
+        """Update the tags associated with this job.
+
+        When multiple parameters are specified, the parameters are processed in the
+        following order:
+
+            1. replacement_tags
+            2. additional_tags
+            3. removal_tags
+
+        For example, if 'new_tag' is specified for both `additional_tags` and `removal_tags`,
+        then it is added and subsequently removed from the tags list, making it a "do nothing"
+        operation.
+
+        Note:
+            * Some tags, such as those starting with ``ibmq_composite_job_``, are used
+              internally by `ibmq-provider` and therefore cannot be modified.
+            * When removing tags, if the job does not have a specified tag, it
+              will be ignored.
+
+        Note:
+            This method blocks until all sub-jobs are submitted.
+
+        Args:
+            replacement_tags: The tags that should replace the current tags
+                associated with this job.
+            additional_tags: The new tags that should be added to the current tags
+                associated with this job.
+            removal_tags: The tags that should be removed from the current tags
+                associated with this job.
+
+        Returns:
+            The new tags associated with this job.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server or updating the job tags.
+            IBMQJobInvalidStateError: If none of the input parameters are specified or
+                if any of the input parameters are invalid.
+        """
+        if (replacement_tags is None) and (additional_tags is None) and (removal_tags is None):
+            raise IBMQJobInvalidStateError(
+                'The tags cannot be updated since none of the parameters are specified.')
+
+        # Get the list of tags to update.
+        tags_to_update = self._get_tags_to_update(replacement_tags=replacement_tags,
+                                                  additional_tags=additional_tags,
+                                                  removal_tags=removal_tags)
+        for job in self._jobs:
+            auto_retry(job.update_tags, tags_to_update)
+        self._tags = tags_to_update
+        return self._tags
+
+    def _get_tags_to_update(self,
+                            replacement_tags: Optional[List[str]],
+                            additional_tags: Optional[List[str]],
+                            removal_tags: Optional[List[str]]) -> List[str]:
+        """Create the list of tags to update for this job.
+
+        Args:
+            replacement_tags: The tags that should replace the current tags
+                associated with this job.
+            additional_tags: The new tags that should be added to the current tags
+                associated with this job.
+            removal_tags: The tags that should be removed from the current tags
+                associated with this job.
+
+        Returns:
+            The new tags to associate with this job.
+
+        Raises:
+            IBMQJobInvalidStateError: If any of the input parameters are invalid.
+        """
+        tags_to_update = set(self._tags or [])  # Get the current job tags.
+        if isinstance(replacement_tags, list):  # `replacement_tags` could be an empty list.
+            # Replace the current tags and re-add those associated with a job set.
+            validate_job_tags(replacement_tags, IBMQJobInvalidStateError)
+            tags_to_update = set(replacement_tags)
+            tags_to_update.update(
+                filter(lambda old_tag: old_tag.startswith(self._id_prefix), self._tags))
+        if additional_tags:
+            # Add the specified tags to the tags to update.
+            validate_job_tags(additional_tags, IBMQJobInvalidStateError)
+            tags_to_update.update(additional_tags)
+        if removal_tags:
+            # Remove the specified tags, except those related to a job set,
+            # from the tags to update.
+            validate_job_tags(removal_tags, IBMQJobInvalidStateError)
+            for tag_to_remove in removal_tags:
+                if tag_to_remove.startswith(self._id_prefix):
+                    logger.warning('The tag "%s" for job %s will not be removed, because '
+                                   'it is used internally by the ibmq-provider.',
+                                   tag_to_remove, self.job_id())
+                    continue
+                if tag_to_remove in tags_to_update:
+                    tags_to_update.remove(tag_to_remove)
+                else:
+                    logger.warning('The tag "%s" for job %s will not be removed, because it was '
+                                   'not found in the job tags to update %s',
+                                   tag_to_remove, self.job_id(), tags_to_update)
+
+        return list(tags_to_update)
+
+    def status(self) -> JobStatus:
+        """Query the server for the latest job status.
+
+        Note:
+            This method is not designed to be invoked repeatedly in a loop for
+            an extended period of time. Doing so may cause the server to reject
+            your request.
+            Use :meth:`wait_for_final_state()` if you want to wait for the job to finish.
+
+        Note:
+            If the job failed, you can use :meth:`error_message()` to get
+            more information.
+
+        Note:
+            Since this job contains multiple sub-jobs, the returned status is mapped
+            in the following order:
+
+                * INITIALIZING - if any sub-job is being initialized.
+                * VALIDATING - if any sub-job is being validated.
+                * QUEUED - if any sub-job is queued.
+                * RUNNING - if any sub-job is still running.
+                * ERROR - if any sub-job incurred an error.
+                * CANCELLED - if any sub-job is cancelled.
+                * DONE - if all sub-jobs finished.
+
+        Returns:
+            The status of the job.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        self._update_status_queue_info_error()
+        return self._status
+
+    def report(self, detailed: bool = True) -> str:
+        """Return a report on current sub-job statuses.
+
+        Args:
+            detailed: If ``True``, return a detailed report. Otherwise return a
+                summary report.
+
+        Returns:
+            A report on sub-job statuses.
+        """
+        report = [f"Composite Job {self.job_id()}:",
+                  "  Summary report:"]
+
+        self._move_jobs_from_queue()
+        print(f">>>>>> report: self._jobs={self._jobs}")
+        by_status = defaultdict(int)
+        by_id = {}
+        for job in self._jobs:
+            status = job.status()
+            by_status[status] += 1
+            by_id[job.job_id()] = status
+        by_status[JobStatus.ERROR] += len(self._job_submit_errors)
+
+        # Summary report.
+        count_report = []
+        # Format header.
+        for stat in ['Total', 'Successful', 'Failed', 'Cancelled', 'Running', 'Pending']:
+            count_report.append(' '*4 + stat + " jobs: {}")
+        max_text = max(len(text) for text in count_report)
+        count_report = [text.rjust(max_text) for text in count_report]
+        # Format counts.
+        count_report[0] = count_report[0].format(len(self._circuit_indexes))
+        non_pending_count = 0
+        for idx, stat in enumerate([JobStatus.DONE, JobStatus.ERROR,
+                                    JobStatus.CANCELLED, JobStatus.RUNNING], 1):
+            non_pending_count += by_status[stat]
+            count_report[idx] = count_report[idx].format(by_status[stat])
+        count_report[-1] = count_report[-1].format(len(self._circuit_indexes) - non_pending_count)
+        report += count_report
+
+        # Detailed report.
+        if detailed:
+            report.append("\n  Detail report:")
+            indexed_jobs = {}
+            for job in self._jobs:
+                job_index = self._find_circuit_indexes(job, ['job_index'])[0]
+                print(f">>>>> report: job_index for job {job} is {job_index}, tag is {job.tags()}")
+                indexed_jobs[job_index] = job
+
+            indexed_error = {sub_err['job_index']: sub_err['error']
+                             for sub_err in self._job_submit_errors}
+
+            print(f">>>>>> report: indexed_jobs={indexed_jobs}")
+            for idx, circuit_indexes in enumerate(self._circuit_indexes):
+                report.append(' '*4 + f'Circuits {circuit_indexes[0]}-{circuit_indexes[1]}:')
+                report.append(' '*6 + f'Job index: {idx}')
+                print(f">>>>>>> report: idx is {idx}")
+                if idx in indexed_jobs:
+                    job = indexed_jobs[idx]
+                    report.append(' '*6 + f'Job ID: {job.job_id()}')
+                    report.append(' '*6 + f'Status: {by_id[job.job_id()]}')
+                elif idx in indexed_error:
+                    report.append(' '*6 + f"Status: {indexed_error[idx]}")
+                else:
+                    report.append(' '*6 + "Status: Job not yet submitted.")
+
+        return '\n'.join(report)
+
+    def error_message(self) -> Optional[str]:
+        """Provide details about the reason of failure.
+
+        Note:
+            This method blocks until the job finishes.
+
+        Returns:
+            An error report if the job failed or ``None`` otherwise.
+        """
+        self.wait_for_final_state()
+        if self._status != JobStatus.ERROR:
+            return None
+
+        if not self._job_error_msg:
+            self._update_status_queue_info_error()
+
+        return self._job_error_msg
+
+    def queue_position(self, refresh: bool = False) -> Optional[int]:
+        """Return the position of the job in the server queue.
+
+        This method returns the queue position of the sub-job that is
+        last in queue.
+
+        Note:
+            The position returned is within the scope of the provider
+            and may differ from the global queue position.
+
+        Args:
+            refresh: If ``True``, re-query the server to get the latest value.
+                Otherwise return the cached value.
+
+        Returns:
+            Position in the queue or ``None`` if position is unknown or not applicable.
+        """
+        if refresh:
+            self._update_status_queue_info_error()
+        return self._queue_info.queue_position if self._queue_info else None
+
+    def queue_info(self) -> Optional[QueueInfo]:
+        """Return queue information for this job.
+
+        This method returns the queue information of the sub-job that is
+        last in queue.
+
+        The queue information may include queue position, estimated start and
+        end time, and dynamic priorities for the hub, group, and project. See
+        :class:`QueueInfo` for more information.
+
+        Note:
+            The queue information is calculated after the job enters the queue.
+            Therefore, some or all of the information may not be immediately
+            available, and this method may return ``None``.
+
+        Returns:
+            A :class:`QueueInfo` instance that contains queue information for
+            this job, or ``None`` if queue information is unknown or not
+            applicable.
+        """
+        self._update_status_queue_info_error()
+        return self._queue_info
+
+    def creation_date(self) -> datetime:
+        """Return job creation date, in local time.
+
+        Returns:
+            The job creation date as a datetime object, in local time.
+        """
+        if not self._creation_date:
+            futures.wait(self._job_submit_futures[:1])  # Wait for first job.
+            self._move_jobs_from_queue()
+            self._creation_date = self._jobs[0].creation_date()
+
+        return self._creation_date
+
+    def share_level(self) -> str:
+        """Return the share level of the job.
+
+        The share level is one of ``global``, ``hub``, ``group``, ``project``, and ``none``.
+
+        Returns:
+            The share level of the job.
+        """
+        return self._share_level
+
+    def time_per_step(self) -> Optional[Dict]:
+        """Return the date and time information on each step of the job processing.
+
+        The output dictionary contains the date and time information on each
+        step of the job processing, in local time. The keys of the dictionary
+        are the names of the steps, and the values are the date and time data,
+        as a datetime object with local timezone info.
+        For example::
+
+            {'CREATING': datetime(2020, 2, 13, 15, 19, 25, 717000, tzinfo=tzlocal(),
+             'CREATED': datetime(2020, 2, 13, 15, 19, 26, 467000, tzinfo=tzlocal(),
+             'VALIDATING': datetime(2020, 2, 13, 15, 19, 26, 527000, tzinfo=tzlocal()}
+
+        Returns:
+            Date and time information on job processing steps, in local time,
+            or ``None`` if the information is not yet available.
+        """
+        output = {'CREATING': self._creation_date}
+        if self._has_pending_submit():
+            return output
+
+        timestamps = defaultdict(list)
+        for job in self._jobs:
+            job_timestamps = job.time_per_step()
+            if job_timestamps is None:
+                continue
+            for key, val in job_timestamps.items():
+                timestamps[key].append(val)
+
+        self._update_status_queue_info_error()
+        for key, val in timestamps.items():
+            if JOB_STATUS_TO_INT(api_status_to_job_status(key)) > JOB_STATUS_TO_INT(self._status):
+                continue
+            if key == 'CREATING':
+                continue
+            if key in ['TRANSPILING', 'VALIDATING', 'QUEUED', 'RUNNING']:
+                output[key] = sorted(val)[0]
+            else:
+                output[key] = sorted(val, reverse=True)[0]
+
+        return output
+
+    def scheduling_mode(self) -> Optional[str]:
+        """Return the scheduling mode the job is in.
+
+        The scheduling mode indicates how the job is scheduled to run. For example,
+        ``fairshare`` indicates the job is scheduled using a fairshare algorithm.
+
+        ``fairshare`` is returned if any of the sub-jobs has scheduling mode of
+        ``fairshare``.
+
+        This information is only available if the job status is ``RUNNING`` or ``DONE``.
+
+        Returns:
+            The scheduling mode the job is in or ``None`` if the information
+            is not available.
+        """
+        if self._has_pending_submit():
+            return None
+
+        mode = None
+        for job in self._jobs:
+            job_mode = job.scheduling_mode()
+            if job_mode == 'fairshare':
+                return 'fairshare'
+            if job_mode:
+                mode = job_mode
+        return mode
+
+    @property
+    def client_version(self) -> Dict[str, str]:
+        """Return version of the client used for this job.
+
+        Returns:
+            Client version in dictionary format, where the key is the name
+                of the client and the value is the version. An empty dictionary
+                is returned if the information is not yet known.
+        """
+        self._move_jobs_from_queue()
+        if not self._jobs:
+            return {}
+        return self._jobs[0].client_version
+
+    @client_version.setter
+    def client_version(self, data: Dict[str, str]) -> None:
+        """Set client version.
+
+        Args:
+            data: Client version.
+        """
+        warnings.warn('The ``client_version`` setter method is deprecated and '
+                      'will be removed in a future release. You can use the '
+                      '"QE_CUSTOM_CLIENT_APP_HEADER" environment variable to '
+                      'specify custom header for requests sent to the server.',
+                      DeprecationWarning, stacklevel=2)
+        if data:
+            if data.get('name', '').startswith('qiskit'):
+                self._client_version = dict(
+                    zip(data['name'].split(','), data['version'].split(',')))
+            else:
+                self._client_version = \
+                    {data.get('name', 'unknown'): data.get('version', 'unknown')}
+        else:
+            self._client_version = {}
+
+    @property
+    def experiment_id(self) -> str:
+        """Return the experiment ID.
+
+        Returns:
+            ID of the experiment this job is part of.
+        """
+        return self._experiment_id
+
+    def refresh(self) -> None:
+        """Obtain the latest job information from the server.
+
+        This method may add additional attributes to this job instance, if new
+        information becomes available.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        self._move_jobs_from_queue()
+        for job in self._jobs:
+            if job.status() not in JOB_FINAL_STATES:
+                job.refresh()
+
+    def circuits(self) -> List[Union[QuantumCircuit, Schedule]]:
+        """Return the circuits or pulse schedules for this job.
+
+        Returns:
+            The circuits or pulse schedules for this job.
+        """
+        if not self._circuits:
+            qobj = self._get_qobj()
+            self._circuits, _, _ = disassemble(qobj)
+
+        return self._circuits
+
+    def backend_options(self) -> Dict[str, Any]:
+        """Return the backend configuration options used for this job.
+
+        Options that are not applicable to the job execution are not returned.
+        Some but not all of the options with default values are returned.
+        You can use :attr:`qiskit.providers.ibmq.IBMQBackend.options` to see
+        all backend options.
+
+        Returns:
+            Backend options used for this job.
+        """
+        qobj = self._get_qobj()
+        _, options, _ = disassemble(qobj)
+        return options
+
+    def header(self) -> Dict:
+        """Return the user header specified for this job.
+
+        Returns:
+            User header specified for this job. An empty dictionary
+            is returned if the header cannot be retrieved.
+        """
+        qobj = self._get_qobj()
+        _, _, header = disassemble(qobj)
+        return header
+
+    @_requires_submit
+    def wait_for_final_state(
+            self,
+            timeout: Optional[float] = None,
+            wait: Optional[float] = None,
+            callback: Optional[Callable] = None
+    ) -> None:
+        """Wait until the job progresses to a final state such as ``DONE`` or ``ERROR``.
+
+        Args:
+            timeout: Seconds to wait for the job. If ``None``, wait indefinitely.
+            wait: Seconds to wait between invoking the callback function. If ``None``,
+                the callback function is invoked only if job status or queue position
+                has changed.
+            callback: Callback function invoked after each querying iteration.
+                The following positional arguments are provided to the callback function:
+
+                    * job_id: Job ID
+                    * job_status: Status of the job from the last query.
+                    * job: This ``IBMQCompositeJob`` instance.
+
+                In addition, the following keyword arguments are also provided:
+
+                    * queue_info: A :class:`QueueInfo` instance with job queue information,
+                      or ``None`` if queue information is unknown or not applicable.
+                      You can use the ``to_dict()`` method to convert the
+                      :class:`QueueInfo` instance to a dictionary, if desired.
+
+        Raises:
+            IBMQJobTimeoutError: if the job does not reach a final state before the
+                specified timeout.
+        """
+        if self._status in JOB_FINAL_STATES:
+            return
+
+        self._user_callback = callback
+        status_callback = self._status_callback if callback else None
+
+        # We need to monitor all jobs to give the most up-to-date information
+        # to the user callback function. Websockets are preferred to avoid
+        # excessive requests.
+        job_futures = []
+        for job in self._jobs:
+            job_futures.append(self._executor.submit(job.wait_for_final_state, timeout=timeout,
+                                                     wait=wait, callback=status_callback))
+        future_stats = futures.wait(job_futures, timeout=timeout)
+        for j in self._jobs:
+            print(f">>>>> sub job {j.job_id()} stat: {j.status()}")
+        self._update_status_queue_info_error()
+        print(f">>>>>> wait_for_final_state self._status={self._status}")
+        if future_stats[1]:
+            raise IBMQJobTimeoutError(f"Timeout waiting for job {self.job_id()}") from None
+        for fut in future_stats[0]:
+            exception = fut.exception()
+            if exception is not None:
+                raise exception from None
+
+    def sub_jobs(self, block_for_submit: bool = True) -> List[IBMQCircuitJob]:
+        """Return all submitted sub-jobs.
+
+        Args:
+            block_for_submit: ``True`` if this method should block until
+                all sub-jobs are submitted. ``False`` if the method should
+                return immediately with submitted sub-jobs, if any.
+
+        Returns:
+            All submitted sub-jobs.
+        """
+        if block_for_submit:
+            futures.wait(self._job_submit_futures)
+        print(f">>>>> len(self._job_submit_futures) = {len(self._job_submit_futures)}")
+        self._move_jobs_from_queue()
+        return self._jobs
+
+    def sub_job(self, circuit_index: int) -> Optional[IBMQCircuitJob]:
+        """Retrieve the job used to submit the specified circuit.
+
+        Args:
+            circuit_index: Index of the circuit whose job is to be returned.
+
+        Returns:
+            The Job submitted for the circuit, or ``None`` if the job has
+            not been submitted.
+
+        Raises:
+            IBMQJobInvalidStateError: If the circuit index is out of range.
+        """
+        self._move_jobs_from_queue()
+        last_index = self._circuit_indexes[-1][1]
+        if circuit_index > last_index:
+            raise IBMQJobInvalidStateError(
+                f"Circuit index {circuit_index} greater than circuit count {last_index}.")
+
+        for job in self._jobs:
+            start_index, end_index = self._find_circuit_indexes(job, ['start_index', 'end_index'])
+            if start_index >= circuit_index >= end_index:
+                return job
+
+        return None
+
+    def rerun_failed(self):
+        """Re-submit all failed sub-jobs.
+
+        Note:
+            All sub-jobs that are in "ERROR" or "CANCELLED" states will
+            be re-submitted.
+            Sub-jobs that failed to be submitted will only be re-submitted if the
+            circuits are known. That is, if this ``IBMQCompositeJob`` was
+            returned by :meth:`qiskit.providers.ibmq.IBMQBackend.run` and not
+            retrieved from the server.
+        """
+        self._move_jobs_from_queue()
+        if self._job_submit_errors:
+            new_qobj = {key: val for key, val in self._qobj.to_dict().items()
+                        if key != 'experiments'}  # Copy all but circuits.
+            new_qobj['experiments'] = []
+            for bad_submit in self._job_submit_errors:
+                start_idx, end_idx = bad_submit['start_index'], bad_submit['end_index']
+                new_qobj['experiments'].extend(self._qobj.experiments[start_idx:end_idx+1])
+                if new_qobj['type'] == 'PULSE':
+                    new_qobj = PulseQobj.from_dict(new_qobj)
+                else:
+                    new_qobj = QasmQobj.from_dict(new_qobj)
+                self._async_submit(new_qobj, start_index=start_idx, end_index=end_idx,
+                                   job_index=bad_submit['job_index'], total=len(self._circuits))
+            self._job_submit_errors = []
+
+        for idx, job in enumerate(self._jobs[:]):
+            if job.status() in [JobStatus.ERROR, JobStatus.CANCELLED]:
+                qobj = job._get_qobj()
+                job_idx, total, start, end = self._find_circuit_indexes(
+                    job, ['job_index', 'total', 'start_index', 'end_index'])
+                self._jobs.remove(job)
+                self._async_submit(qobj, start_index=start, end_index=end,
+                                   job_index=job_idx, total=total)
+
+    def block_for_submit(self) -> None:
+        """Block until all sub-jobs are submitted."""
+        futures.wait(self._job_submit_futures)
+
+    def _status_callback(
+            self,
+            job_id: str,
+            job_status: JobStatus,
+            job: IBMQCircuitJob,
+            queue_info: QueueInfo
+    ) -> None:
+        """Callback function used when a sub-job status changes.
+
+        Args:
+            job_id: Sub-job ID.
+            job_status: Sub-job status.
+            job: Sub-job.
+            queue_info: Sub-job queue info.
+        """
+        with self._callback_lock:
+            self._job_statuses[job_id] = JobStatusQueueInfo(job_status, queue_info)
+            self._status, self._queue_info = last_job_stat_pos(list(self._job_statuses.values()))
+            pos = self._queue_info.position if self._queue_info else None
+            if self._last_reported != (self._status, pos):
+                self._last_reported_status = (self._status, pos)
+                logger.debug("Invoking callback function, job status=%s, queue_info=%s",
+                             self._status, self._queue_info)
+                self._user_callback(self.job_id(), self._status, self, self._queue_info)
+
+    def _update_status_queue_info_error(self) -> None:
+        """Update the status, queue information, and error message of this composite job."""
+
+        def sort_by_date(date_job: IBMQCircuitJob):
+            """Sort the job by estimated completion date."""
+            queue_info = date_job.queue_info()
+            est_comp = queue_info.estimated_complete_time if queue_info else None
+            return est_comp is None, est_comp
+
+        if self._has_pending_submit():
+            self._status = JobStatus.INITIALIZING
+            return
+
+        if self._status in [JobStatus.CANCELLED, JobStatus.DONE]:
+            return
+        if self._status is JobStatus.ERROR and self._job_error_msg:
+            return
+
+        self._move_jobs_from_queue()
+        print(f">>>>> self._jobs={self._jobs}")
+        statuses = defaultdict(list)
+        for job in self._jobs:
+            status = job.status()
+            statuses[status].append(job)
+
+        print(f">>>>>> _update_status_queue_info_error: statuses={statuses.keys()}, {statuses.values()}")
+
+        for stat in [JobStatus.INITIALIZING, JobStatus.VALIDATING]:
+            if stat in statuses:
+                self._status = stat
+                return
+
+        if JobStatus.QUEUED in statuses:
+            self._status = JobStatus.QUEUED
+            # Sort by queue position. Put `None` to the end.
+            last_queued = sorted(
+                statuses[JobStatus.QUEUED],
+                key=lambda j: (j.queue_position() is None, j.queue_position()))[-1]
+            self._queue_info = last_queued.queue_info()
+            return
+
+        if JobStatus.RUNNING in statuses:
+            self._status = JobStatus.RUNNING
+            last_running = sorted(statuses[JobStatus.RUNNING], key=sort_by_date)[-1]
+            self._queue_info = last_running.queue_info()
+            return
+
+        if JobStatus.ERROR in statuses or self._job_submit_errors:
+            self._status = JobStatus.ERROR
+            self._build_error_report(statuses.get(JobStatus.ERROR, []))
+            return
+
+        for stat in [JobStatus.CANCELLED, JobStatus.DONE]:
+            if stat in statuses:
+                self._status = stat
+                return
+
+        print(f">>>>>> all statuses: {statuses.keys()}")
+        bad_stats = {k: [j.job_id() for j in v] for k, v in statuses.items()
+                     if k not in JobStatus}
+        raise IBMQJobInvalidStateError("Invalid job status found: " + str(bad_stats))
+
+    def _build_error_report(self, failed_jobs: List[IBMQCircuitJob]) -> None:
+        """Build the error report.
+
+        Args:
+            failed_jobs: A list of failed jobs.
+        """
+        def sort_by_indexes(item):
+            match = re.match(r"Circuits (\d+)-(\d+):", item)
+            if not match:
+                return 0
+            return match.group(1)
+
+        error_list = []
+        for job in failed_jobs:
+            start_index, end_index = self._find_circuit_indexes(job, ['start_index', 'end_index'])
+            error_list.append(f"Circuits {start_index}-{end_index}: Job {job.job_id()} failed: "
+                              f"{job.error_message()}")
+        for bad_submit in self._job_submit_errors:
+            error_list.append(f"Circuits {bad_submit['start_index']}-{bad_submit['end_index']}: "
+                              f"Job submit failed: {bad_submit['error']}")
+
+        error_list.sort(key=sort_by_indexes)
+        if len(error_list) > 1:
+            self._job_error_msg = \
+                'The following circuits failed:\n{}'.format('\n'.join(error_list))
+        else:
+            self._job_error_msg = error_list[0]
+
+    def _find_circuit_indexes(self, job: IBMQCircuitJob, indexes: List[str]) -> List[int]:
+        """Find the circuit indexes of the input job.
+
+        Args:
+            job: The circuit job.
+            indexes: Names of the indexes to retrieve. The names can be
+                ``job_index``, ``total``, ``start_index``, and ``end_index``.
+
+        Returns:
+            Job indexes.
+        """
+        index_tag = [tag for tag in job.tags() if tag.startswith(self._index_prefix)]
+        match = None
+        if index_tag:
+            match = re.match(self._index_pattern, index_tag[0])
+        if match is None:
+            raise IBMQJobInvalidStateError(f"Job {job.job_id()} in composite job {self.job_id()}"
+                                           f" is missing proper tags.")
+        output = []
+        for name in indexes:
+            output.append(int(match.group(name)))
+        return output
+
+    def _has_pending_submit(self) -> bool:
+        """Return whether there are pending job submit futures.
+
+        Returns:
+            Whether there are pending job submit futures.
+        """
+        print(f">>>>>> self._job_submit_futures={self._job_submit_futures}")
+        return not all(fut.done() for fut in self._job_submit_futures)
+
+    def _gather_results(self, refresh: bool = False) -> Optional[Result]:
+        """Retrieve the job result response.
+
+        Args:
+            refresh: If ``True``, re-query the server for the result.
+               Otherwise return the cached value.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when communicating
+                with the server.
+        """
+        if self._result and not refresh:
+            return self._result
+
+        job_results = []
+        for job in self._jobs:
+            try:
+                res = auto_retry(job.result, refresh=refresh, partial=True)
+                job_results.append(res)
+            except (IBMQJobFailureError, IBMQJobInvalidStateError):
+                job_results.append(None)
+
+        try:
+            good_result = next(res for res in job_results if res is not None).to_dict()
+        except StopIteration:
+            return None
+
+        ref_expr_result = good_result['results'][0]
+        template_expr_result = {
+            'success': False,
+            'data': {},
+            'status': 'ERROR'
+        }
+        for key in ['shots', 'meas_level', 'seed', 'meas_return']:
+            template_expr_result[key] = ref_expr_result.get(key, None)
+
+        good_result['job_id'] = self.job_id()
+        good_result['success'] = self._status == JobStatus.DONE
+        good_result['results'] = []
+        good_result['status'] = 'PARTIAL COMPLETED' if self._status == JobStatus.DONE \
+            else 'COMPLETED'
+        combined_result = Result.from_dict(good_result)
+
+        for idx, result in enumerate(job_results):
+            if result is not None:
+                combined_result.results.extend(result.results)
+            else:
+                expr_results = []
+                # Copy Qobj header to result
+                qobj = self._jobs[idx]._get_qobj()
+                for expr in qobj.experiments:
+                    template_expr_result['header'] = expr.header.to_dict()
+                    expr_results.append(ExperimentResult.from_dict(template_expr_result))
+                combined_result.results.extend(expr_results)
+
+        return combined_result
+
+    def _get_qobj(self) -> Optional[Union[QasmQobj, PulseQobj]]:
+        """Return the Qobj for this job.
+
+        Returns:
+            The Qobj for this job, or ``None`` if the job does not have a Qobj.
+
+        Raises:
+            IBMQJobApiError: If an unexpected error occurred when retrieving
+                job information from the server.
+        """
+        if not self._qobj:
+            self._qobj = copy.deepcopy(self._jobs[0]._get_qobj())
+            for idx in range(1, len(self._jobs)):
+                self._qobj.experiments.extend(self._jobs[idx]._get_qobj().experiments)
+        return self._qobj
+
+    def _move_jobs_from_queue(self) -> None:
+        """Move jobs from the thread-safe queue to list."""
+        def _queue_to_list(from_queue, to_list):
+            while not from_queue.empty():
+                try:
+                    to_list.append(from_queue.get_nowait())
+                except queue.Empty:
+                    pass
+
+        _queue_to_list(self._jobs_queue, self._jobs)
+        self._jobs.sort(key=lambda job: self._find_circuit_indexes(job, ['job_index'])[0])
+        _queue_to_list(self._job_submit_error_queue, self._job_submit_errors)

--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -13,113 +13,38 @@
 """IBM Quantum Experience job."""
 
 import logging
-from typing import Dict, Optional, Tuple, Any, List, Callable, Union
-import warnings
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Any, List, Union
 from datetime import datetime
-from concurrent import futures
-from threading import Event
-from queue import Empty
-import dateutil.parser
+import warnings
 
 from qiskit.providers.job import JobV1 as Job
-from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
 from qiskit.providers.models import BackendProperties
-from qiskit.qobj import QasmQobj, PulseQobj
 from qiskit.result import Result
 from qiskit.providers.ibmq import ibmqbackend  # pylint: disable=unused-import
-from qiskit.assembler.disassemble import disassemble
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.pulse import Schedule
+from qiskit.qobj import QasmQobj, PulseQobj
 
-from ..apiconstants import ApiJobStatus, ApiJobKind
 from ..api.clients import AccountClient
-from ..api.exceptions import ApiError, UserTimeoutExceededError
-from ..utils.utils import RefreshQueue, validate_job_tags, api_status_to_job_status
-from ..utils.qobj_utils import dict_to_qobj
-from ..utils.json_decoder import decode_backend_properties, decode_result
-from ..utils.converters import utc_to_local, utc_to_local_all
-from .exceptions import (IBMQJobApiError, IBMQJobFailureError,
-                         IBMQJobTimeoutError, IBMQJobInvalidStateError)
 from .queueinfo import QueueInfo
-from .utils import build_error_report, api_to_job_error, get_cancel_status
 
 logger = logging.getLogger(__name__)
 
 
-class IBMQJob(Job):
-    """Representation of a job that executes on an IBM Quantum Experience backend.
-
-    The job may be executed on a simulator or a real device. A new ``IBMQJob``
-    instance is returned when you call
-    :meth:`IBMQBackend.run()<qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run()>`
-    to submit a job to a particular backend.
-
-    If the job is successfully submitted, you can inspect the job's status by
-    calling :meth:`status()`. Job status can be one of the
-    :class:`~qiskit.providers.JobStatus` members.
-    For example::
-
-        from qiskit.providers.jobstatus import JobStatus
-
-        job = backend.run(...)
-
-        try:
-            job_status = job.status()  # Query the backend server for job status.
-            if job_status is JobStatus.RUNNING:
-                print("The job is still running")
-        except IBMQJobApiError as ex:
-            print("Something wrong happened!: {}".format(ex))
-
-    Note:
-        An error may occur when querying the remote server to get job information.
-        The most common errors are temporary network failures
-        and server errors, in which case an
-        :class:`~qiskit.providers.ibmq.job.IBMQJobApiError`
-        is raised. These errors usually clear quickly, so retrying the operation is
-        likely to succeed.
-
-    Some of the methods in this class are blocking, which means control may
-    not be returned immediately. :meth:`result()` is an example
-    of a blocking method::
-
-        job = backend.run(...)
-
-        try:
-            job_result = job.result()  # It will block until the job finishes.
-            print("The job finished with result {}".format(job_result))
-        except JobError as ex:
-            print("Something wrong happened!: {}".format(ex))
-
-    Job information retrieved from the server is attached to the ``IBMQJob``
-    instance as attributes. Given that Qiskit and the server can be updated
-    independently, some of these attributes might be deprecated or experimental.
-    Supported attributes can be retrieved via methods. For example, you
-    can use :meth:`creation_date()` to retrieve the job creation date,
-    which is a supported attribute.
-    """
+class IBMQJob(Job, ABC):
+    """Abstract base class for all IBM Quantum job."""
 
     _data = {}  # type: Dict
-
-    _executor = futures.ThreadPoolExecutor()
-    """Threads used for asynchronous processing."""
 
     def __init__(
             self,
             backend: 'ibmqbackend.IBMQBackend',
             api_client: AccountClient,
             job_id: str,
-            creation_date: str,
-            status: str,
-            kind: Optional[str] = None,
             name: Optional[str] = None,
-            time_per_step: Optional[dict] = None,
-            result: Optional[dict] = None,
-            qobj: Optional[Union[dict, QasmQobj, PulseQobj]] = None,
-            error: Optional[dict] = None,
-            tags: Optional[List[str]] = None,
-            run_mode: Optional[str] = None,
             share_level: Optional[str] = None,
-            client_info: Optional[Dict[str, str]] = None,
+            tags: Optional[List[str]] = None,
             experiment_id: Optional[str] = None,
             **kwargs: Any
     ) -> None:
@@ -129,53 +54,218 @@ class IBMQJob(Job):
             backend: The backend instance used to run this job.
             api_client: Object for connecting to the server.
             job_id: Job ID.
-            creation_date: Job creation date.
-            status: Job status returned by the server.
-            kind: Job type.
-            name: Job name.
-            time_per_step: Time spent for each processing step.
-            result: Job result.
-            qobj: Qobj for this job.
-            error: Job error.
-            tags: Job tags.
-            run_mode: Scheduling mode the job runs in.
-            share_level: Level the job can be shared with.
-            client_info: Client version.
-            experiment_id: ID of the experiment this job is part of.
             kwargs: Additional job attributes.
         """
-        self._backend = backend
+        Job.__init__(self, backend, job_id)
         self._api_client = api_client
-        self._job_id = job_id
-        self._creation_date = dateutil.parser.isoparse(creation_date)
-        self._api_status = status
-        self._kind = ApiJobKind(kind) if kind else None
         self._name = name
-        self._time_per_step = time_per_step
-        if isinstance(qobj, dict):
-            qobj = dict_to_qobj(qobj)
-        self._qobj = qobj
-        self._error = error
-        self._tags = tags or []
-        self._run_mode = run_mode
-        self._status, self._queue_info = \
-            self._get_status_position(status, kwargs.pop('info_queue', None))
-        self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
         self._share_level = share_level
-        self.client_version = client_info
+        self._tags = tags or []
         self._experiment_id = experiment_id
-        self._set_result(result)
 
         self._data = {}
         for key, value in kwargs.items():
             # Append suffix to key to avoid conflicts.
             self._data[key + '_'] = value
-        super().__init__(self.backend(), self.job_id())
 
-        # Properties used for caching.
-        self._cancelled = False
-        self._job_error_msg = None  # type: Optional[str]
-        self._refreshed = False
+    @abstractmethod
+    def properties(self) -> Optional[BackendProperties]:
+        """Return the backend properties for this job.
+
+        Returns:
+            The backend properties used for this job, or ``None`` if
+            properties are not available.
+        """
+        pass
+
+    @abstractmethod
+    def result(
+            self,
+            timeout: Optional[float] = None,
+            wait: float = 5,
+            partial: bool = False,
+            refresh: bool = False
+    ) -> Result:
+        """Return the result of the job.
+
+        Args:
+            timeout: Number of seconds to wait for job.
+            wait: Time in seconds between queries.
+            partial: If ``True``, return partial results if possible.
+            refresh: If ``True``, re-query the server for the result. Otherwise
+                return the cached value.
+
+        Returns:
+            Job result.
+        """
+        pass
+
+    @abstractmethod
+    def cancel(self) -> bool:
+        """Attempt to cancel the job.
+
+        Returns:
+            ``True`` if the job is cancelled, else ``False``.
+        """
+        pass
+
+    @abstractmethod
+    def update_name(self, name: str) -> str:
+        """Update the name associated with this job.
+
+        Args:
+            name: The new `name` for this job.
+
+        Returns:
+            The new name associated with this job.
+        """
+        pass
+
+    @abstractmethod
+    def update_tags(self, new_tags: List[str]) -> None:
+        """Update the tags associated with this job.
+
+        Args:
+            new_tags: New tags to be assigned to the job.
+        """
+        pass
+
+    @abstractmethod
+    def error_message(self) -> Optional[str]:
+        """Provide details about the reason of failure.
+
+        Returns:
+            An error report if the job failed or ``None`` otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def queue_position(self, refresh: bool = False) -> Optional[int]:
+        """Return the position of the job in the server queue.
+
+        Args:
+            refresh: If ``True``, re-query the server to get the latest value.
+                Otherwise return the cached value.
+
+        Returns:
+            Position in the queue or ``None`` if position is unknown or not applicable.
+        """
+        pass
+
+    @abstractmethod
+    def queue_info(self) -> Optional[QueueInfo]:
+        """Return queue information for this job.
+
+        Returns:
+            A :class:`QueueInfo` instance that contains queue information for
+            this job, or ``None`` if queue information is unknown or not
+            applicable.
+        """
+        pass
+
+    @abstractmethod
+    def creation_date(self) -> datetime:
+        """Return job creation date, in local time.
+
+        Returns:
+            The job creation date as a datetime object, in local time.
+        """
+        pass
+
+    @abstractmethod
+    def share_level(self) -> str:
+        """Return the share level of the job.
+
+        The share level is one of ``global``, ``hub``, ``group``, ``project``, and ``none``.
+
+        Returns:
+            The share level of the job.
+        """
+        pass
+
+    @abstractmethod
+    def time_per_step(self) -> Optional[Dict]:
+        """Return the date and time information on each step of the job processing.
+
+        Returns:
+            Date and time information on job processing steps, in local time,
+            or ``None`` if the information is not yet available.
+        """
+        pass
+
+    @abstractmethod
+    def scheduling_mode(self) -> Optional[str]:
+        """Return the scheduling mode the job is in.
+
+        Returns:
+            The scheduling mode the job is in or ``None`` if the information
+            is not available.
+        """
+        pass
+
+    @abstractmethod
+    def refresh(self) -> None:
+        """Obtain the latest job information from the server."""
+        pass
+
+    @abstractmethod
+    def circuits(self) -> List[Union[QuantumCircuit, Schedule]]:
+        """Return the circuits or pulse schedules for this job.
+
+        Returns:
+            The circuits or pulse schedules for this job. An empty list
+            is returned if the circuits cannot be retrieved (for example, if
+            the job uses an old format that is no longer supported).
+        """
+        pass
+
+    @abstractmethod
+    def backend_options(self) -> Dict[str, Any]:
+        """Return the backend configuration options used for this job.
+
+        Returns:
+            Backend options used for this job.
+        """
+        pass
+
+    @abstractmethod
+    def header(self) -> Dict:
+        """Return the user header specified for this job.
+
+        Returns:
+            User header specified for this job.
+        """
+        pass
+
+    def name(self) -> Optional[str]:
+        """Return the name assigned to this job.
+
+        Returns:
+            Job name or ``None`` if no name was assigned to this job.
+        """
+        return self._name
+
+    def tags(self) -> List[str]:
+        """Return the tags assigned to this job.
+
+        Returns:
+            Tags assigned to this job.
+        """
+        return self._tags.copy()
+
+    def submit(self) -> None:
+        """Unsupported method.
+
+        Note:
+            This method is not supported, please use
+            :meth:`~qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run`
+            to submit a job.
+
+        Raises:
+            NotImplementedError: Upon invocation.
+        """
+        raise NotImplementedError("job.submit() is not supported. Please use "
+                                  "IBMQBackend.run() to submit a job.")
 
     def qobj(self) -> Optional[Union[QasmQobj, PulseQobj]]:
         """Return the Qobj for this job.
@@ -195,913 +285,14 @@ class IBMQJob(Job):
                       DeprecationWarning, stacklevel=2)
         return self._get_qobj()
 
-    def properties(self) -> Optional[BackendProperties]:
-        """Return the backend properties for this job.
-
-        Returns:
-            The backend properties used for this job, or ``None`` if
-            properties are not available.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        with api_to_job_error():
-            properties = self._api_client.job_properties(job_id=self.job_id())
-
-        if not properties:
-            return None
-
-        decode_backend_properties(properties)
-        properties = utc_to_local_all(properties)
-        return BackendProperties.from_dict(properties)
-
-    def result(
-            self,
-            timeout: Optional[float] = None,
-            wait: float = 5,
-            partial: bool = False,
-            refresh: bool = False
-    ) -> Result:
-        """Return the result of the job.
-
-        Note:
-            Some IBM Quantum Experience job results can only be read once. A
-            second attempt to query the server for the same job will fail,
-            since the job has already been "consumed".
-
-            The first call to this method in an ``IBMQJob`` instance will
-            query the server and consume any available job results. Subsequent
-            calls to that instance's ``result()`` will also return the results, since
-            they are cached. However, attempting to retrieve the results again in
-            another instance or session might fail due to the job results
-            having been consumed.
-
-        Note:
-            When `partial=True`, this method will attempt to retrieve partial
-            results of failed jobs. In this case, precaution should
-            be taken when accessing individual experiments, as doing so might
-            cause an exception. The ``success`` attribute of the returned
-            :class:`~qiskit.result.Result` instance can be used to verify
-            whether it contains partial results.
-
-            For example, if one of the experiments in the job failed, trying to
-            get the counts of the unsuccessful experiment would raise an exception
-            since there are no counts to return::
-
-                try:
-                    counts = result.get_counts("failed_experiment")
-                except QiskitError:
-                    print("Experiment failed!")
-
-        If the job failed, you can use :meth:`error_message()` to get more information.
-
-        Args:
-            timeout: Number of seconds to wait for job.
-            wait: Time in seconds between queries.
-            partial: If ``True``, return partial results if possible.
-            refresh: If ``True``, re-query the server for the result. Otherwise
-                return the cached value.
-
-        Returns:
-            Job result.
-
-        Raises:
-            IBMQJobInvalidStateError: If the job was cancelled.
-            IBMQJobFailureError: If the job failed.
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        # pylint: disable=arguments-differ
-        if not self._wait_for_completion(timeout=timeout, wait=wait,
-                                         required_status=(JobStatus.DONE,)):
-            if self._status is JobStatus.CANCELLED:
-                raise IBMQJobInvalidStateError('Unable to retrieve result for job {}. '
-                                               'Job was cancelled.'.format(self.job_id()))
-            # Job failed.
-            if partial:
-                self._retrieve_result(refresh=refresh)
-            if not partial or not self._result or not self._result.results:
-                error_message = self.error_message()
-                if '\n' in error_message:
-                    error_message = ". Use the error_message() method to get more details"
-                else:
-                    error_message = ": " + error_message
-                raise IBMQJobFailureError(
-                    'Unable to retrieve result for job {}. Job has failed{}'.format(
-                        self.job_id(), error_message))
-        else:
-            self._retrieve_result(refresh=refresh)
-
-        return self._result
-
-    def cancel(self) -> bool:
-        """Attempt to cancel the job.
-
-        Note:
-            Depending on the state the job is in, it might be impossible to
-            cancel the job.
-
-        Returns:
-            ``True`` if the job is cancelled, else ``False``.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        try:
-            response = self._api_client.job_cancel(self.job_id())
-            self._cancelled = get_cancel_status(response)
-            logger.debug('Job %s cancel status is "%s". Response data: %s.',
-                         self.job_id(), self._cancelled, response)
-            return self._cancelled
-        except ApiError as error:
-            self._cancelled = False
-            raise IBMQJobApiError('Unexpected error when cancelling job {}: {}'
-                                  .format(self.job_id(), str(error))) from error
-
-    def update_name(self, name: str) -> str:
-        """Update the name associated with this job.
-
-        Args:
-            name: The new `name` for this job.
-
-        Returns:
-            The new name associated with this job.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server or updating the job name.
-            IBMQJobInvalidStateError: If the input job name is not a string.
-        """
-        if not isinstance(name, str):
-            raise IBMQJobInvalidStateError(
-                '"{}" of type "{}" is not a valid job name. '
-                'The job name needs to be a string.'.format(name, type(name)))
-
-        with api_to_job_error():
-            response = self._api_client.job_update_attribute(
-                job_id=self.job_id(), attr_name='name', attr_value=name)
-
-        # Get the name from the response and check if the update was successful.
-        updated_name = response.get('name', None)
-        if (updated_name is None) or (name != updated_name):
-            raise IBMQJobApiError('An unexpected error occurred when updating the '
-                                  'name for job {}. The name was not updated for '
-                                  'the job.'.format(self.job_id()))
-
-        # Cache updated name.
-        self._name = updated_name
-
-        return self._name
-
-    def update_tags(
-            self,
-            replacement_tags: Optional[List[str]] = None,
-            additional_tags: Optional[List[str]] = None,
-            removal_tags: Optional[List[str]] = None
-    ) -> List[str]:
-        """Update the tags associated with this job.
-
-        When multiple parameters are specified, the parameters are processed in the
-        following order:
-
-            1. replacement_tags
-            2. additional_tags
-            3. removal_tags
-
-        For example, if 'new_tag' is specified for both `additional_tags` and `removal_tags`,
-        then it is added and subsequently removed from the tags list, making it a "do nothing"
-        operation.
-
-        Note:
-            * Some tags, such as those starting with ``ibmq_jobset``, are used
-              internally by `ibmq-provider` and therefore cannot be modified.
-            * When removing tags, if the job does not have a specified tag, it
-              will be ignored.
-
-        Args:
-            replacement_tags: The tags that should replace the current tags
-                associated with this job.
-            additional_tags: The new tags that should be added to the current tags
-                associated with this job.
-            removal_tags: The tags that should be removed from the current tags
-                associated with this job.
-
-        Returns:
-            The new tags associated with this job.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server or updating the job tags.
-            IBMQJobInvalidStateError: If none of the input parameters are specified or
-                if any of the input parameters are invalid.
-        """
-        if (replacement_tags is None) and (additional_tags is None) and (removal_tags is None):
-            raise IBMQJobInvalidStateError(
-                'The tags cannot be updated since none of the parameters are specified.')
-
-        # Get the list of tags to update.
-        tags_to_update = self._get_tags_to_update(replacement_tags=replacement_tags,
-                                                  additional_tags=additional_tags,
-                                                  removal_tags=removal_tags)
-
-        with api_to_job_error():
-            response = self._api_client.job_update_attribute(
-                job_id=self.job_id(), attr_name='tags', attr_value=tags_to_update)
-
-        # Get the tags from the response and check if the update was successful.
-        updated_tags = response.get('tags', None)
-        if (updated_tags is None) or (set(updated_tags) != set(tags_to_update)):
-            raise IBMQJobApiError('An unexpected error occurred when updating the '
-                                  'tags for job {}. The tags were not updated for '
-                                  'the job.'.format(self.job_id()))
-
-        # Cache the updated tags.
-        self._tags = updated_tags
-
-        return self._tags
-
-    def _get_tags_to_update(self,
-                            replacement_tags: Optional[List[str]],
-                            additional_tags: Optional[List[str]],
-                            removal_tags: Optional[List[str]]) -> List[str]:
-        """Create the list of tags to update for this job.
-
-        Args:
-            replacement_tags: The tags that should replace the current tags
-                associated with this job.
-            additional_tags: The new tags that should be added to the current tags
-                associated with this job.
-            removal_tags: The tags that should be removed from the current tags
-                associated with this job.
-
-        Returns:
-            The new tags to associate with this job.
-
-        Raises:
-            IBMQJobInvalidStateError: If any of the input parameters are invalid.
-        """
-        # Tags prefix that denotes a job belongs to a jobset.
-        ibmq_jobset_prefix = 'ibmq_jobset_'
-
-        tags_to_update = set(self._tags or [])  # Get the current job tags.
-        if isinstance(replacement_tags, list):  # `replacement_tags` could be an empty list.
-            # Replace the current tags and re-add those associated with a job set.
-            validate_job_tags(replacement_tags, IBMQJobInvalidStateError)
-            tags_to_update = set(replacement_tags)
-            tags_to_update.update(
-                filter(lambda old_tag: old_tag.startswith(ibmq_jobset_prefix), self._tags))
-        if additional_tags:
-            # Add the specified tags to the tags to update.
-            validate_job_tags(additional_tags, IBMQJobInvalidStateError)
-            tags_to_update.update(additional_tags)
-        if removal_tags:
-            # Remove the specified tags, except those related to a job set,
-            # from the tags to update.
-            validate_job_tags(removal_tags, IBMQJobInvalidStateError)
-            for tag_to_remove in removal_tags:
-                if tag_to_remove.startswith(ibmq_jobset_prefix):
-                    logger.warning('The tag "%s" for job %s will not be removed, because '
-                                   'it is used internally by the ibmq-provider.',
-                                   tag_to_remove, self.job_id())
-                    continue
-                if tag_to_remove in tags_to_update:
-                    tags_to_update.remove(tag_to_remove)
-                else:
-                    logger.warning('The tag "%s" for job %s will not be removed, because it was '
-                                   'not found in the job tags to update %s',
-                                   tag_to_remove, self.job_id(), tags_to_update)
-
-        return list(tags_to_update)
-
-    def status(self) -> JobStatus:
-        """Query the server for the latest job status.
-
-        Note:
-            This method is not designed to be invoked repeatedly in a loop for
-            an extended period of time. Doing so may cause the server to reject
-            your request.
-            Use :meth:`wait_for_final_state()` if you want to wait for the job to finish.
-
-        Note:
-            If the job failed, you can use :meth:`error_message()` to get
-            more information.
-
-        Returns:
-            The status of the job.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        if self._status in JOB_FINAL_STATES:
-            return self._status
-
-        with api_to_job_error():
-            api_response = self._api_client.job_status(self.job_id())
-            self._api_status = api_response['status']
-            self._status, self._queue_info = self._get_status_position(
-                self._api_status, api_response.get('info_queue', None))
-
-        # Get all job attributes if the job is done.
-        if self._status in JOB_FINAL_STATES:
-            self.refresh()
-
-        return self._status
-
-    def error_message(self) -> Optional[str]:
-        """Provide details about the reason of failure.
-
-        Returns:
-            An error report if the job failed or ``None`` otherwise.
-        """
-        # pylint: disable=attribute-defined-outside-init
-        if not self._wait_for_completion(required_status=(JobStatus.ERROR,)):
-            return None
-
-        if not self._job_error_msg:
-            # First try getting error messages from the result.
-            self._retrieve_result()
-
-        if not self._job_error_msg:
-            # Then try refreshing the job
-            if not self._error:
-                self.refresh()
-            if self._error:
-                self._job_error_msg = self._format_message_from_error(self._error)
-            elif self._api_status.startswith('ERROR'):
-                self._job_error_msg = self._api_status
-            else:
-                self._job_error_msg = "Unknown error."
-
-        return self._job_error_msg
-
-    def queue_position(self, refresh: bool = False) -> Optional[int]:
-        """Return the position of the job in the server queue.
-
-        Note:
-            The position returned is within the scope of the provider
-            and may differ from the global queue position.
-
-        Args:
-            refresh: If ``True``, re-query the server to get the latest value.
-                Otherwise return the cached value.
-
-        Returns:
-            Position in the queue or ``None`` if position is unknown or not applicable.
-        """
-        if refresh:
-            # Get latest position
-            self.status()
-
-        if self._queue_info:
-            return self._queue_info.position
-        return None
-
-    def queue_info(self) -> Optional[QueueInfo]:
-        """Return queue information for this job.
-
-        The queue information may include queue position, estimated start and
-        end time, and dynamic priorities for the hub, group, and project. See
-        :class:`QueueInfo` for more information.
-
-        Note:
-            The queue information is calculated after the job enters the queue.
-            Therefore, some or all of the information may not be immediately
-            available, and this method may return ``None``.
-
-        Returns:
-            A :class:`QueueInfo` instance that contains queue information for
-            this job, or ``None`` if queue information is unknown or not
-            applicable.
-        """
-        # Get latest queue information.
-        self.status()
-
-        # Return queue information only if it has any useful information.
-        if self._queue_info and any(
-                value is not None for attr, value in self._queue_info.__dict__.items()
-                if not attr.startswith('_') and attr != 'job_id'):
-            return self._queue_info
-        return None
-
-    def creation_date(self) -> datetime:
-        """Return job creation date, in local time.
-
-        Returns:
-            The job creation date as a datetime object, in local time.
-        """
-        creation_date_local_dt = utc_to_local(self._creation_date)
-        return creation_date_local_dt
-
-    def job_id(self) -> str:
-        """Return the job ID assigned by the server.
-
-        Returns:
-            Job ID.
-        """
-        return self._job_id
-
-    def name(self) -> Optional[str]:
-        """Return the name assigned to this job.
-
-        Returns:
-            Job name or ``None`` if no name was assigned to this job.
-        """
-        return self._name
-
-    def tags(self) -> List[str]:
-        """Return the tags assigned to this job.
-
-        Returns:
-            Tags assigned to this job.
-        """
-        return self._tags.copy()
-
-    def share_level(self) -> str:
-        """Return the share level of the job.
-
-        The share level is one of ``global``, ``hub``, ``group``, ``project``, and ``none``.
-
-        Returns:
-            The share level of the job.
-        """
-        if not self._share_level and not self._refreshed:
-            self.refresh()
-        return self._share_level
-
-    def time_per_step(self) -> Optional[Dict]:
-        """Return the date and time information on each step of the job processing.
-
-        The output dictionary contains the date and time information on each
-        step of the job processing, in local time. The keys of the dictionary
-        are the names of the steps, and the values are the date and time data,
-        as a datetime object with local timezone info.
-        For example::
-
-            {'CREATING': datetime(2020, 2, 13, 15, 19, 25, 717000, tzinfo=tzlocal(),
-             'CREATED': datetime(2020, 2, 13, 15, 19, 26, 467000, tzinfo=tzlocal(),
-             'VALIDATING': datetime(2020, 2, 13, 15, 19, 26, 527000, tzinfo=tzlocal()}
-
-        Returns:
-            Date and time information on job processing steps, in local time,
-            or ``None`` if the information is not yet available.
-        """
-        if not self._time_per_step or self._status not in JOB_FINAL_STATES:
-            self.refresh()
-
-        # Note: By default, `None` should be returned if no time per step info is available.
-        time_per_step_local = None
-        if self._time_per_step:
-            time_per_step_local = {}
-            for step_name, time_data_utc in self._time_per_step.items():
-                time_per_step_local[step_name] = utc_to_local(time_data_utc)
-
-        return time_per_step_local
-
-    def scheduling_mode(self) -> Optional[str]:
-        """Return the scheduling mode the job is in.
-
-        The scheduling mode indicates how the job is scheduled to run. For example,
-        ``fairshare`` indicates the job is scheduled using a fairshare algorithm.
-
-        This information is only available if the job status is ``RUNNING`` or ``DONE``.
-
-        Returns:
-            The scheduling mode the job is in or ``None`` if the information
-            is not available.
-        """
-        if self._run_mode is None:
-            self.refresh()
-            if self._status in [JobStatus.RUNNING, JobStatus.DONE] and self._run_mode is None:
-                self._run_mode = "fairshare"
-
-        return self._run_mode
-
-    @property
-    def client_version(self) -> Dict[str, str]:
-        """Return version of the client used for this job.
-
-        Returns:
-            Client version in dictionary format, where the key is the name
-                of the client and the value is the version.
-        """
-        if not self._client_version and not self._refreshed:
-            self.refresh()
-        return self._client_version
-
-    @client_version.setter
-    def client_version(self, data: Dict[str, str]) -> None:
-        """Set client version.
-
-        Args:
-            data: Client version.
-        """
-        if data:
-            if data.get('name', '').startswith('qiskit'):
-                self._client_version = dict(
-                    zip(data['name'].split(','), data['version'].split(',')))
-            else:
-                self._client_version = \
-                    {data.get('name', 'unknown'): data.get('version', 'unknown')}
-        else:
-            self._client_version = {}
-
-    @property
-    def experiment_id(self) -> str:
-        """Return the experiment ID.
-
-        Returns:
-            ID of the experiment this job is part of.
-        """
-        if not self._experiment_id and not self._refreshed:
-            self.refresh()
-        return self._experiment_id
-
-    def submit(self) -> None:
-        """Unsupported method.
-
-        Note:
-            This method is not supported, please use
-            :meth:`~qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run`
-            to submit a job.
-
-        Raises:
-            NotImplementedError: Upon invocation.
-        """
-        raise NotImplementedError("job.submit() is not supported. Please use "
-                                  "IBMQBackend.run() to submit a job.")
-
-    def refresh(self) -> None:
-        """Obtain the latest job information from the server.
-
-        This method may add additional attributes to this job instance, if new
-        information becomes available.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        with api_to_job_error():
-            api_response = self._api_client.job_get(self.job_id())
-
-        try:
-            api_response.pop('job_id')
-            self._creation_date = dateutil.parser.isoparse(api_response.pop('creation_date'))
-            self._api_status = api_response.pop('status')
-            if 'kind' in api_response:
-                self._kind = ApiJobKind(api_response.pop('kind'))
-            if 'qobj' in api_response:
-                self._qobj = dict_to_qobj(api_response.pop('qobj'))
-        except (KeyError, TypeError) as err:
-            raise IBMQJobApiError("Unexpected return value received "
-                                  "from the server: {}".format(err)) from err
-
-        self._name = api_response.pop('name', None)
-        self._time_per_step = api_response.pop('time_per_step', None)
-        self._error = api_response.pop('error', None)
-        self._tags = api_response.pop('tags', [])
-        self._run_mode = api_response.pop('run_mode', None)
-        self._use_object_storage = (self._kind == ApiJobKind.QOBJECT_STORAGE)
-        self._status, self._queue_info = \
-            self._get_status_position(self._api_status, api_response.pop('info_queue', None))
-        self._share_level = api_response.pop('share_level', 'none')
-        self.client_version = api_response.pop('client_info', None)
-        self._set_result(api_response.pop('result', None))
-        self._experiment_id = api_response.pop('experiment_id', None)
-
-        for key, value in api_response.items():
-            self._data[key + '_'] = value
-        self._refreshed = True
-
-    def circuits(self) -> List[Union[QuantumCircuit, Schedule]]:
-        """Return the circuits or pulse schedules for this job.
-
-        Returns:
-            The circuits or pulse schedules for this job. An empty list
-            is returned if the circuits cannot be retrieved (for example, if
-            the job uses an old format that is no longer supported).
-        """
-        qobj = self._get_qobj()
-        if not qobj:
-            return []
-        circuits, _, _ = disassemble(qobj)
-        return circuits
-
-    def backend_options(self) -> Dict[str, Any]:
-        """Return the backend configuration options used for this job.
-
-        Options that are not applicable to the job execution are not returned.
-        Some but not all of the options with default values are returned.
-        You can use :attr:`qiskit.providers.ibmq.IBMQBackend.options` to see
-        all backend options.
-
-        Returns:
-            Backend options used for this job. An empty dictionary
-            is returned if the options cannot be retrieved.
-        """
-        qobj = self._get_qobj()
-        if not qobj:
-            return {}
-        _, options, _ = disassemble(qobj)
-        return options
-
-    def header(self) -> Dict:
-        """Return the user header specified for this job.
-
-        Returns:
-            User header specified for this job. An empty dictionary
-            is returned if the header cannot be retrieved.
-        """
-        qobj = self._get_qobj()
-        if not qobj:
-            return {}
-        _, _, header = disassemble(qobj)
-        return header
-
-    def wait_for_final_state(
-            self,
-            timeout: Optional[float] = None,
-            wait: Optional[float] = None,
-            callback: Optional[Callable] = None
-    ) -> None:
-        """Wait until the job progresses to a final state such as ``DONE`` or ``ERROR``.
-
-        Args:
-            timeout: Seconds to wait for the job. If ``None``, wait indefinitely.
-            wait: Seconds to wait between invoking the callback function. If ``None``,
-                the callback function is invoked only if job status or queue position
-                has changed.
-            callback: Callback function invoked after each querying iteration.
-                The following positional arguments are provided to the callback function:
-
-                    * job_id: Job ID
-                    * job_status: Status of the job from the last query.
-                    * job: This ``IBMQJob`` instance.
-
-                In addition, the following keyword arguments are also provided:
-
-                    * queue_info: A :class:`QueueInfo` instance with job queue information,
-                      or ``None`` if queue information is unknown or not applicable.
-                      You can use the ``to_dict()`` method to convert the
-                      :class:`QueueInfo` instance to a dictionary, if desired.
-
-        Raises:
-            IBMQJobTimeoutError: if the job does not reach a final state before the
-                specified timeout.
-        """
-        exit_event = Event()
-        status_queue = RefreshQueue(maxsize=1)
-        future = None
-        if callback:
-            future = self._executor.submit(self._status_callback,
-                                           status_queue=status_queue,
-                                           exit_event=exit_event,
-                                           callback=callback,
-                                           wait=wait)
-        try:
-            self._wait_for_completion(timeout=timeout, status_queue=status_queue)
-        finally:
-            if future:
-                # Make sure the callback thread wakes up.
-                exit_event.set()
-                status_queue.notify_all()
-                future.result()
-
-    def _wait_for_completion(
-            self,
-            timeout: Optional[float] = None,
-            wait: float = 5,
-            required_status: Tuple[JobStatus] = JOB_FINAL_STATES,
-            status_queue: Optional[RefreshQueue] = None
-    ) -> bool:
-        """Wait until the job progress to a final state such as ``DONE`` or ``ERROR``.
-
-        Args:
-            timeout: Seconds to wait for job. If ``None``, wait indefinitely.
-            wait: Seconds between queries.
-            required_status: The final job status required.
-            status_queue: Queue used to share the latest status.
-
-        Returns:
-            ``True`` if the final job status matches one of the required states.
-
-        Raises:
-            IBMQJobTimeoutError: if the job does not return results before a
-                specified timeout.
-            IBMQJobApiError: if there was an error getting the job status
-                due to a network issue.
-        """
-        if self._status in JOB_FINAL_STATES:
-            return self._status in required_status
-
-        try:
-            status_response = self._api_client.job_final_status(
-                self.job_id(), timeout=timeout, wait=wait, status_queue=status_queue)
-        except UserTimeoutExceededError:
-            raise IBMQJobTimeoutError(
-                'Timeout while waiting for job {}.'.format(self._job_id)) from None
-        except ApiError as api_err:
-            logger.error('Maximum retries exceeded: '
-                         'Error checking job status due to a network error.')
-            raise IBMQJobApiError('Error checking job status due to a network '
-                                  'error: {}'.format(str(api_err))) from api_err
-
-        self._api_status = status_response['status']
-        self._status, self._queue_info = self._get_status_position(
-            self._api_status, status_response.get('info_queue', None))
-
-        # Get all job attributes when the job is done.
-        self.refresh()
-
-        return self._status in required_status
-
-    def _retrieve_result(self, refresh: bool = False) -> None:
-        """Retrieve the job result response.
-
-        Args:
-            refresh: If ``True``, re-query the server for the result.
-               Otherwise return the cached value.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        if self._api_status in (ApiJobStatus.ERROR_CREATING_JOB.value,
-                                ApiJobStatus.ERROR_VALIDATING_JOB.value,
-                                ApiJobStatus.ERROR_TRANSPILING_JOB.value):
-            # No results if job was never executed.
-            return
-
-        if not self._result or refresh:  # type: ignore[has-type]
-            try:
-                result_response = self._api_client.job_result(
-                    self.job_id(), self._use_object_storage)
-                self._set_result(result_response)
-                if self._status is JobStatus.ERROR:
-                    # Look for error message in result response.
-                    self._check_for_error_message(result_response)
-            except ApiError as err:
-                if self._status not in (JobStatus.ERROR, JobStatus.CANCELLED):
-                    raise IBMQJobApiError(
-                        'Unable to retrieve result for '
-                        'job {}: {}'.format(self.job_id(), str(err))) from err
-
-    def _set_result(self, raw_data: Optional[Dict]) -> None:
-        """Set the job result.
-
-        Args:
-            raw_data: Raw result data.
-
-        Raises:
-            IBMQJobInvalidStateError: If result is in an unsupported format.
-            IBMQJobApiError: If an unexpected error occurred when communicating
-                with the server.
-        """
-        if raw_data is None:
-            self._result = None
-            return
-        raw_data['client_version'] = self.client_version
-        decode_result(raw_data)
-        try:
-            self._result = Result.from_dict(raw_data)
-        except (KeyError, TypeError) as err:
-            if not self._kind:
-                raise IBMQJobInvalidStateError(
-                    'Unable to retrieve result for job {}. Job result '
-                    'is in an unsupported format.'.format(self.job_id())) from err
-            raise IBMQJobApiError(
-                'Unable to retrieve result for '
-                'job {}: {}'.format(self.job_id(), str(err))) from err
-
-    def _check_for_error_message(self, result_response: Dict[str, Any]) -> None:
-        """Retrieves the error message from the result response.
-
-        Args:
-            result_response: Dictionary of the result response.
-        """
-        if result_response.get('results', None):
-            # If individual errors given
-            self._job_error_msg = build_error_report(result_response['results'])
-        elif 'error' in result_response:
-            self._job_error_msg = self._format_message_from_error(result_response['error'])
-
-    def _format_message_from_error(self, error: Dict) -> str:
-        """Format message from the error field.
-
-        Args:
-            The error field.
-
-        Returns:
-            A formatted error message.
-
-        Raises:
-            IBMQJobApiError: If invalid data received from the server.
-        """
-        try:
-            return "{}. Error code: {}.".format(error['message'], error['code'])
-        except KeyError as ex:
-            raise IBMQJobApiError('Failed to get error message for job {}. Invalid error '
-                                  'data received: {}'.format(self.job_id(), error)) from ex
-
-    def _status_callback(
-            self,
-            status_queue: RefreshQueue,
-            exit_event: Event,
-            callback: Callable,
-            wait: Optional[float]
-    ) -> None:
-        """Invoke the callback function with the latest job status.
-
-        Args:
-            status_queue: Queue containing the latest status.
-            exit_event: Event used to notify this thread to quit.
-            callback: Callback function to invoke.
-            wait: Time between each callback function call. If ``None``,
-                the callback function is invoked only if job status or queue position
-                has changed.
-        """
-        status_response = None
-        last_data = (None, None)  # type: Tuple[Optional[JobStatus], Optional[QueueInfo]]
-
-        while not exit_event.is_set():
-            try:
-                if wait is None:
-                    status_response = status_queue.get(block=True)
-                else:
-                    exit_event.wait(wait)
-                    status_response = status_queue.get(block=False)
-            except Empty:
-                pass
-
-            if not status_response:
-                continue
-
-            try:
-                status, queue_info = self._get_status_position(
-                    status_response['status'], status_response.get('info_queue', None))
-            except IBMQJobApiError as ex:
-                logger.warning("Unexpected error when getting job status: %s", ex)
-                continue
-
-            if status in JOB_FINAL_STATES:
-                return
-            if wait is None:
-                if (status, queue_info) == last_data:
-                    continue
-                last_data = (status, queue_info)
-            logger.debug("Invoking callback function, job status=%s, queue_info=%s",
-                         status, queue_info)
-            callback(self.job_id(), status, self, queue_info=queue_info)
-
-    def _get_status_position(
-            self,
-            api_status: str,
-            api_info_queue: Optional[Dict] = None
-    ) -> Tuple[JobStatus, Optional[QueueInfo]]:
-        """Return the corresponding job status for the input server job status.
-
-        Args:
-            api_status: Server job status
-            api_info_queue: Job queue information from the server response.
-
-        Returns:
-            A tuple of job status and queue information (``None`` if not available).
-
-        Raises:
-             IBMQJobApiError: if unexpected return value received from the server.
-        """
-        queue_info = None
-        status = api_status_to_job_status(api_status)
-        if api_status == ApiJobStatus.QUEUED.value and api_info_queue:
-            queue_info = QueueInfo(job_id=self.job_id(), **api_info_queue)
-
-        if status is not JobStatus.QUEUED:
-            queue_info = None
-
-        return status, queue_info
-
+    @abstractmethod
     def _get_qobj(self) -> Optional[Union[QasmQobj, PulseQobj]]:
         """Return the Qobj for this job.
 
         Returns:
             The Qobj for this job, or ``None`` if the job does not have a Qobj.
-
-        Raises:
-            IBMQJobApiError: If an unexpected error occurred when retrieving
-                job information from the server.
         """
-        if not self._kind:
-            return None
-
-        if not self._qobj:
-            with api_to_job_error():
-                qobj = self._api_client.job_download_qobj(
-                    self.job_id(), self._use_object_storage)
-                self._qobj = dict_to_qobj(qobj)
-
-        return self._qobj
+        pass
 
     def __getattr__(self, name: str) -> Any:
         try:

--- a/qiskit/providers/ibmq/job/sub_job.py
+++ b/qiskit/providers/ibmq/job/sub_job.py
@@ -1,0 +1,66 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""IBM Quantum Experience composite job."""
+
+import re
+import logging
+from typing import Dict, Optional, Tuple, Any, List, Callable, Union, Set
+import warnings
+import uuid
+from datetime import datetime
+from concurrent import futures
+import queue
+from collections import defaultdict, OrderedDict
+import threading
+import copy
+from functools import wraps
+import time
+import traceback
+
+from qiskit.compiler import assemble
+from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
+from qiskit.providers.models import BackendProperties
+from qiskit.qobj import QasmQobj, PulseQobj
+from qiskit.result import Result
+from qiskit.providers.ibmq import ibmqbackend  # pylint: disable=unused-import
+from qiskit.assembler.disassemble import disassemble
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.pulse import Schedule
+from qiskit.result.models import ExperimentResult
+
+from ..apiconstants import API_JOB_FINAL_STATES
+from ..api.clients import AccountClient
+from ..utils.utils import validate_job_tags, api_status_to_job_status
+from .exceptions import (IBMQJobApiError, IBMQJobFailureError, IBMQJobTimeoutError,
+                         IBMQJobInvalidStateError)
+from .queueinfo import QueueInfo
+from .utils import auto_retry, JOB_STATUS_TO_INT, JobStatusQueueInfo, last_job_stat_pos
+from .ibmqjob import IBMQJob
+from .ibmq_circuit_job import IBMQCircuitJob
+from ..exceptions import IBMQBackendJobLimitError
+
+
+class SubJob:
+
+    def __init__(
+            self,
+            start_index: int,
+            end_index: int,
+            job_index: int,
+            total: int
+    ) -> None:
+        self.start_index = start_index
+        self.end_index = end_index
+        self.job_index = job_index
+        self.total_jobs = total
+        self.job = None

--- a/qiskit/providers/ibmq/job/utils.py
+++ b/qiskit/providers/ibmq/job/utils.py
@@ -12,11 +12,24 @@
 
 """Utilities for working with IBM Quantum Experience jobs."""
 
-from typing import Dict, List, Generator, Any
+from typing import Dict, List, Generator, Any, Callable, Optional, NamedTuple
 from contextlib import contextmanager
+
+from qiskit.providers.jobstatus import JobStatus
 
 from ..api.exceptions import ApiError
 from .exceptions import IBMQJobApiError
+from .queueinfo import QueueInfo
+
+JOB_STATUS_TO_INT = {
+    JobStatus.INITIALIZING: 0,
+    JobStatus.VALIDATING: 1,
+    JobStatus.QUEUED: 2,
+    JobStatus.RUNNING: 3,
+    JobStatus.DONE: 4,
+    JobStatus.CANCELLED: 4,
+    JobStatus.ERROR: 4
+}
 
 
 def build_error_report(results: List[Dict[str, Any]]) -> str:
@@ -57,3 +70,59 @@ def api_to_job_error() -> Generator[None, None, None]:
         yield
     except ApiError as api_err:
         raise IBMQJobApiError(str(api_err)) from api_err
+
+
+def auto_retry(func: Callable, *args, **kwargs) -> Any:
+    """Retry the function if encountered server error.
+
+    Args:
+        func: Function to be retried.
+        *args: Function arguments.
+        **kwargs: Function arguments. `max_retry` can be
+            specified. The default is 3.
+
+    Returns:
+        function return value.
+    """
+    max_retry = kwargs.pop('max_retry', 3)
+    while True:
+        try:
+            return func(*args, **kwargs)
+        except IBMQJobApiError:
+            max_retry -= 1
+            if max_retry == 0:
+                raise
+
+
+class JobStatusQueueInfo(NamedTuple):
+    """A named tuple of job status and queue info."""
+    status: JobStatus
+    queue_info: Optional[QueueInfo]
+
+
+def last_job_stat_pos(jobs: List[JobStatusQueueInfo]) -> JobStatusQueueInfo:
+    """Find the status and queue information of the job last to finish.
+
+    Jobs are sorted by status, queue position, and estimated completion time.
+    A status of "QUEUED", for example, is "later" than one of status "RUNNING".
+    A higher queue position or estimated completion time is also considered
+    "later". A queue position of ``None`` is assumed to be higher than any
+    other positions, since the job is likely to be so new in the queue that
+    its position is yet to be determined. The same thing applies to estimated
+    completion time.
+
+    Args:
+        jobs: A list of jobs to assess.
+
+    Returns:
+        Status and queue information of the job last to finish.
+    """
+
+    def sort_3_keys(elem: JobStatusQueueInfo):
+        """Sort by job status, queue position, and est completion time."""
+        queue_info = elem.queue_info
+        queue_pos = queue_info.position if queue_info else None
+        est_comp = queue_info.estimated_complete_time if queue_info else None
+        return JOB_STATUS_TO_INT[elem.status]*-1, queue_pos is None, queue_pos, est_comp is None, est_comp
+
+    return sorted(jobs, key=sort_3_keys)[-1]

--- a/qiskit/providers/ibmq/job/utils.py
+++ b/qiskit/providers/ibmq/job/utils.py
@@ -26,9 +26,9 @@ JOB_STATUS_TO_INT = {
     JobStatus.VALIDATING: 1,
     JobStatus.QUEUED: 2,
     JobStatus.RUNNING: 3,
-    JobStatus.DONE: 4,
-    JobStatus.CANCELLED: 4,
-    JobStatus.ERROR: 4
+    JobStatus.ERROR: 4,
+    JobStatus.CANCELLED: 5,
+    JobStatus.DONE: 6
 }
 
 

--- a/test/fake_account_client.py
+++ b/test/fake_account_client.py
@@ -18,6 +18,8 @@ import copy
 from random import randrange
 import uuid
 from concurrent.futures import ThreadPoolExecutor, wait
+from datetime import timedelta, datetime
+import warnings
 
 from qiskit.test.mock.backends.poughkeepsie.fake_poughkeepsie import FakePoughkeepsie
 from qiskit.providers.ibmq.apiconstants import ApiJobStatus, API_JOB_FINAL_STATES, ApiJobShareLevel
@@ -52,6 +54,17 @@ VALID_RESULT = {
     }
 }
 
+API_STATUS_TO_INT = {
+    ApiJobStatus.CREATING: 0,
+    ApiJobStatus.VALIDATING: 1,
+    ApiJobStatus.QUEUED: 2,
+    ApiJobStatus.RUNNING: 3,
+    ApiJobStatus.COMPLETED: 4,
+    ApiJobStatus.ERROR_RUNNING_JOB: 4,
+    ApiJobStatus.ERROR_VALIDATING_JOB: 4,
+    ApiJobStatus.CANCELLED: 4
+}
+
 
 class BaseFakeJob:
     """Base class for faking a remote job."""
@@ -59,49 +72,73 @@ class BaseFakeJob:
     _job_progress = [
         ApiJobStatus.CREATING,
         ApiJobStatus.VALIDATING,
+        ApiJobStatus.QUEUED,
         ApiJobStatus.RUNNING,
         ApiJobStatus.COMPLETED
     ]
 
     def __init__(self, executor, job_id, qobj, backend_name, job_tags=None,
-                 share_level=None, job_name=None):
+                 share_level=None, job_name=None, experiment_id=None,
+                 run_mode=None, progress_time=0.5, **kwargs):
         """Initialize a fake job."""
         self._job_id = job_id
         self._status = ApiJobStatus.CREATING
         self.qobj = qobj
-        self._future = executor.submit(self._auto_progress)
         self._result = None
         self._backend_name = backend_name
         self._share_level = share_level
         self._job_tags = job_tags
         self._job_name = job_name
+        self._experiment_id = experiment_id
+        self._creation_date = datetime.now()
+        self._run_mode = run_mode
+        self._queue_pos = kwargs.pop('queue_pos', 'auto')
+        self._comp_time = kwargs.pop('est_completion', 'auto')
+        self._queue_info = None
+        self._progress_time = progress_time
+        self._future = executor.submit(self._auto_progress)
 
     def _auto_progress(self):
         """Automatically update job status."""
         for status in self._job_progress:
-            time.sleep(0.5)
+            time.sleep(self._progress_time)
             self._status = status
 
         if self._status == ApiJobStatus.COMPLETED:
-            new_result = copy.deepcopy(VALID_RESULT_RESPONSE)
-            for _ in range(len(self.qobj['experiments'])):
-                valid_result = copy.deepcopy(VALID_RESULT)
-                counts = randrange(1024)
-                valid_result['data']['counts'] = {
-                    '0x0': counts, '0x3': 1024-counts}
-                new_result['results'].append(valid_result)
-            new_result['job_id'] = self._job_id
-            new_result['backend_name'] = self._backend_name
-            self._result = new_result
+            self._save_result()
+        elif self._status == ApiJobStatus.ERROR_RUNNING_JOB:
+            self._save_bad_result()
+
+    def _save_result(self):
+        new_result = copy.deepcopy(VALID_RESULT_RESPONSE)
+        for _ in range(len(self.qobj['experiments'])):
+            valid_result = copy.deepcopy(VALID_RESULT)
+            counts = randrange(1024)
+            valid_result['data']['counts'] = {
+                '0x0': counts, '0x3': 1024-counts}
+            new_result['results'].append(valid_result)
+        new_result['job_id'] = self._job_id
+        new_result['backend_name'] = self._backend_name
+        self._result = new_result
+
+    def _save_bad_result(self):
+        new_result = copy.deepcopy(VALID_RESULT_RESPONSE)
+        new_result['job_id'] = self._job_id
+        new_result['backend_name'] = self._backend_name
+        new_result['success'] = False
+        new_result['error'] = {'message': 'Kaboom', 'code': 1234}
+        self._result = new_result
 
     def data(self):
         """Return job data."""
+        status = self._status
         data = {
             'job_id': self._job_id,
             'kind': 'q-object',
-            'status': self._status.value,
-            'creation_date': '2019-01-01T13:15:58.425972',
-            '_backend_info': {'name': self._backend_name}
+            'status': status.value,
+            'creation_date': self._creation_date.isoformat(),
+            '_backend_info': {'name': self._backend_name},
+            'client_info': {'qiskit': '0.23.5'}
         }
         if self._share_level:
             data['share_level'] = self._share_level
@@ -109,8 +146,44 @@ class BaseFakeJob:
             data['tags'] = self._job_tags.copy()
         if self._job_name:
             data['name'] = self._job_name
+        if self._experiment_id:
+            data['experiment_id'] = self._experiment_id
+        if status == ApiJobStatus.ERROR_VALIDATING_JOB:
+            data['error'] = {'message': 'Validation failed.', 'code': 1234}
+        if status in [ApiJobStatus.RUNNING] + list(API_JOB_FINAL_STATES) and self._run_mode:
+            data['run_mode'] = self._run_mode
+
+        time_per_step = {}
+        timestamp = self._creation_date
+        for api_stat in API_STATUS_TO_INT:
+            if API_STATUS_TO_INT[status] > API_STATUS_TO_INT[api_stat]:
+                time_per_step[api_stat.value] = timestamp.isoformat()
+                timestamp += timedelta(seconds=30)
+            elif status == api_stat:
+                time_per_step[api_stat.value] = timestamp.isoformat()
+                timestamp += timedelta(seconds=30)
+        data['time_per_step'] = time_per_step
 
         return data
+
+    def _get_info_queue(self):
+        self._queue_info = {
+            'status': 'PENDING_IN_QUEUE',
+            'position': randrange(1, 10) if self._queue_pos == 'auto' else self._queue_pos
+        }
+        if self._queue_info['position'] is None:
+            return self._queue_info
+
+        est_comp_ts = self._creation_date + timedelta(minutes=10*self._queue_info['position']) \
+            if self._comp_time == 'auto' else self._comp_time
+        if est_comp_ts is None:
+            return self._queue_info
+
+        self._queue_info['estimated_complete_time'] = est_comp_ts.isoformat()
+        self._queue_info['estimated_start_time'] = \
+            (est_comp_ts - timedelta(minutes=20)).isoformat()
+
+        return self._queue_info
 
     def cancel(self):
         """Cancel the job."""
@@ -124,6 +197,15 @@ class BaseFakeJob:
         if not self._result:
             raise RequestsApiError('Result is not available')
         return self._result
+
+    def status_data(self):
+        """Return job status data, including queue info."""
+        status = self._status
+        data = {'status': status.value}
+        if status == ApiJobStatus.QUEUED:
+            data['info_queue'] = self._get_info_queue()
+            print(f">>>>> fake account client: job {self._job_id} queue info: {data['info_queue']}")
+        return data
 
     def status(self):
         """Return job status."""
@@ -169,23 +251,66 @@ class FailedFakeJob(BaseFakeJob):
 
     _job_progress = [
         ApiJobStatus.CREATING,
-        ApiJobStatus.VALIDATING,
-        ApiJobStatus.RUNNING,
-        ApiJobStatus.ERROR_RUNNING_JOB
+        ApiJobStatus.VALIDATING
     ]
 
-    def data(self):
-        """Return job data."""
-        data = super().data()
-        if self.status() == ApiJobStatus.ERROR_RUNNING_JOB:
-            data['error'] = {'message': 'Job failed.', 'code': 1234}
-        return data
+    def __init__(self, *args, **kwargs):
+        # failure_type can be "validation", "result", or "partial"
+        self._failure_type = kwargs.pop('failure_type', 'validation')
+        self._job_progress = FailedFakeJob._job_progress.copy()
+        if self._failure_type == 'validation':
+            self._job_progress.append(ApiJobStatus.ERROR_VALIDATING_JOB)
+        else:
+            self._job_progress.extend([ApiJobStatus.RUNNING, ApiJobStatus.ERROR_RUNNING_JOB])
+        super().__init__(*args, **kwargs)
+
+    def _save_bad_result(self):
+        if self._failure_type != 'partial':
+            return super()._save_bad_result()
+        new_result = copy.deepcopy(VALID_RESULT_RESPONSE)
+        new_result['job_id'] = self._job_id
+        new_result['backend_name'] = self._backend_name
+        new_result['success'] = False
+        # Good first result.
+        valid_result = copy.deepcopy(VALID_RESULT)
+        counts = randrange(1024)
+        valid_result['data']['counts'] = {
+            '0x0': counts, '0x3': 1024-counts}
+        new_result['results'].append(valid_result)
+
+        for _ in range(1, len(self.qobj['experiments'])):
+            valid_result = copy.deepcopy(VALID_RESULT)
+            valid_result['success'] = False
+            valid_result['status'] = 'This circuit failed.'
+            new_result['results'].append(valid_result)
+        self._result = new_result
+
+
+class FixedStatusFakeJob(BaseFakeJob):
+    """Fake job that stays in a specific status."""
+
+    def __init__(self, *args, **kwargs):
+        self._fixed_status = kwargs.pop('fixed_status')
+        super().__init__(*args, **kwargs)
+
+    def _auto_progress(self):
+        """Automatically update job status."""
+        for status in self._job_progress:
+            time.sleep(0.5)
+            self._status = status
+            if status == self._fixed_status:
+                break
+
+        if self._status == ApiJobStatus.COMPLETED:
+            self._save_result()
 
 
 class BaseFakeAccountClient:
     """Base class for faking the AccountClient."""
 
-    def __init__(self, job_limit=-1, job_class=BaseFakeJob):
+    def __init__(self, job_limit=-1, job_class=BaseFakeJob, job_kwargs=None,
+                 props_count=None, queue_positions=None, est_completion=None,
+                 run_mode=None):
         """Initialize a fake account client."""
         self._jobs = {}
         self._results_retrieved = set()
@@ -194,19 +319,35 @@ class BaseFakeAccountClient:
         self._job_class = job_class
         if isinstance(self._job_class, list):
             self._job_class.reverse()
+        self._job_kwargs = job_kwargs or {}
+        self._props_count = props_count or 0
+        self._props_date = datetime.now().isoformat()
+        self._queue_positions = queue_positions.copy() if queue_positions else []
+        self._queue_positions.reverse()
+        self._est_completion = est_completion.copy() if est_completion else []
+        self._est_completion.reverse()
+        self._run_mode = run_mode
 
     def list_jobs_statuses(self, limit, skip, descending=True, extra_filter=None):
         """Return a list of statuses of jobs."""
         # pylint: disable=unused-argument
-        job_data = []
+        print(f">>>>>>>> BaseFakeAccountClient.list_jobs_statuse extra_filter={extra_filter}")
+        extra_filter = extra_filter or {}
+        if all(fil in extra_filter for fil in ['creationDate', 'id']):
+            return {}
+        tag = extra_filter.get('tags', None)
+        all_job_data = []
         for job in list(self._jobs.values())[skip:skip+limit]:
-            job_data.append(job.data())
+            job_data = job.data()
+            print(f">>>>>>>> BaseFakeAccountClient.list_jobs_statuse tag is {tag}, in data {tag in job_data['tags']}")
+            if tag is None or tag in job_data['tags']:
+                all_job_data.append(job_data)
         if not descending:
-            job_data.reverse()
-        return job_data
+            all_job_data.reverse()
+        return all_job_data
 
     def job_submit(self, backend_name, qobj_dict, job_name, job_share_level,
-                   job_tags, *_args, **_kwargs):
+                   job_tags, experiment_id, *_args, **_kwargs):
         """Submit a Qobj to a device."""
         if self._job_limit != -1 and self._unfinished_jobs() >= self._job_limit:
             raise RequestsApiError(
@@ -217,6 +358,17 @@ class BaseFakeAccountClient:
         job_share_level = job_share_level or ApiJobShareLevel.NONE
         job_class = self._job_class.pop() \
             if isinstance(self._job_class, list) else self._job_class
+        job_kwargs = copy.copy(self._job_kwargs)
+        if self._queue_positions:
+            job_kwargs['queue_pos'] = self._queue_positions.pop()
+        if self._est_completion:
+            job_kwargs['est_completion'] = self._est_completion.pop()
+
+        run_mode = self._run_mode
+        if run_mode == 'dedicated_once':
+            run_mode = 'dedicated'
+            self._run_mode = 'fairshare'
+
         new_job = job_class(
             executor=self._executor,
             job_id=new_job_id,
@@ -224,7 +376,10 @@ class BaseFakeAccountClient:
             backend_name=backend_name,
             share_level=job_share_level.value,
             job_tags=job_tags,
-            job_name=job_name)
+            job_name=job_name,
+            experiment_id=experiment_id,
+            run_mode=run_mode,
+            **job_kwargs)
         self._jobs[new_job_id] = new_job
         return new_job.data()
 
@@ -235,7 +390,7 @@ class BaseFakeAccountClient:
     def job_result(self, job_id, *_args, **_kwargs):
         """Return a random job result."""
         if job_id in self._results_retrieved:
-            raise ValueError('Result already retrieved for job {}!'.format(job_id))
+            warnings.warn(f'Result already retrieved for job {job_id}')
         self._results_retrieved.add(job_id)
         return self._get_job(job_id).result()
 
@@ -245,7 +400,7 @@ class BaseFakeAccountClient:
 
     def job_status(self, job_id, *_args, **_kwargs):
         """Return the status of a job."""
-        return {'status': self._get_job(job_id).status().value}
+        return self._get_job(job_id).status_data()
 
     def job_final_status(self, job_id, *_args, **_kwargs):
         """Wait until the job progress to a final state."""
@@ -253,18 +408,26 @@ class BaseFakeAccountClient:
         status = job.status()
         while status not in API_JOB_FINAL_STATES:
             time.sleep(0.5)
-            status = job.status()
+            status_data = job.status_data()
+            status = ApiJobStatus(status_data['status'])
             if _kwargs.get('status_queue', None):
-                data = {'status': status.value}
-                if status is ApiJobStatus.QUEUED:
-                    data['infoQueue'] = {'status': 'PENDING_IN_QUEUE',
-                                         'position': 1}
-                _kwargs['status_queue'].put(data)
+
+                # data = {'status': status.value}
+                # if status is ApiJobStatus.QUEUED:
+                #     data['infoQueue'] = {'status': 'PENDING_IN_QUEUE',
+                #                          'position': 1}
+                _kwargs['status_queue'].put(status_data)
         return self.job_status(job_id)
 
     def job_properties(self, *_args, **_kwargs):
         """Return the backend properties of a job."""
-        return FakePoughkeepsie().properties()
+        props = FakePoughkeepsie().properties().to_dict()
+        if self._props_count > 0:
+            self._props_count -= 1
+            new_dt = datetime.now() + timedelta(hours=randrange(300))
+            self._props_date = new_dt.isoformat()
+        props['last_update_date'] = self._props_date
+        return props
 
     def job_cancel(self, job_id, *_args, **_kwargs):
         """Submit a request for cancelling a job."""
@@ -306,21 +469,22 @@ class BaseFakeAccountClient:
 class JobSubmitFailClient(BaseFakeAccountClient):
     """Fake AccountClient used to fail a job submit."""
 
-    def __init__(self, max_fail_count=-1):
+    def __init__(self, failed_indexes):
         """JobSubmitFailClient constructor."""
-        self._fail_count = max_fail_count
+        self._failed_indexes = list(failed_indexes)
+        self._job_count = -1
         super().__init__()
 
     def job_submit(self, *_args, **_kwargs):  # pylint: disable=arguments-differ
         """Failing job submit."""
-        if self._fail_count != 0:
-            self._fail_count -= 1
+        self._job_count += 1
+        if self._job_count in self._failed_indexes:
             raise RequestsApiError('Job submit failed!')
         return super().job_submit(*_args, **_kwargs)
 
 
 class JobTimeoutClient(BaseFakeAccountClient):
-    """Fake AccountClient used to fail a job submit."""
+    """Fake AccountClient used to timeout waiting for job."""
 
     def __init__(self, *args, max_fail_count=-1, **kwargs):
         """JobTimeoutClient constructor."""

--- a/test/ibmq/test_composite_job.py
+++ b/test/ibmq/test_composite_job.py
@@ -18,27 +18,33 @@ import time
 from inspect import getfullargspec, isfunction
 import uuid
 from concurrent.futures import wait
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from dateutil import tz
 
 from qiskit import QuantumCircuit
 from qiskit import transpile
 from qiskit.result import Result
+from qiskit.exceptions import QiskitError
+from qiskit.circuit.random import random_circuit
+from qiskit.providers.models import BackendProperties
 
 from qiskit.providers.ibmq.managed.ibmqjobmanager import IBMQJobManager
 from qiskit.providers.ibmq.managed.managedresults import ManagedResults
 from qiskit.providers.ibmq.managed import managedjob
 from qiskit.providers.ibmq.managed.exceptions import (
     IBMQJobManagerJobNotFound, IBMQManagedResultDataNotAvailable, IBMQJobManagerInvalidStateError)
-from qiskit.providers.jobstatus import JobStatus
+from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.test.reference_circuits import ReferenceCircuits
-from qiskit.providers.ibmq.job.exceptions import IBMQJobFailureError
+from qiskit.providers.ibmq.job.exceptions import (IBMQJobFailureError, IBMQJobInvalidStateError,
+                                                  IBMQJobNotFoundError, IBMQJobTimeoutError)
 from qiskit.providers.ibmq.job import IBMQCompositeJob
+from qiskit.providers.ibmq.apiconstants import ApiJobStatus
 
 from ..ibmqtestcase import IBMQTestCase
 from ..decorators import requires_provider
 from ..fake_account_client import (BaseFakeAccountClient, CancelableFakeJob,
                                    JobSubmitFailClient, BaseFakeJob, FailedFakeJob,
-                                   JobTimeoutClient)
+                                   JobTimeoutClient, FixedStatusFakeJob, MissingFieldFakeJob)
 
 
 class TestIBMQCompositeJob(IBMQTestCase):
@@ -58,129 +64,228 @@ class TestIBMQCompositeJob(IBMQTestCase):
         """Initial test setup."""
         super().setUp()
         self._qc = ReferenceCircuits.bell()
-        # self._jm = IBMQJobManager()
-        self._fake_api_backend = None
-        self._fake_api_provider = None
+        self.fake_backend = copy.copy(self.sim_backend)
+        self.fake_provider = copy.copy(self.provider)
+        self._set_fake_client(BaseFakeAccountClient())
+        self.fake_backend._provider = self.fake_provider
+        self.fake_provider.backend._provider = self.fake_provider
+        self.fake_backend._configuration.max_experiments = 5
 
     def tearDown(self):
         """Tear down."""
         super().tearDown()
-        if self._fake_api_backend:
-            self._fake_api_backend._api_client.tear_down()
+        self.fake_backend._api_client.tear_down()
         # Restore provider backends since we cannot deep copy provider.
-        self.provider.backend._provider = self.provider
+        # self.provider.backend._provider = self.provider
 
-    @property
-    def fake_api_backend(self):
-        """Setup a backend instance with fake API client."""
-        if not self._fake_api_backend:
-            self._fake_api_backend = copy.copy(self.sim_backend)
-            self._fake_api_provider = copy.copy(self.provider)
-            self._fake_api_provider._api_client = self._fake_api_backend._api_client \
-                = BaseFakeAccountClient()
-            self._fake_api_backend._provider = self._fake_api_provider
-            self._fake_api_provider.backend._provider = self._fake_api_provider
-            self._fake_api_backend._configuration.max_experiments = 10
-        return self._fake_api_backend
-
-    @property
-    def fake_api_provider(self):
-        """Setup a provider instance with fake API client."""
-        if not self._fake_api_provider:
-            _ = self.fake_api_backend
-        return self._fake_api_provider
+    def _set_fake_client(self, fake_client):
+        self.fake_backend._api_client = fake_client
+        self.fake_provider._api_client = fake_client
 
     def test_split_circuits(self):
         """Test having circuits split into multiple jobs."""
-        max_circs = self.fake_api_backend.configuration().max_experiments
+        max_circs = self.fake_backend.configuration().max_experiments
 
         circs = []
         for _ in range(max_circs+2):
             circs.append(self._qc)
-        job_set = self.fake_api_backend.run(circs)
+        job_set = self.fake_backend.run(circs)
         result = job_set.result()
 
         self.assertEqual(len(job_set.sub_jobs()), 2)
         self.assertEqual(len(result.results), max_circs+2)
+        self.assertTrue(job_set.job_id().startswith(IBMQCompositeJob._id_prefix))
 
     def test_custom_split_circuits(self):
         """Test having circuits split with custom slices."""
-        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1)
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
         self.assertEqual(len(job_set.sub_jobs()), 2)
 
     def test_job_report(self):
         """Test job report."""
-        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1)
-        job_set.block_for_submit()
+        job_classes = [BaseFakeJob, FailedFakeJob, CancelableFakeJob, CancelableFakeJob,
+                       FixedStatusFakeJob]
+        job_count = len(job_classes)
+        self._set_fake_client(BaseFakeAccountClient(
+            job_class=job_classes,
+            job_kwargs={'fixed_status': ApiJobStatus.VALIDATING}))
 
-        report = job_set.report()
-        for sub_job in job_set.sub_jobs():
-            self.assertIn(sub_job.job_id(), report)
+        job_set = self.fake_backend.run([self._qc] * len(job_classes), max_circuits_per_job=1)
+        job_set.sub_jobs()[2].cancel()
+        job_set.sub_jobs()[0].wait_for_final_state()
 
-    def test_status_initializing(self):
-        pass
+        for detailed in [True, False]:
+            with self.subTest(detailed=detailed):
+                report = job_set.report(detailed=detailed)
+                self.assertIn(job_set.job_id(), report)
+                self.assertIn(f"Total jobs: {job_count}", report)
+                for stat in ['Successful', 'Failed', 'Cancelled', 'Running', 'Pending']:
+                    self.assertIn(f"{stat} jobs: 1", report)
+                if detailed:
+                    for sub_job in job_set.sub_jobs():
+                        self.assertIn(sub_job.job_id(), report)
+                    for i in range(job_count):
+                        self.assertIn(f"Circuits {i}-{i}:", report)
+                        self.assertIn(f"Job index: {i}", report)
+                    for stat in [JobStatus.DONE, JobStatus.ERROR, JobStatus.CANCELLED, JobStatus.RUNNING,
+                                 JobStatus.VALIDATING]:
+                        self.assertIn(f"Status: {stat}", report)
+                else:
+                    for sub_job in job_set.sub_jobs():
+                        self.assertNotIn(sub_job.job_id(), report)
 
-    def test_status_validating(self):
-        pass
+    def test_job_pending_status(self):
+        """Test pending and running status."""
+        sub_tests = [(ApiJobStatus.VALIDATING, JobStatus.VALIDATING, 'Pending'),
+                     (ApiJobStatus.RUNNING, JobStatus.RUNNING, 'Running'),
+                     (ApiJobStatus.QUEUED, JobStatus.QUEUED, 'Pending')]
 
-    def test_status_running(self):
-        pass
+        for api_status, job_status, report_text in sub_tests:
+            with self.subTest(status=job_status):
+                self._set_fake_client(BaseFakeAccountClient(
+                    job_class=[BaseFakeJob, FixedStatusFakeJob],
+                    job_kwargs={'fixed_status': api_status}))
 
-    def test_status_queued(self):
-        pass
-
-    def test_status_cancelled(self):
-        pass
+                job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+                stat_job = job_set.sub_jobs()[1]
+                while stat_job.status() != job_status:
+                    time.sleep(1)
+                time.sleep(0.5)  # Wait for other job to advance.
+                self.assertEqual(job_set.status(), job_status)
+                self.assertNotEqual(job_set.sub_jobs()[0].status(), job_status)
+                self.assertEqual(stat_job.status(), job_status)
+                report = job_set.report()
+                self.assertIn(f"{report_text} jobs: 1", report)
+                self.assertIsNotNone(
+                    re.search(rf"Job ID: {stat_job.job_id()}\s*Status: {job_status}", report),
+                    report)
 
     def test_status_done(self):
-        pass
-
-    def test_status_error(self):
-        pass
+        """Test job status of completed."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        job_set.wait_for_final_state()
+        self.assertEqual(job_set.status(), JobStatus.DONE)
+        for sub_job in job_set.sub_jobs():
+            self.assertEqual(sub_job.status(), JobStatus.DONE)
+        self.assertIn("Successful jobs: 2", job_set.report())
 
     def test_job_circuits(self):
-        pass
+        """Test job circuits."""
+        circs = []
+        for _ in range(3):
+            circs.append(random_circuit(num_qubits=2, depth=3, measure=True))
+        circs_copied = circs.copy()
+        job_set = self.fake_backend.run(circs, max_circuits_per_job=1)
+        job_circuits = job_set.circuits()
+        self.assertEqual(job_circuits, circs_copied)
+        for i, sub_job in enumerate(job_set.sub_jobs()):
+            self.assertEqual(sub_job.circuits()[0], circs_copied[i])
 
     def test_job_backend_options(self):
-        pass
+        """Test getting backend options."""
+        custom_options = {'shots': 100, 'memory': True}
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        **custom_options)
+        self.assertLessEqual(custom_options.items(), job_set.backend_options().items())
+        job_set.block_for_submit()
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertLessEqual(custom_options.items(), rjob_set.backend_options().items())
 
     def test_job_header(self):
-        pass
+        """Test getting job header."""
+        custom_header = {'test': 'test_job_header'}
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        header=custom_header)
+        self.assertLessEqual(custom_header.items(), job_set.header().items())
+        job_set.block_for_submit()
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertLessEqual(custom_header.items(), rjob_set.header().items())
+
+    def test_job_backend(self):
+        """Test getting job backend."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        self.assertEqual(job_set.backend().name(), self.fake_backend.name())
+        job_set.block_for_submit()
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertEqual(rjob_set.backend().name(), self.fake_backend.name())
+
+    def test_job_name(self):
+        """Test job name."""
+        custom_name = 'batman'
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        job_name=custom_name)
+        self.assertEqual(job_set.name(), custom_name)
+        job_set.block_for_submit()
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertEqual(rjob_set.name(), custom_name)
+
+    def test_job_name_update(self):
+        """Test changing the name associated with a job."""
+        new_name = 'robin'
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        job_name='batman')
+        job_set.update_name(new_name)
+        self.assertEqual(job_set.name(), new_name)
+        job_set.block_for_submit()
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertEqual(rjob_set.name(), new_name)
+
+    def test_job_properties(self):
+        """Test job properties."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        self.assertIsInstance(job_set.properties(), BackendProperties)
+
+    def test_multiple_job_properties(self):
+        """Test multiple job properties."""
+        self._set_fake_client(BaseFakeAccountClient(props_count=2))
+
+        job_set = self.fake_backend.run([self._qc] * 3, max_circuits_per_job=1)
+        props = job_set.properties()
+        self.assertIsInstance(props, list)
+        self.assertEqual(len(props), 2)
+        self.assertTrue(all(isinstance(prop, BackendProperties) for prop in props))
 
     def test_error_message_one(self):
-        """Test error message report when one job failed."""
-        self.fake_api_backend._api_client = \
-            BaseFakeAccountClient(job_class=[BaseFakeJob, FailedFakeJob])
-        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+        """Test error message when one job failed."""
+        failure_types = ['validation', 'partial', 'result']
+        for fail_type in failure_types:
+            with self.subTest(fail_type=fail_type):
+                self._set_fake_client(
+                    BaseFakeAccountClient(job_class=[BaseFakeJob, FailedFakeJob],
+                                          job_kwargs={'failure_type': fail_type}))
 
-        job_set = self.fake_api_backend.run([self._qc]*4, max_circuits_per_job=2)
-        error_report = job_set.error_message()
-        self.assertIsNotNone(error_report)
-        self.assertEqual(job_set.status(), JobStatus.ERROR)
-        bad_job = job_set.sub_jobs()[1]
-        self.assertIsNotNone(
-            re.search(f"Circuits 2-3: Job {bad_job.job_id()} failed: " +
-                      r".+ Error code: \d{4}", error_report), f"Error report: {error_report}")
+                job_set = self.fake_backend.run([self._qc] * 4, max_circuits_per_job=2)
+                error_msg = job_set.error_message()
+                self.assertIsNotNone(error_msg)
+                self.assertEqual(job_set.status(), JobStatus.ERROR)
+                self.assertNotEqual(job_set.sub_jobs()[0].status, JobStatus.ERROR)
+                bad_job = job_set.sub_jobs()[1]
+                self.assertIsNotNone(
+                    re.search(f"Circuits 2-3: Job {bad_job.job_id()} failed: ", error_msg),
+                    f"Error msg: {error_msg}")
+                if fail_type == 'partial':
+                    self.assertIn('Experiment 1:', error_msg)
+                else:
+                    self.assertIsNotNone(re.search(r"Error code: \d{4}", error_msg),
+                                         f"Error msg: {error_msg}")
 
     def test_error_message_all(self):
         """Test error message report when all jobs failed."""
-        self.fake_api_backend._api_client = \
-            BaseFakeAccountClient(job_class=FailedFakeJob)
-        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+        self._set_fake_client(BaseFakeAccountClient(job_class=FailedFakeJob))
 
-        job_set = self.fake_api_backend.run([self._qc]*4, max_circuits_per_job=2)
-        error_report = job_set.error_message()
-        self.assertIsNotNone(error_report)
+        job_set = self.fake_backend.run([self._qc] * 4, max_circuits_per_job=2)
+        error_msg = job_set.error_message()
+        self.assertIsNotNone(error_msg)
         for idx, job in enumerate(job_set.sub_jobs()):
             self.assertIsNotNone(
                 re.search(f"Circuits {idx*2}-{idx*2+1}: Job {job.job_id()} failed: " +
-                          r".+ Error code: \d{4}", error_report), f"Error report: {error_report}")
+                          r".+ Error code: \d{4}", error_msg), f"Error msg: {error_msg}")
 
     def test_async_submit_exception(self):
         """Test asynchronous job submit failed."""
-        self.fake_api_backend._api_client = JobSubmitFailClient(max_fail_count=1)
+        self.fake_backend._api_client = JobSubmitFailClient(failed_indexes=1)
 
-        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1)
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
         job_set.wait_for_final_state()
         self.assertEqual(job_set.status(), JobStatus.ERROR)
         with self.assertRaises(IBMQJobFailureError):
@@ -192,226 +297,369 @@ class TestIBMQCompositeJob(IBMQTestCase):
         self.assertIn("Error submitting job", report)
         self.assertIn("Status: JobStatus.DONE", report)
 
+        result = job_set.result(partial=True)
+        self.assertFalse(result.success)
+        self.assertFalse(result.results[0].success)
+        self.assertFalse(result.results[0].data.to_dict())
+
     def test_share_job_in_project(self):
         """Test sharing managed jobs within a project."""
-        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1,
-                                            job_share_level="project")
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        job_share_level="project")
         for job in job_set.sub_jobs():
             self.assertEqual(job.share_level(), 'project')
 
     def test_job_limit(self):
         """Test reaching job limit."""
-        job_limit = 5
-        self.fake_api_backend._api_client = BaseFakeAccountClient(
-            job_limit=job_limit, job_class=CancelableFakeJob)
-        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+        job_limit = 3
+        self._set_fake_client(BaseFakeAccountClient(
+            job_limit=job_limit, job_class=CancelableFakeJob))
 
         job_set = None
         try:
-            with self.assertLogs(managedjob.logger, 'WARNING'):
-                job_set = self._jm.run([self._qc]*(job_limit+2),
-                                       backend=self.fake_api_backend, max_experiments_per_job=1)
-                time.sleep(1)
+            job_set = self.fake_backend.run(
+                [self._qc]*(job_limit+2), max_circuits_per_job=1)
 
-            # There should be 5 done and 2 running futures.
-            running_futures = [mjob.future for mjob in job_set.managed_jobs()
-                               if mjob.future.running()]
-            max_wait = 6
-            while len(running_futures) > 2 and max_wait > 0:
-                running_futures = [f for f in running_futures if f.running()]
+            # Wait for first 5 jobs to be submitted.
+            max_loop = 5
+            while len(job_set.sub_jobs(block_for_submit=False)) < job_limit and max_loop:
                 time.sleep(0.5)
-            self.assertEqual(len(running_futures), 2)
+                max_loop -= 1
+            self.assertGreater(max_loop, 0)
+            self.assertEqual(job_set.status(), JobStatus.INITIALIZING)
+            report = job_set.report()
+            self.assertIsNotNone(
+                re.search(r"index: 3\s+Status: Job not yet submitted.*"
+                          r"index: 4\s+Status: Job not yet submitted", report, re.DOTALL), report)
 
-            for mjob in job_set.managed_jobs():
-                if mjob.job is not None:
-                    mjob.cancel()
-            self.assertEqual(len(job_set.jobs()), job_limit+2)
-            self.assertTrue(all(job_set.jobs()))
+            for job in job_set.sub_jobs(block_for_submit=False):
+                job.cancel()
+            time.sleep(0.5)
+            self.assertNotIn('Job not yet submitted', job_set.report())
         finally:
-            # Cancel all submitted jobs first.
-            for mjob in job_set.managed_jobs():
-                if mjob.job is not None:
-                    mjob.cancel()
-                elif job_set._job_submit_lock.locked():
-                    job_set._job_submit_lock.release()
-            wait([mjob.future for mjob in job_set.managed_jobs()], timeout=5)
+            job_set.cancel()
 
     def test_job_limit_timeout(self):
-        """Test reaching job limit."""
-        job_limit = 5
-        self.fake_api_backend._api_client = JobTimeoutClient(
-            job_limit=job_limit, max_fail_count=1)
-        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+        """Test timing out while waiting for old job to finish."""
+        job_limit = 3
+        self._set_fake_client(JobTimeoutClient(job_limit=job_limit, max_fail_count=1))
 
         job_set = None
         try:
-            job_set = self._jm.run([self._qc]*(job_limit+2),
-                                   backend=self.fake_api_backend, max_experiments_per_job=1)
-            last_mjobs = job_set._managed_jobs[-2:]
-            for _ in range(10):
-                if all(mjob.job for mjob in last_mjobs):
-                    break
-            self.assertTrue(all(job.job_id() for job in job_set.jobs()))
+            job_set = self.fake_backend.run(
+                [self._qc]*(job_limit+2), max_circuits_per_job=1)
+            self.assertEqual(job_set.status(), JobStatus.INITIALIZING)
+            job_set.wait_for_final_state(timeout=60)
         finally:
-            # Cancel all jobs.
-            for mjob in job_set.managed_jobs():
-                if mjob.job is not None:
-                    mjob.cancel()
-                elif job_set._job_submit_lock.locked():
-                    job_set._job_submit_lock.release()
-            wait([mjob.future for mjob in job_set.managed_jobs()], timeout=5)
+            job_set.cancel()
 
     def test_job_tags_replace(self):
-        """Test updating job tags by replacing the job set's existing tags."""
+        """Test updating job tags by replacing existing tags."""
         initial_job_tags = [uuid.uuid4().hex]
-        job_set = self._jm.run([self._qc]*2, backend=self.fake_api_backend,
-                               max_experiments_per_job=1, job_tags=initial_job_tags)
-
-        # Wait for jobs to be submitted.
-        while JobStatus.INITIALIZING in job_set.statuses():
-            time.sleep(1)
-
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        job_tags=initial_job_tags)
+        job_set.block_for_submit()
         tag_prefix = uuid.uuid4().hex
         replacement_tags = ['{}_new_tag_{}'.format(tag_prefix, i) for i in range(2)]
-        _ = job_set.update_tags(replacement_tags=replacement_tags)
-
-        for job in job_set.jobs():
+        job_set.update_tags(replacement_tags=replacement_tags)
+        for job in job_set.sub_jobs():
             job.refresh()
-            self.assertEqual(set(job.tags()), set(replacement_tags + [job_set._id_long]))
-
-    def test_job_tags_remove(self):
-        """Test updating job tags by removing the job set's existing tags."""
-        initial_job_tags = [uuid.uuid4().hex]
-        job_set = self._jm.run([self._qc] * 2, backend=self.fake_api_backend,
-                               max_experiments_per_job=1, job_tags=initial_job_tags)
-
-        # Wait for jobs to be submitted.
-        while JobStatus.INITIALIZING in job_set.statuses():
-            time.sleep(1)
-
-        initial_job_tags_with_id_long = initial_job_tags + [job_set._id_long]
-
-        # Update the job tags
-        _ = job_set.update_tags(removal_tags=initial_job_tags_with_id_long)
-
-        for job in job_set.jobs():
-            job.refresh()
-            self.assertEqual(job.tags(), [job_set._id_long])
-
-    def test_index_by_number(self):
-        """Test indexing results by number."""
-        max_per_job = 5
-        job_set = self._jm.run([self._qc]*max_per_job*2, backend=self.fake_api_backend,
-                               max_experiments_per_job=max_per_job)
-        result_manager = job_set.results()
-        jobs = job_set.jobs()
-
-        for i in [0, max_per_job-1, max_per_job+1]:
-            with self.subTest(i=i):
-                job_index = int(i / max_per_job)
-                exp_index = i % max_per_job
-                self.assertEqual(result_manager.get_counts(i),
-                                 jobs[job_index].result().get_counts(exp_index))
-
-    def test_index_by_name(self):
-        """Test indexing results by name."""
-        max_per_job = 5
-        circs = []
-        for i in range(max_per_job*2+1):
-            new_qc = copy.deepcopy(self._qc)
-            new_qc.name = "test_qc_{}".format(i)
-            circs.append(new_qc)
-        job_set = self._jm.run(circs, backend=self.fake_api_backend,
-                               max_experiments_per_job=max_per_job)
-        result_manager = job_set.results()
-        jobs = job_set.jobs()
-
-        for i in [1, max_per_job, len(circs)-1]:
-            with self.subTest(i=i):
-                job_index = int(i / max_per_job)
-                exp_index = i % max_per_job
-                self.assertEqual(result_manager.get_counts(circs[i].name),
-                                 jobs[job_index].result().get_counts(exp_index))
-
-    def test_index_out_of_range(self):
-        """Test result index out of range."""
-        job_set = self._jm.run([self._qc], backend=self.fake_api_backend)
-        result_manager = job_set.results()
-        with self.assertRaises(IBMQJobManagerJobNotFound):
-            result_manager.get_counts(1)
+            job_set_tags = \
+                {tag for tag in job.tags() if tag.startswith(IBMQCompositeJob._tag_prefix)}
+            self.assertEqual(set(job.tags())-job_set_tags, set(replacement_tags), job.tags())
+            self.assertIn(job_set.job_id(), job_set_tags, job.tags())
+            self.assertEqual(len(job_set_tags), 2, job.tags())
 
     def test_skipped_result(self):
-        """Test one of jobs has no result."""
-        self.fake_api_backend._api_client = BaseFakeAccountClient(
+        """Test one of the jobs has no result."""
+        sub_tests = [CancelableFakeJob, FailedFakeJob]
+        for job_class in sub_tests:
+            with self.subTest(job_class=job_class):
+                self.fake_backend._api_client = BaseFakeAccountClient(
+                    job_class=[BaseFakeJob, job_class])
+
+                job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+                job_set.block_for_submit()
+                if job_class == CancelableFakeJob:
+                    job_set.sub_jobs()[1].cancel()
+                result = job_set.result(partial=True)
+                self.assertEqual(len(result.results), 2)
+                self.assertFalse(result.success)
+                self.assertTrue(result.results[0].success)
+                self.assertFalse(result.results[1].success)
+                self.assertTrue(result.get_counts(0))
+                with self.assertRaises(QiskitError):
+                    result.get_counts(1)
+
+    def test_partial_result(self):
+        """Test one of the circuits has no result."""
+        self.fake_backend._api_client = BaseFakeAccountClient(
+            job_class=[BaseFakeJob, FailedFakeJob], job_kwargs={'failure_type': 'partial'})
+        job_set = self.fake_backend.run([self._qc] * 4, max_circuits_per_job=2)
+        job_set.block_for_submit()
+        result = job_set.result(partial=True)
+        self.assertEqual(len(result.results), 4)
+        self.assertFalse(result.success)
+        self.assertTrue(all(res.success for res in result.results[:3]))
+        self.assertFalse(result.results[3].success)
+        with self.assertRaises(QiskitError):
+            result.get_counts(3)
+
+    def test_job_result(self):
+        """Test job result."""
+        max_per_job = 3
+        job_set = self.fake_backend.run([self._qc] * max_per_job * 2,
+                                        max_circuits_per_job=max_per_job)
+        result = job_set.result()
+        self.assertTrue(result.success)
+        for i in range(max_per_job*2):
+            self.assertEqual(
+                result.get_counts(i),
+                job_set.sub_jobs()[int(i/max_per_job)].result().get_counts(i % max_per_job))
+            self.assertTrue(result.results[i].success)
+
+    def test_cancel(self):
+        """Test job cancellation."""
+        self.fake_backend._api_client = BaseFakeAccountClient(
             job_class=[BaseFakeJob, CancelableFakeJob])
 
-        job_set = self._jm.run([self._qc]*2, backend=self.fake_api_backend,
-                               max_experiments_per_job=1)
-        jobs = job_set.jobs()
-        jobs[1].cancel()
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        job_set.block_for_submit()
+        job_set.cancel()
+        self.assertEqual(job_set.status(), JobStatus.CANCELLED)
+        with self.assertRaises(IBMQJobInvalidStateError):
+            job_set.result(partial=False)
 
-        result_manager = job_set.results()
-        with self.assertRaises(IBMQManagedResultDataNotAvailable):
-            result_manager.get_counts(1)
+    def test_refresh(self):
+        """Test refreshing job data."""
+        pass
 
-    def test_combine_results(self):
-        """Test converting ManagedResult to Result."""
-        max_per_job = 5
-        job_set = self._jm.run([self._qc]*max_per_job*2, backend=self.fake_api_backend,
-                               max_experiments_per_job=max_per_job)
-        result_manager = job_set.results()
-        combined_result = result_manager.combine_results()
+    def test_creation_date(self):
+        """Test retrieving creation date."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        creation_date = job_set.creation_date()
+        self.assertTrue(creation_date)
+        self.assertIsNotNone(creation_date.tzinfo)
+        self.assertEqual(creation_date, job_set.sub_jobs()[0].creation_date())
 
-        for i in range(max_per_job*2):
-            self.assertEqual(result_manager.get_counts(i), combined_result.get_counts(i))
+    def test_time_per_step_done(self):
+        """Test retrieving time per step when job is done."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        job_set.wait_for_final_state()
+        time_per_step = job_set.time_per_step()
+        self.assertTrue(time_per_step)
+        self.assertIn('COMPLETED', time_per_step)
+        self.assertEqual(time_per_step['CREATING'], job_set.creation_date())
+        status_samples = ['CREATING', 'QUEUED', 'RUNNING', 'COMPLETED']
+        for i in range(0, len(status_samples)-1):
+            self.assertLessEqual(time_per_step[status_samples[i]],
+                                 time_per_step[status_samples[i+1]])
 
-    def test_ibmq_managed_results_signature(self):
-        """Test ``ManagedResults`` and ``Result`` contain the same public methods.
+    def test_time_per_step_running(self):
+        """Test retrieving time per step when job is running."""
+        self._set_fake_client(
+            BaseFakeAccountClient(job_class=[BaseFakeJob, FixedStatusFakeJob],
+                                  job_kwargs={'fixed_status': ApiJobStatus.RUNNING}))
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        while job_set.status() != JobStatus.RUNNING:
+            time.sleep(1)
+        job_set.sub_jobs()[0].wait_for_final_state()
+        time_per_step = job_set.time_per_step()
+        self.assertTrue(time_per_step)
+        self.assertIn('RUNNING', time_per_step)
+        self.assertNotIn('COMPLETED', time_per_step)
+        self.assertEqual(time_per_step['CREATING'], job_set.creation_date())
+        status_samples = ['CREATING', 'QUEUED', 'RUNNING']
+        for i in range(0, len(status_samples)-1):
+            self.assertLessEqual(time_per_step[status_samples[i]],
+                                 time_per_step[status_samples[i+1]])
 
-        Note:
-            Aside from ensuring the two classes contain the same public
-            methods, it is also necessary to check that the corresponding
-            methods have the same signature.
-        """
-        result_methods = self._get_class_methods(Result)
-        self.assertTrue(result_methods)
+    def test_time_per_step_error(self):
+        """Test retrieving time per step when job failed."""
+        self._set_fake_client(BaseFakeAccountClient(job_class=[BaseFakeJob, FailedFakeJob]))
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        job_set.wait_for_final_state()
+        self.assertEqual(job_set.status(), JobStatus.ERROR)
+        time_per_step = job_set.time_per_step()
+        self.assertTrue(time_per_step)
+        self.assertIn('ERROR_VALIDATING_JOB', time_per_step)
+        self.assertNotIn('COMPLETED', time_per_step)
+        self.assertEqual(time_per_step['CREATING'], job_set.creation_date())
+        status_samples = ['CREATING', 'VALIDATING', 'ERROR_VALIDATING_JOB']
+        for i in range(0, len(status_samples)-1):
+            self.assertLessEqual(time_per_step[status_samples[i]],
+                                 time_per_step[status_samples[i+1]])
 
-        managed_results_methods = self._get_class_methods(ManagedResults)
-        self.assertTrue(managed_results_methods)
-        del managed_results_methods['combine_results']
-        for ignore_meth in ['to_dict', 'from_dict']:
-            result_methods.pop(ignore_meth, None)
+    def test_queue_info(self):
+        """Test retrieving queue information."""
+        ts1 = datetime.now() + timedelta(minutes=5)
+        ts2 = datetime.now() + timedelta(minutes=10)
+        sub_tests = [  # Queue positions and expected position/completion time.
+            ([2, 5], (5, ts2)),
+            ([2, None], None),
+            ([None, 5], None),
+            ([None, None], None)]
 
-        # Ensure both classes share the *exact* same public methods.
-        self.assertEqual(result_methods.keys(), managed_results_methods.keys())
+        for positions, expected in sub_tests:
+            with self.subTest(positions=positions):
+                self._set_fake_client(BaseFakeAccountClient(
+                    job_class=FixedStatusFakeJob, job_kwargs={'fixed_status': ApiJobStatus.QUEUED},
+                    queue_positions=positions, est_completion=[ts1, ts2]))
+                job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+                while job_set.status() != JobStatus.QUEUED:
+                    time.sleep(1)
+                queue_info = job_set.queue_info()
+                if expected is not None:
+                    self.assertIsNotNone(queue_info)
+                    self.assertEqual(queue_info.position, expected[0])
+                    ts_local = expected[1].replace(tzinfo=timezone.utc)
+                    ts_local = ts_local.astimezone(tz.tzlocal())
+                    self.assertEqual(queue_info.estimated_complete_time, ts_local)
+                else:
+                    self.assertIsNone(queue_info)
 
-        # Ensure the signature for the public methods from both classes are compatible.
-        for name, method in managed_results_methods.items():
-            managed_results_params = getattr(getfullargspec(method), 'args', [])
-            result_params = getattr(getfullargspec(result_methods[name]), 'args', [])
-            self.assertTrue(managed_results_params)
-            self.assertTrue(result_params)
-            # pylint: disable=duplicate-string-formatting-argument
-            self.assertEqual(result_params, managed_results_params,
-                             "The signatures for method `{}` differ. "
-                             "`Result.{}` params = {} "
-                             "`ManagedResults.{}` params = {}."
-                             .format(name, name, managed_results_params,
-                                     name, result_params))
+    def test_scheduling_mode(self):
+        """Test job scheduling mode."""
+        sub_tests = [('fairshare', 'fairshare'),
+                     ('dedicated', 'dedicated'),
+                     ('dedicated_once', 'fairshare')]
+        for mode, expected in sub_tests:
+            with self.subTest(mode=mode):
+                self._set_fake_client(BaseFakeAccountClient(run_mode=mode))
+                job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+                while job_set.status() not in [JobStatus.RUNNING, JobStatus.DONE]:
+                    time.sleep(1)
+                self.assertEqual(job_set.scheduling_mode(), expected)
 
-    def _get_class_methods(self, cls):
-        """Get public class methods from its namespace.
+    def test_client_version(self):
+        """Test job client version information."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        job_set.block_for_submit()
+        client_version = job_set.client_version
+        self.assertTrue(client_version)
+        self.assertEqual(client_version, job_set.sub_jobs()[0].client_version)
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertEqual(rjob_set.client_version, client_version)
 
-        Note:
-            Since the methods are found using the class itself and not
-            and instance, the "methods" are categorized as functions.
-            Methods are only bound when they belong to an actual instance.
-        """
-        cls_methods = {}
-        for name, method in cls.__dict__.items():
-            if isfunction(method) and not name.startswith('_'):
-                cls_methods[name] = method
-        return cls_methods
+    def test_experiment_id(self):
+        """Test job experiment id."""
+        experiment_id = 12345
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1,
+                                        experiment_id=experiment_id)
+        job_set.block_for_submit()
+        self.assertTrue(job_set.experiment_id)
+        self.assertEqual(job_set.experiment_id, experiment_id)
+        rjob_set = self.fake_backend.retrieve_job(job_set.job_id())
+        self.assertEqual(rjob_set.experiment_id, experiment_id)
+
+    def test_retrieve_job_error(self):
+        """Test retrieving an invalid job."""
+        with self.assertRaises(IBMQJobNotFoundError):
+            self.fake_backend.retrieve_job(IBMQCompositeJob._id_prefix + '1234')
+
+    def test_missing_required_fields(self):
+        """Test response data is missing required fields."""
+        self._set_fake_client(BaseFakeAccountClient(job_class=[BaseFakeJob, MissingFieldFakeJob]))
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        job_set.wait_for_final_state()
+        self.assertEqual(job_set.status(), JobStatus.ERROR)
+        self.assertIn("Unexpected return value received", job_set.error_message())
+
+    def test_refresh_job_result(self):
+        """Test re-retrieving job result via refresh."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        result = job_set.result()
+
+        self.assertTrue(result)
+        cached_result = copy.deepcopy(result.to_dict())
+        result.results[0].header.name = 'modified_result'
+        self.assertNotEqual(cached_result, result.to_dict())
+
+        # Re-retrieve result via refresh.
+        result = job_set.result(refresh=True)
+        self.assertDictEqual(cached_result, result.to_dict())
+        self.assertNotEqual(result.results[0].header.name, 'modified_result')
+
+    def test_wait_for_final_state(self):
+        """Test waiting for job to reach final state."""
+
+        def final_state_callback(c_job_id, c_status, c_job, **kwargs):
+            """Job status query callback function."""
+            self.assertEqual(c_job_id, job_set.job_id())
+            self.assertNotIn(c_status, JOB_FINAL_STATES)
+            self.assertEqual(c_job.job_id(), job_set.job_id())
+            self.assertIn('queue_info', kwargs)
+
+            queue_info = kwargs.pop('queue_info', None)
+            callback_info['called'] = True
+
+            if wait_time is None:
+                # Look for status change.
+                data = {'status': c_status, 'queue_info': queue_info}
+                self.assertNotEqual(data, callback_info['last data'])
+                callback_info['last data'] = data
+            else:
+                # Check called within wait time.
+                if callback_info['last call time'] and job_set._status not in JOB_FINAL_STATES:
+                    self.assertAlmostEqual(
+                        time.time() - callback_info['last call time'], wait_time, delta=0.2)
+                callback_info['last call time'] = time.time()
+
+        wait_args = [2, None]
+        self._set_fake_client(BaseFakeAccountClient(job_kwargs={'progress_time': 1}))
+
+        for wait_time in wait_args:
+            with self.subTest(wait_time=wait_time):
+                # Put callback data in a dictionary to make it mutable.
+                callback_info = {'called': False, 'last call time': 0.0, 'last data': {}}
+                job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+                job_set.wait_for_final_state(timeout=10, wait=wait_time,
+                                             callback=final_state_callback)
+                self.assertEqual(job_set.status(), JobStatus.DONE)
+                self.assertTrue(callback_info['called'])
+
+    def test_wait_for_final_state_timeout(self):
+        """Test waiting for job to reach final state times out."""
+        job_set = self.fake_backend.run([self._qc] * 2, max_circuits_per_job=1)
+        with self.assertRaises(IBMQJobTimeoutError):
+            job_set.wait_for_final_state(timeout=0.1)
+
+    def test_retry_failed_submit(self):
+        """Test retrying failed job submit."""
+        max_circs = self.fake_backend.configuration().max_experiments
+        circs = []
+        count = 3
+        for i in range(max_circs*(count-1)+1):
+            circs.append(random_circuit(num_qubits=2, depth=3, measure=True))
+        sub_tests = [[0], [1, 2], [0, 2]]
+
+        for failed_index in sub_tests:
+            with self.subTest(failed_index=failed_index):
+                self._set_fake_client(JobSubmitFailClient(failed_indexes=failed_index))
+                job_set = self.fake_backend.run(circs)
+                job_set.wait_for_final_state()
+                self.assertEqual(job_set.status(), JobStatus.ERROR)
+                good_indexes = set(range(count)) - set(failed_index)
+                self.assertEqual(len(job_set.sub_jobs()), len(good_indexes))
+                good_ids = {job.job_id() for job in job_set.sub_jobs()}
+
+                job_set.rerun_failed()
+                job_set.wait_for_final_state()
+                self.assertEqual(job_set.status(), JobStatus.DONE)
+                self.assertEqual(len(job_set.sub_jobs()), count)
+                self.assertTrue(good_ids.issubset({job.job_id() for job in job_set.sub_jobs()}))
+                circ_idx = 0
+                for sub_job in job_set.sub_jobs():
+                    for job_circ in sub_job.circuits():
+                        self.assertEqual(job_circ, circs[circ_idx])
+                        circ_idx += 1
+                self.assertEqual(job_set.circuits(), circs)
+
+    def test_retry_failed_jobs(self):
+        """Test retrying failed jobs."""
+
+    def test_sub_job(self):
+        pass
 
 
 class TestIBMQCompositeJobIntegration(IBMQTestCase):
@@ -434,8 +682,11 @@ class TestIBMQCompositeJobIntegration(IBMQTestCase):
         circs_counts = [3, 4]
         for count in circs_counts:
             with self.subTest(count=count):
-                job_set = self.sim_backend.run([self._qc]*count, max_circuits_per_job=2,
-                                               job_tags=tags)
+                circs = []
+                for i in range(count):
+                    circs.append(random_circuit(num_qubits=2, depth=3, measure=True))
+                circs = transpile(circs, backend=self.sim_backend)
+                job_set = self.sim_backend.run(circs, max_circuits_per_job=2, job_tags=tags)
                 job_set.block_for_submit()
                 self.assertEqual(job_set.tags(), tags)
 
@@ -447,6 +698,12 @@ class TestIBMQCompositeJobIntegration(IBMQTestCase):
                                  {sub.job_id() for sub in job_set.sub_jobs()})
                 self.assertEqual(rjob_set.tags(), job_set.tags())
                 self.assertEqual(job_set.result().to_dict(), rjob_set.result().to_dict())
+                job_circuits = job_set.circuits()
+                rjob_circuits = rjob_set.circuits()
+                self.assertEqual(len(job_circuits), count)
+                self.assertEqual(len(job_circuits), len(rjob_circuits))
+                for i in range(len(job_circuits)):
+                    self.assertEqual(job_circuits[i], rjob_circuits[i])
 
     def test_jobs(self):
         """Test retrieving a composite job using jobs."""
@@ -466,3 +723,10 @@ class TestIBMQCompositeJobIntegration(IBMQTestCase):
                                  {sub.job_id() for sub in job_set.sub_jobs()})
             else:
                 self.assertEqual(job.job_id(), circ_job.job_id())
+
+    def test_retrieve_job_missing_subjobs(self):
+        pass
+
+    def test_partial_result(self):
+        # with simulator
+        pass

--- a/test/ibmq/test_composite_job.py
+++ b/test/ibmq/test_composite_job.py
@@ -1,0 +1,468 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the IBMQCompositeJob."""
+
+import re
+import copy
+import time
+from inspect import getfullargspec, isfunction
+import uuid
+from concurrent.futures import wait
+from datetime import datetime, timedelta
+
+from qiskit import QuantumCircuit
+from qiskit import transpile
+from qiskit.result import Result
+
+from qiskit.providers.ibmq.managed.ibmqjobmanager import IBMQJobManager
+from qiskit.providers.ibmq.managed.managedresults import ManagedResults
+from qiskit.providers.ibmq.managed import managedjob
+from qiskit.providers.ibmq.managed.exceptions import (
+    IBMQJobManagerJobNotFound, IBMQManagedResultDataNotAvailable, IBMQJobManagerInvalidStateError)
+from qiskit.providers.jobstatus import JobStatus
+from qiskit.test.reference_circuits import ReferenceCircuits
+from qiskit.providers.ibmq.job.exceptions import IBMQJobFailureError
+from qiskit.providers.ibmq.job import IBMQCompositeJob
+
+from ..ibmqtestcase import IBMQTestCase
+from ..decorators import requires_provider
+from ..fake_account_client import (BaseFakeAccountClient, CancelableFakeJob,
+                                   JobSubmitFailClient, BaseFakeJob, FailedFakeJob,
+                                   JobTimeoutClient)
+
+
+class TestIBMQCompositeJob(IBMQTestCase):
+    """Tests for IBMQCompositeJob."""
+
+    @classmethod
+    @requires_provider
+    def setUpClass(cls, provider):
+        """Initial class level setup."""
+        # pylint: disable=arguments-differ
+        super().setUpClass()
+        cls.provider = provider
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.last_week = datetime.now() - timedelta(days=7)
+
+    def setUp(self):
+        """Initial test setup."""
+        super().setUp()
+        self._qc = ReferenceCircuits.bell()
+        # self._jm = IBMQJobManager()
+        self._fake_api_backend = None
+        self._fake_api_provider = None
+
+    def tearDown(self):
+        """Tear down."""
+        super().tearDown()
+        if self._fake_api_backend:
+            self._fake_api_backend._api_client.tear_down()
+        # Restore provider backends since we cannot deep copy provider.
+        self.provider.backend._provider = self.provider
+
+    @property
+    def fake_api_backend(self):
+        """Setup a backend instance with fake API client."""
+        if not self._fake_api_backend:
+            self._fake_api_backend = copy.copy(self.sim_backend)
+            self._fake_api_provider = copy.copy(self.provider)
+            self._fake_api_provider._api_client = self._fake_api_backend._api_client \
+                = BaseFakeAccountClient()
+            self._fake_api_backend._provider = self._fake_api_provider
+            self._fake_api_provider.backend._provider = self._fake_api_provider
+            self._fake_api_backend._configuration.max_experiments = 10
+        return self._fake_api_backend
+
+    @property
+    def fake_api_provider(self):
+        """Setup a provider instance with fake API client."""
+        if not self._fake_api_provider:
+            _ = self.fake_api_backend
+        return self._fake_api_provider
+
+    def test_split_circuits(self):
+        """Test having circuits split into multiple jobs."""
+        max_circs = self.fake_api_backend.configuration().max_experiments
+
+        circs = []
+        for _ in range(max_circs+2):
+            circs.append(self._qc)
+        job_set = self.fake_api_backend.run(circs)
+        result = job_set.result()
+
+        self.assertEqual(len(job_set.sub_jobs()), 2)
+        self.assertEqual(len(result.results), max_circs+2)
+
+    def test_custom_split_circuits(self):
+        """Test having circuits split with custom slices."""
+        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1)
+        self.assertEqual(len(job_set.sub_jobs()), 2)
+
+    def test_job_report(self):
+        """Test job report."""
+        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1)
+        job_set.block_for_submit()
+
+        report = job_set.report()
+        for sub_job in job_set.sub_jobs():
+            self.assertIn(sub_job.job_id(), report)
+
+    def test_status_initializing(self):
+        pass
+
+    def test_status_validating(self):
+        pass
+
+    def test_status_running(self):
+        pass
+
+    def test_status_queued(self):
+        pass
+
+    def test_status_cancelled(self):
+        pass
+
+    def test_status_done(self):
+        pass
+
+    def test_status_error(self):
+        pass
+
+    def test_job_circuits(self):
+        pass
+
+    def test_job_backend_options(self):
+        pass
+
+    def test_job_header(self):
+        pass
+
+    def test_error_message_one(self):
+        """Test error message report when one job failed."""
+        self.fake_api_backend._api_client = \
+            BaseFakeAccountClient(job_class=[BaseFakeJob, FailedFakeJob])
+        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+
+        job_set = self.fake_api_backend.run([self._qc]*4, max_circuits_per_job=2)
+        error_report = job_set.error_message()
+        self.assertIsNotNone(error_report)
+        self.assertEqual(job_set.status(), JobStatus.ERROR)
+        bad_job = job_set.sub_jobs()[1]
+        self.assertIsNotNone(
+            re.search(f"Circuits 2-3: Job {bad_job.job_id()} failed: " +
+                      r".+ Error code: \d{4}", error_report), f"Error report: {error_report}")
+
+    def test_error_message_all(self):
+        """Test error message report when all jobs failed."""
+        self.fake_api_backend._api_client = \
+            BaseFakeAccountClient(job_class=FailedFakeJob)
+        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+
+        job_set = self.fake_api_backend.run([self._qc]*4, max_circuits_per_job=2)
+        error_report = job_set.error_message()
+        self.assertIsNotNone(error_report)
+        for idx, job in enumerate(job_set.sub_jobs()):
+            self.assertIsNotNone(
+                re.search(f"Circuits {idx*2}-{idx*2+1}: Job {job.job_id()} failed: " +
+                          r".+ Error code: \d{4}", error_report), f"Error report: {error_report}")
+
+    def test_async_submit_exception(self):
+        """Test asynchronous job submit failed."""
+        self.fake_api_backend._api_client = JobSubmitFailClient(max_fail_count=1)
+
+        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1)
+        job_set.wait_for_final_state()
+        self.assertEqual(job_set.status(), JobStatus.ERROR)
+        with self.assertRaises(IBMQJobFailureError):
+            job_set.result()
+        self.assertIn("Circuits 0-0: Job submit failed", job_set.error_message())
+        report = job_set.report()
+        self.assertIn("Failed jobs: 1", report)
+        self.assertIn("Successful jobs: 1", report)
+        self.assertIn("Error submitting job", report)
+        self.assertIn("Status: JobStatus.DONE", report)
+
+    def test_share_job_in_project(self):
+        """Test sharing managed jobs within a project."""
+        job_set = self.fake_api_backend.run([self._qc]*2, max_circuits_per_job=1,
+                                            job_share_level="project")
+        for job in job_set.sub_jobs():
+            self.assertEqual(job.share_level(), 'project')
+
+    def test_job_limit(self):
+        """Test reaching job limit."""
+        job_limit = 5
+        self.fake_api_backend._api_client = BaseFakeAccountClient(
+            job_limit=job_limit, job_class=CancelableFakeJob)
+        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+
+        job_set = None
+        try:
+            with self.assertLogs(managedjob.logger, 'WARNING'):
+                job_set = self._jm.run([self._qc]*(job_limit+2),
+                                       backend=self.fake_api_backend, max_experiments_per_job=1)
+                time.sleep(1)
+
+            # There should be 5 done and 2 running futures.
+            running_futures = [mjob.future for mjob in job_set.managed_jobs()
+                               if mjob.future.running()]
+            max_wait = 6
+            while len(running_futures) > 2 and max_wait > 0:
+                running_futures = [f for f in running_futures if f.running()]
+                time.sleep(0.5)
+            self.assertEqual(len(running_futures), 2)
+
+            for mjob in job_set.managed_jobs():
+                if mjob.job is not None:
+                    mjob.cancel()
+            self.assertEqual(len(job_set.jobs()), job_limit+2)
+            self.assertTrue(all(job_set.jobs()))
+        finally:
+            # Cancel all submitted jobs first.
+            for mjob in job_set.managed_jobs():
+                if mjob.job is not None:
+                    mjob.cancel()
+                elif job_set._job_submit_lock.locked():
+                    job_set._job_submit_lock.release()
+            wait([mjob.future for mjob in job_set.managed_jobs()], timeout=5)
+
+    def test_job_limit_timeout(self):
+        """Test reaching job limit."""
+        job_limit = 5
+        self.fake_api_backend._api_client = JobTimeoutClient(
+            job_limit=job_limit, max_fail_count=1)
+        self.fake_api_provider._api_client = self.fake_api_backend._api_client
+
+        job_set = None
+        try:
+            job_set = self._jm.run([self._qc]*(job_limit+2),
+                                   backend=self.fake_api_backend, max_experiments_per_job=1)
+            last_mjobs = job_set._managed_jobs[-2:]
+            for _ in range(10):
+                if all(mjob.job for mjob in last_mjobs):
+                    break
+            self.assertTrue(all(job.job_id() for job in job_set.jobs()))
+        finally:
+            # Cancel all jobs.
+            for mjob in job_set.managed_jobs():
+                if mjob.job is not None:
+                    mjob.cancel()
+                elif job_set._job_submit_lock.locked():
+                    job_set._job_submit_lock.release()
+            wait([mjob.future for mjob in job_set.managed_jobs()], timeout=5)
+
+    def test_job_tags_replace(self):
+        """Test updating job tags by replacing the job set's existing tags."""
+        initial_job_tags = [uuid.uuid4().hex]
+        job_set = self._jm.run([self._qc]*2, backend=self.fake_api_backend,
+                               max_experiments_per_job=1, job_tags=initial_job_tags)
+
+        # Wait for jobs to be submitted.
+        while JobStatus.INITIALIZING in job_set.statuses():
+            time.sleep(1)
+
+        tag_prefix = uuid.uuid4().hex
+        replacement_tags = ['{}_new_tag_{}'.format(tag_prefix, i) for i in range(2)]
+        _ = job_set.update_tags(replacement_tags=replacement_tags)
+
+        for job in job_set.jobs():
+            job.refresh()
+            self.assertEqual(set(job.tags()), set(replacement_tags + [job_set._id_long]))
+
+    def test_job_tags_remove(self):
+        """Test updating job tags by removing the job set's existing tags."""
+        initial_job_tags = [uuid.uuid4().hex]
+        job_set = self._jm.run([self._qc] * 2, backend=self.fake_api_backend,
+                               max_experiments_per_job=1, job_tags=initial_job_tags)
+
+        # Wait for jobs to be submitted.
+        while JobStatus.INITIALIZING in job_set.statuses():
+            time.sleep(1)
+
+        initial_job_tags_with_id_long = initial_job_tags + [job_set._id_long]
+
+        # Update the job tags
+        _ = job_set.update_tags(removal_tags=initial_job_tags_with_id_long)
+
+        for job in job_set.jobs():
+            job.refresh()
+            self.assertEqual(job.tags(), [job_set._id_long])
+
+    def test_index_by_number(self):
+        """Test indexing results by number."""
+        max_per_job = 5
+        job_set = self._jm.run([self._qc]*max_per_job*2, backend=self.fake_api_backend,
+                               max_experiments_per_job=max_per_job)
+        result_manager = job_set.results()
+        jobs = job_set.jobs()
+
+        for i in [0, max_per_job-1, max_per_job+1]:
+            with self.subTest(i=i):
+                job_index = int(i / max_per_job)
+                exp_index = i % max_per_job
+                self.assertEqual(result_manager.get_counts(i),
+                                 jobs[job_index].result().get_counts(exp_index))
+
+    def test_index_by_name(self):
+        """Test indexing results by name."""
+        max_per_job = 5
+        circs = []
+        for i in range(max_per_job*2+1):
+            new_qc = copy.deepcopy(self._qc)
+            new_qc.name = "test_qc_{}".format(i)
+            circs.append(new_qc)
+        job_set = self._jm.run(circs, backend=self.fake_api_backend,
+                               max_experiments_per_job=max_per_job)
+        result_manager = job_set.results()
+        jobs = job_set.jobs()
+
+        for i in [1, max_per_job, len(circs)-1]:
+            with self.subTest(i=i):
+                job_index = int(i / max_per_job)
+                exp_index = i % max_per_job
+                self.assertEqual(result_manager.get_counts(circs[i].name),
+                                 jobs[job_index].result().get_counts(exp_index))
+
+    def test_index_out_of_range(self):
+        """Test result index out of range."""
+        job_set = self._jm.run([self._qc], backend=self.fake_api_backend)
+        result_manager = job_set.results()
+        with self.assertRaises(IBMQJobManagerJobNotFound):
+            result_manager.get_counts(1)
+
+    def test_skipped_result(self):
+        """Test one of jobs has no result."""
+        self.fake_api_backend._api_client = BaseFakeAccountClient(
+            job_class=[BaseFakeJob, CancelableFakeJob])
+
+        job_set = self._jm.run([self._qc]*2, backend=self.fake_api_backend,
+                               max_experiments_per_job=1)
+        jobs = job_set.jobs()
+        jobs[1].cancel()
+
+        result_manager = job_set.results()
+        with self.assertRaises(IBMQManagedResultDataNotAvailable):
+            result_manager.get_counts(1)
+
+    def test_combine_results(self):
+        """Test converting ManagedResult to Result."""
+        max_per_job = 5
+        job_set = self._jm.run([self._qc]*max_per_job*2, backend=self.fake_api_backend,
+                               max_experiments_per_job=max_per_job)
+        result_manager = job_set.results()
+        combined_result = result_manager.combine_results()
+
+        for i in range(max_per_job*2):
+            self.assertEqual(result_manager.get_counts(i), combined_result.get_counts(i))
+
+    def test_ibmq_managed_results_signature(self):
+        """Test ``ManagedResults`` and ``Result`` contain the same public methods.
+
+        Note:
+            Aside from ensuring the two classes contain the same public
+            methods, it is also necessary to check that the corresponding
+            methods have the same signature.
+        """
+        result_methods = self._get_class_methods(Result)
+        self.assertTrue(result_methods)
+
+        managed_results_methods = self._get_class_methods(ManagedResults)
+        self.assertTrue(managed_results_methods)
+        del managed_results_methods['combine_results']
+        for ignore_meth in ['to_dict', 'from_dict']:
+            result_methods.pop(ignore_meth, None)
+
+        # Ensure both classes share the *exact* same public methods.
+        self.assertEqual(result_methods.keys(), managed_results_methods.keys())
+
+        # Ensure the signature for the public methods from both classes are compatible.
+        for name, method in managed_results_methods.items():
+            managed_results_params = getattr(getfullargspec(method), 'args', [])
+            result_params = getattr(getfullargspec(result_methods[name]), 'args', [])
+            self.assertTrue(managed_results_params)
+            self.assertTrue(result_params)
+            # pylint: disable=duplicate-string-formatting-argument
+            self.assertEqual(result_params, managed_results_params,
+                             "The signatures for method `{}` differ. "
+                             "`Result.{}` params = {} "
+                             "`ManagedResults.{}` params = {}."
+                             .format(name, name, managed_results_params,
+                                     name, result_params))
+
+    def _get_class_methods(self, cls):
+        """Get public class methods from its namespace.
+
+        Note:
+            Since the methods are found using the class itself and not
+            and instance, the "methods" are categorized as functions.
+            Methods are only bound when they belong to an actual instance.
+        """
+        cls_methods = {}
+        for name, method in cls.__dict__.items():
+            if isfunction(method) and not name.startswith('_'):
+                cls_methods[name] = method
+        return cls_methods
+
+
+class TestIBMQCompositeJobIntegration(IBMQTestCase):
+
+    @classmethod
+    @requires_provider
+    def setUpClass(cls, provider):
+        """Initial class level setup."""
+        # pylint: disable=arguments-differ
+        super().setUpClass()
+        cls.provider = provider
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls._qc = transpile(ReferenceCircuits.bell(), backend=cls.sim_backend)
+        cls.last_week = datetime.now() - timedelta(days=7)
+
+    def test_retrieve_job(self):
+        """Test retrieving a composite job."""
+        tags = ['test_retrieve_job_set']
+
+        circs_counts = [3, 4]
+        for count in circs_counts:
+            with self.subTest(count=count):
+                job_set = self.sim_backend.run([self._qc]*count, max_circuits_per_job=2,
+                                               job_tags=tags)
+                job_set.block_for_submit()
+                self.assertEqual(job_set.tags(), tags)
+
+                rjob_set = self.sim_backend.retrieve_job(job_set.job_id())
+                self.assertIsInstance(rjob_set, IBMQCompositeJob)
+                self.assertEqual(rjob_set.job_id(), job_set.job_id())
+                self.assertEqual(len(rjob_set.sub_jobs()), len(job_set.sub_jobs()))
+                self.assertEqual({rsub.job_id() for rsub in rjob_set.sub_jobs()},
+                                 {sub.job_id() for sub in job_set.sub_jobs()})
+                self.assertEqual(rjob_set.tags(), job_set.tags())
+                self.assertEqual(job_set.result().to_dict(), rjob_set.result().to_dict())
+
+    def test_jobs(self):
+        """Test retrieving a composite job using jobs."""
+        job_tags = [uuid.uuid4().hex]
+        job_set = self.sim_backend.run([self._qc]*2, max_circuits_per_job=1,
+                                       job_tags=job_tags)
+        job_set.block_for_submit()
+        circ_job = self.sim_backend.run(self._qc, job_tags=job_tags)
+
+        rjobs = self.provider.backend.jobs(job_tags=job_tags, start_datetime=self.last_week)
+        self.assertEqual(len(rjobs), 2)
+        for job in rjobs:
+            if job.job_id().startswith(IBMQCompositeJob._id_prefix):
+                self.assertEqual(job.job_id(), job_set.job_id())
+                self.assertEqual(len(job.sub_jobs()), len(job_set.sub_jobs()))
+                self.assertEqual({rsub.job_id() for rsub in job.sub_jobs()},
+                                 {sub.job_id() for sub in job_set.sub_jobs()})
+            else:
+                self.assertEqual(job.job_id(), circ_job.job_id())

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -31,7 +31,7 @@ from qiskit.providers.ibmq.apiconstants import ApiJobStatus, API_JOB_FINAL_STATE
 from qiskit.providers.ibmq.ibmqbackend import IBMQRetiredBackend
 from qiskit.providers.ibmq.exceptions import IBMQBackendError, IBMQBackendApiError
 from qiskit.providers.ibmq.utils.utils import api_status_to_job_status
-from qiskit.providers.ibmq.job.exceptions import IBMQJobTimeoutError
+from qiskit.providers.ibmq.job.exceptions import IBMQJobTimeoutError, IBMQJobNotFoundError
 from qiskit.providers.ibmq.utils.converters import local_to_utc
 from qiskit.providers.ibmq.api.rest.job import Job as RestJob
 from qiskit.providers.ibmq.api.exceptions import RequestsApiError
@@ -230,7 +230,7 @@ class TestIBMQJob(IBMQTestCase):
 
     def test_retrieve_job_error(self):
         """Test retrieving an invalid job."""
-        self.assertRaises(IBMQBackendError,
+        self.assertRaises(IBMQJobNotFoundError,
                           self.provider.backend.retrieve_job, 'BAD_JOB_ID')
 
     def test_retrieve_jobs_status(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Replace `IBMQJobManager` with `backend.run()`. Job manager today divides long circuits into multiple jobs and aggregates the results. It is, however, an `ibmq-provider`-only feature and cannot be easily used by backend-agnostic code.

This PR replaces Job Manager with `IBMQCompositeJob`, which is a child of `Job` and returned by `backend.run()`. This allows people to pass in long circuits but still use the returned job as a "normal" job. 


### Details and comments


