### PR TITLE
Remove deprecated ResultQuality values

### DIFF
--- a/qiskit/providers/ibmq/experiment/analysis_result.py
+++ b/qiskit/providers/ibmq/experiment/analysis_result.py
@@ -36,7 +36,7 @@ class AnalysisResult:
             result_type: str,
             fit: Optional[Dict] = None,
             chisq: Optional[float] = None,
-            quality: Union[ResultQuality, str] = ResultQuality.NO_INFORMATION,
+            quality: Union[ResultQuality, str] = ResultQuality.UNKNOWN,
             tags: Optional[List[str]] = None,
             result_uuid: Optional[str] = None,
             backend_name: Optional[str] = None,

--- a/qiskit/providers/ibmq/experiment/constants.py
+++ b/qiskit/providers/ibmq/experiment/constants.py
@@ -47,7 +47,7 @@ class ResultQuality(enum.Enum):
         return NotImplemented
 
     BAD = 'Bad', 1
-    NO_INFORMATION = 'No Information', 2
+    UNKNOWN = 'No Information', 2
     GOOD = 'Good', 3
 
 

--- a/qiskit/providers/ibmq/experiment/constants.py
+++ b/qiskit/providers/ibmq/experiment/constants.py
@@ -46,13 +46,9 @@ class ResultQuality(enum.Enum):
             return self.ranking < other.ranking  # type: ignore[attr-defined]
         return NotImplemented
 
-    HUMAN_BAD = 'Human Bad', 1
-    COMPUTER_BAD = 'Computer Bad', 2
-    BAD = 'Bad', 3
-    NO_INFORMATION = 'No Information', 4
-    GOOD = 'Good', 5
-    COMPUTER_GOOD = 'Computer Good', 6
-    HUMAN_GOOD = 'Human Good', 7
+    BAD = 'Bad', 1
+    NO_INFORMATION = 'No Information', 2
+    GOOD = 'Good', 3
 
 
 class ExperimentShareLevel(enum.Enum):

--- a/qiskit/providers/ibmq/experiment/experimentservice.py
+++ b/qiskit/providers/ibmq/experiment/experimentservice.py
@@ -429,6 +429,8 @@ class ExperimentService:
             data['fit'] = result.fit  # type: ignore[assignment]
         if result.tags:
             data['tags'] = result.tags  # type: ignore[assignment]
+        if result.verified is not None:
+            data['verified'] = result.verified
 
         if not data:  # Nothing to update.
             return

--- a/qiskit/providers/ibmq/experiment/experimentservice.py
+++ b/qiskit/providers/ibmq/experiment/experimentservice.py
@@ -328,8 +328,8 @@ class ExperimentService:
                 of an operator and a value. The operator is one of
                 ``lt``, ``le``, ``gt``, ``ge``, and ``eq``. The value is one of the
                 :class:`ResultQuality` values. For example,
-                ``analysis_results(quality=[('ge', 'Computer Bad'), ('lt', 'Computer Good')])``
-                will return all analysis results with a quality of ``Computer Bad`` and
+                ``analysis_results(quality=[('ge', 'Bad'), ('lt', 'Good')])``
+                will return all analysis results with a quality of ``Bad`` and
                 ``No Information``.
             verified: Indicates whether this result has been verified..
 

--- a/releasenotes/notes/analysis-result-quality-changes-c0296a10ef48292d.yaml
+++ b/releasenotes/notes/analysis-result-quality-changes-c0296a10ef48292d.yaml
@@ -19,3 +19,5 @@ upgrade:
     +---------------+-------------+----------+
     | Human Good    | Good        | True     |
     +---------------+-------------+----------+
+
+    Furthermore, the ``NO_INFORMATION`` enum has been renamed to ``UNKNOWN``.

--- a/releasenotes/notes/analysis-result-quality-changes-c0296a10ef48292d.yaml
+++ b/releasenotes/notes/analysis-result-quality-changes-c0296a10ef48292d.yaml
@@ -1,0 +1,21 @@
+---
+upgrade:
+  - |
+    The deprecated ``Human Bad``, ``Computer Bad``, ``Computer Good`` and
+    ``Human Good`` enum values have been removed from
+    :class:`qiskit.providers.ibmq.experiment.constants.ResultQuality`. They
+    are replaced with ``Bad`` and ``Good`` values which should be used with
+    the ``verified`` attribute on
+    :class:`qiskit.providers.ibmq.experiment.analysis_result.AnalysisResult`:
+
+    +---------------+-------------+----------+
+    | Old Quality   | New Quality | Verified |
+    +===============+=============+==========+
+    | Human Bad     | Bad         | True     |
+    +---------------+-------------+----------+
+    | Computer Bad  | Bad         | False    |
+    +---------------+-------------+----------+
+    | Computer Good | Good        | False    |
+    +---------------+-------------+----------+
+    | Human Good    | Good        | True     |
+    +---------------+-------------+----------+

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -447,7 +447,7 @@ class TestExperiment(IBMQTestCase):
         """Test updating an analysis result."""
         new_result = self._create_analysis_result()
         original_type = new_result.type
-        new_result.quality = ResultQuality.HUMAN_BAD
+        new_result.quality = ResultQuality.BAD
         new_result.verified = True
         new_fit = dict(
             value=new_result.fit['value']*2,
@@ -561,14 +561,13 @@ class TestExperiment(IBMQTestCase):
                                      "Analysis result {} with type {} does not match {}.".format(
                                          result.uuid, result.type, res_type))
 
-    @skip("Skip until issue 902 is fixed")
     def test_analysis_results_quality(self):
         """Test filtering analysis results with quality."""
         all_results = self.provider.experiment.analysis_results()
         ref_result = all_results[0]
         # Find a result whose quality is in the middle.
         for result in all_results:
-            if result.quality not in [ResultQuality.HUMAN_BAD, ResultQuality.HUMAN_GOOD]:
+            if result.quality not in [ResultQuality.BAD, ResultQuality.GOOD]:
                 ref_result = result
                 break
 

--- a/test/ibmq/test_experiment.py
+++ b/test/ibmq/test_experiment.py
@@ -14,7 +14,7 @@
 
 import os
 import uuid
-from unittest import mock, SkipTest, skipIf, skip
+from unittest import mock, SkipTest, skipIf
 from datetime import datetime, timedelta
 from typing import Optional, Union, Dict
 
@@ -447,7 +447,7 @@ class TestExperiment(IBMQTestCase):
         """Test updating an analysis result."""
         new_result = self._create_analysis_result()
         original_type = new_result.type
-        new_result.quality = ResultQuality.BAD
+        new_result.quality = ResultQuality.BAD  # pylint: disable=no-member
         new_result.verified = True
         new_fit = dict(
             value=new_result.fit['value']*2,
@@ -566,8 +566,9 @@ class TestExperiment(IBMQTestCase):
         all_results = self.provider.experiment.analysis_results()
         ref_result = all_results[0]
         # Find a result whose quality is in the middle.
+        bad_good = [ResultQuality.BAD, ResultQuality.GOOD]  # pylint: disable=no-member
         for result in all_results:
-            if result.quality not in [ResultQuality.BAD, ResultQuality.GOOD]:
+            if result.quality not in bad_good:
                 ref_result = result
                 break
 


### PR DESCRIPTION

### Summary

The resultsdb service has deprecated the Human/Computer
analysis result `quality` values. They are replaced with
just `Good` and `Bad` values to be used with the `verified`
flag on an analysis result.

This builds on #909 and #915 to remove the deprecated
enum quality values, gets the skipped test working again,
and adds an upgrade release note.

### Details and comments

Since the experiment service in Qiskit is still considered beta
there is no deprecation period in Qiskit itself though the service/API
continues to honor and translate the old quality values for now.

Closes #902