### PR TITLE
Skip partial result tests

### DIFF
--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -15,7 +15,7 @@
 import time
 import copy
 from datetime import datetime, timedelta
-from unittest import SkipTest, mock
+from unittest import SkipTest, mock, skip
 from threading import Thread, Event
 
 from dateutil import tz
@@ -457,6 +457,7 @@ class TestIBMQJob(IBMQTestCase):
             limit=10, status=JobStatus.DONE, descending=False, start_datetime=self.last_month)
         self.assertNotIn(job.job_id(), [rjob.job_id() for rjob in oldest_jobs])
 
+    @skip("Skip until aer issue 1214 is fixed")
     def test_retrieve_failed_job_simulator_partial(self):
         """Test retrieving partial results from a simulator backend."""
         job = submit_job_one_bad_instr(self.sim_backend)

--- a/test/ibmq/test_ibmq_job_attributes.py
+++ b/test/ibmq/test_ibmq_job_attributes.py
@@ -13,7 +13,7 @@
 """Test IBMQJob attributes."""
 
 import time
-from unittest import mock
+from unittest import mock, skip
 from datetime import datetime, timedelta
 import re
 import uuid
@@ -164,6 +164,7 @@ class TestIBMQJobAttributes(IBMQTestCase):
                     self.assertIn('bad_instruction', msg)
                     self.assertIsNotNone(re.search(r'Error code: [0-9]{4}\.$', msg), msg)
 
+    @skip("Skip until aer issue 1214 is fixed")
     def test_error_message_simulator(self):
         """Test retrieving job error messages from a simulator backend."""
         job = submit_job_one_bad_instr(self.sim_backend)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Partial result tests all use `ibmq_qasm_simulator` because only simulators support partial results.  Aer 0.8.0, however, no longer gives a valid partial result format (see Qiskit/qiskit-aer#1214), causing these tests to fail. This PR disables the tests until the issue is fixed. 


### Details and comments


