### PR TITLE
Don't skip jobs in test_retrieve_jobs_db_filter

### DIFF
--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -414,7 +414,7 @@ class TestIBMQJob(IBMQTestCase):
                      'status': 'COMPLETED'}
 
         job_list = self.provider.backend.jobs(backend_name=self.sim_backend.name(),
-                                              limit=2, skip=5, db_filter=my_filter,
+                                              limit=2, skip=0, db_filter=my_filter,
                                               start_datetime=self.last_month)
         self.assertTrue(job_list)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#846 added code to delete test jobs to avoid overloading the server. It also added `skip=5` to most `backend.jobs()` calls to avoid picking up deleted jobs. That shouldn't have applied to `test_retrieve_jobs_db_filter` because it submits its own job for the test, and the job doesn't get deleted until the test ends. Having `skip=5` may result in an empty list returned by `backend.jobs()` since there are very few "old" jobs to use now. 


### Details and comments


