### PR TITLE
Always return pulse defaults

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -479,9 +479,6 @@ class IBMQBackend(Backend):
         Returns:
             The backend pulse defaults or ``None`` if the backend does not support pulse.
         """
-        if not self.configuration().open_pulse:
-            return None
-
         if refresh or self._defaults is None:
             api_defaults = self._api_client.backend_pulse_defaults(self.name())
             if api_defaults:

--- a/test/ibmq/test_ibmq_backend.py
+++ b/test/ibmq/test_ibmq_backend.py
@@ -89,8 +89,6 @@ class TestIBMQBackend(IBMQTestCase):
                 defaults = backend.defaults()
                 if backend.configuration().open_pulse:
                     self.assertIsNotNone(defaults)
-                else:
-                    self.assertIsNone(defaults)
 
     def test_backend_reservations(self):
         """Test backend reservations."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR updates `backend.defaults()` to always return pulse defaults, if available, regardless whether open pulse is enabled for the provider.


### Details and comments


