### PR TITLE
Fix job client_version deprecation message

### DIFF
--- a/qiskit/providers/ibmq/job/ibmqjob.py
+++ b/qiskit/providers/ibmq/job/ibmqjob.py
@@ -698,8 +698,8 @@ class IBMQJob(Job):
         Args:
             data: Client version.
         """
-        warnings.warn("The ``IBMQJob.client_version()`` method is deprecated and will "
-                      "be removed in a future release.",
+        warnings.warn('The ``client_version`` setter method is deprecated and '
+                      'will be removed in a future release.',
                       DeprecationWarning, stacklevel=2)
         self._set_client_version(data)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#889 deprecated `client_version` setter in `IBMQJob`. The message, however, should have said the "setter method" instead of "client_version() method", since it's not a regular method.


### Details and comments


