### PR TITLE
Avoid use of __qiskit_version__ for client version header

### DIFF
--- a/qiskit/providers/ibmq/api/session.py
+++ b/qiskit/providers/ibmq/api/session.py
@@ -15,14 +15,16 @@
 import os
 import re
 import logging
+import pkg_resources
 from typing import Dict, Optional, Any, Tuple, Union
+
 from requests import Session, RequestException, Response
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from urllib3.util.retry import Retry
 
 from qiskit.providers.ibmq.utils.utils import filter_data
-from qiskit.version import __qiskit_version__
+from qiskit import __version__ as terra_version
 
 from .exceptions import RequestsApiError
 from ..version import __version__ as ibmq_provider_version
@@ -47,14 +49,11 @@ RE_DEVICES_ENDPOINT = re.compile(r'^(.*/devices/)([^/}]{2,})(.*)$', re.IGNORECAS
 
 def _get_client_header() -> str:
     """Return the client version."""
-    if __qiskit_version__.get('qiskit', None):
-        client_header = 'qiskit/' + __qiskit_version__['qiskit']
-    else:
-        known_versions = dict(
-            filter(lambda item: item[1] is not None, __qiskit_version__.items()))
-        # Always include provider version.
-        known_versions['qiskit-ibmq-provider'] = ibmq_provider_version
-        client_header = ','.join(known_versions.keys()) + '/' + ','.join(known_versions.values())
+    try:
+        client_header = 'qiskit/' + pkg_resources.get_distribution('qiskit').version
+    except Exception:
+        client_header = (f'qiskit-ibmq-provider/{ibmq_provider_version},'
+                         f'qiskit-terra/{terra_version}')
     return client_header
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The ibmq provider was using the `__qiskit_version__` attribute to try and
determine the various qiskit versions for inclusion in a client version
header. At first glance this would seem like the correct way to handle
this, however it actually is problematic. This is because
`__qiskit_version__` imports all the installed qiskit packages (including
things completely unrelated to the use-case for the client version
header) to provide a single end-user entrypoint for debugging to get all
the qiskit package versions. This is undesirable because the
qiskit-ibmq-provider usage of the `__qiskit_version__` attribute happens
on import, this means that we'll be unconditionally importing the entire
set of qiskit packages even if only terra and the qiskit provider are
used. This has the negative effect of both significantly increasing
import time (as things like aqua have very heavy dependencies and a slow
import tree) but also by potentially causing undesirable deprecation
warnings to be emitted if there are things in the import path that are
deprecated (like aqua). To fix this issue this commit switches away from
using the `__qiskit_version__` attribute and queries the qiskit
metapackage version directly, and if it's not available then the ibmq
provider and terra versions are set in the header. This avoids the
import related issues from using `__qiskit_version__` while not changing
the functionality (because the other non-terra requirements in the
header should have no impact on the api behavior).

### Details and comments

The client version used in the header should honestly be independent of
anything outside of the qiskit-ibmq-provider as it's the only
interaction point between the iqx api and qiskit (and things I believe
this was added for like the basis gate change can be handled by the
minimum version of terra in the requirements). Doing it this way just adds
an unnecessary dependency and complexity to version negotiation. But it's
probably too late to change the iqx api design at this point.
