### PR TITLE
Add Good/Bad ResultQuality enum values

### DIFF
--- a/qiskit/providers/ibmq/experiment/constants.py
+++ b/qiskit/providers/ibmq/experiment/constants.py
@@ -48,9 +48,11 @@ class ResultQuality(enum.Enum):
 
     HUMAN_BAD = 'Human Bad', 1
     COMPUTER_BAD = 'Computer Bad', 2
-    NO_INFORMATION = 'No Information', 3
-    COMPUTER_GOOD = 'Computer Good', 4
-    HUMAN_GOOD = 'Human Good', 5
+    BAD = 'Bad', 3
+    NO_INFORMATION = 'No Information', 4
+    GOOD = 'Good', 5
+    COMPUTER_GOOD = 'Computer Good', 6
+    HUMAN_GOOD = 'Human Good', 7
 
 
 class ExperimentShareLevel(enum.Enum):


### PR DESCRIPTION

### Summary

The Computer/Human analysis result `quality` values are
being deprecated and replaced with Good/Bad `quality` values.
The `verified` field indicates if a human verified the quality,
so `Human Bad` maps to `quality='Bad'` and `verified=True` while
`Computer Good` maps to `quality='Good'` and `verified=False`.
The server handles the mapping of the old deprecated `quality`
values when an analysis result is created or updated.

Existing data has already been migrated so when getting analysis
results back they should have `quality` of `Bad`, `No Information`
or `Good` which means we need to add the new `Bad` and `Good`
values to the `ResultQuality` enum.

### Details and comments

Part of #902
