### PR TITLE
Add wait time after cancel

### DIFF
--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -256,6 +256,7 @@ def main(backend, user_messenger, **kwargs):
             time.sleep(5)
         job.cancel()
         self.assertEqual(job.status(), JobStatus.CANCELLED)
+        time.sleep(3)  # Wait a bit for DB to update.
         rjob = self.provider.runtime.job(job.job_id())
         self.assertEqual(rjob.status(), JobStatus.CANCELLED)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR updates `test_cancel_job_running` to wait a few seconds for the server to update before verifying job status.


### Details and comments


