### PR TITLE
Fix runtime websocket cancel

### DIFF
--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -238,7 +238,7 @@ class RuntimeJob:
         """Cancel result streaming."""
         if not self._streaming:
             return
-        self._streaming_loop.call_soon_threadsafe(self._streaming_task.cancel())
+        self._streaming_loop.call_soon_threadsafe(self._streaming_task.cancel)
 
     def _start_websocket_client(
             self,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the issue wherein when a runtime job streaming is cancelled, it raises `TypeError: 'bool' object is not callable`.


### Details and comments


