### PR TITLE
Fix reno from PR 909

### DIFF
--- a/releasenotes/add-verified-field-to-analysis-results-5926fa1428ef1df5.yaml
+++ b/releasenotes/add-verified-field-to-analysis-results-5926fa1428ef1df5.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    :class:`qiskit.providers.ibmq.analysis_result.AnalysisResult now has an additional
-    ``verified`` attribute which identifies if the ``quality`` has been verified by a human.

--- a/releasenotes/notes/add-verified-field-to-analysis-results-5926fa1428ef1df5.yaml
+++ b/releasenotes/notes/add-verified-field-to-analysis-results-5926fa1428ef1df5.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    :class:`qiskit.providers.ibmq.experiment.analysis_result.AnalysisResult` now has an additional
+    ``verified`` attribute which identifies if the ``quality`` has been verified by a human.


### PR DESCRIPTION

### Summary

The release note added with PR #909 must not have been
created using `reno` because it's not in the `notes`
directory. This moves it and fixes a typo in `class`
path and closes the formatting on `class`.

### Details and comments

n/a