### PR TITLE
Fix backend not found when retrieving jobs from different provider

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -25,6 +25,7 @@ from qiskit.providers.backend import BackendV1 as Backend
 from qiskit.providers.basebackend import BaseBackend
 from qiskit.transpiler import Layout
 from qiskit.providers.ibmq.runtime import runtime_job  # pylint: disable=unused-import
+from qiskit.providers.ibmq import ibmqfactory  # pylint: disable=unused-import
 
 from .api.clients import AccountClient
 from .ibmqbackend import IBMQBackend, IBMQSimulator
@@ -96,15 +97,17 @@ class AccountProvider(Provider):
         in Jupyter Notebook and the Python interpreter.
     """
 
-    def __init__(self, credentials: Credentials) -> None:
+    def __init__(self, credentials: Credentials, factory: 'ibmqfactory.IBMQFactory') -> None:
         """AccountProvider constructor.
 
         Args:
             credentials: IBM Quantum Experience credentials.
+            factory: IBM Quantum account.
         """
         super().__init__()
 
         self.credentials = credentials
+        self._factory = factory
         self._api_client = AccountClient(credentials,
                                          **credentials.connection_parameters())
 

--- a/qiskit/providers/ibmq/ibmqfactory.py
+++ b/qiskit/providers/ibmq/ibmqfactory.py
@@ -471,7 +471,7 @@ class IBMQFactory:
 
             # Build the provider.
             try:
-                provider = AccountProvider(provider_credentials)
+                provider = AccountProvider(provider_credentials, self)
                 self._providers[provider_credentials.unique_id()] = provider
             except Exception:  # pylint: disable=broad-except
                 # Catch-all for errors instantiating the provider.

--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -464,7 +464,11 @@ class IBMRuntimeService:
         Returns:
             Decoded job data.
         """
-        backend = self._provider.get_backend(raw_data['backend'])
+        if self._provider.credentials.unique_id().to_tuple() != \
+                (raw_data['hub'], raw_data['group'], raw_data['project']):
+            backend = raw_data['backend']
+        else:
+            backend = self._provider.get_backend(raw_data['backend'])
 
         params = raw_data.get('params', {})
         if isinstance(params, list):

--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -17,6 +17,7 @@ from typing import Dict, Callable, Optional, Union, List, Any, Type
 import json
 import copy
 
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.providers.ibmq import accountprovider  # pylint: disable=unused-import
 
 from .runtime_job import RuntimeJob
@@ -28,7 +29,9 @@ from .program.result_decoder import ResultDecoder
 from ..api.clients.runtime import RuntimeClient
 from ..api.clients.runtime_ws import RuntimeWebsocketClient
 from ..api.exceptions import RequestsApiError
-from ..exceptions import IBMQNotAuthorizedError, IBMQInputValueError
+from ..exceptions import IBMQNotAuthorizedError, IBMQInputValueError, IBMQProviderError
+from ..ibmqbackend import IBMQRetiredBackend
+from ..credentials import Credentials
 
 logger = logging.getLogger(__name__)
 
@@ -464,9 +467,22 @@ class IBMRuntimeService:
         Returns:
             Decoded job data.
         """
-        if self._provider.credentials.unique_id().to_tuple() != \
-                (raw_data['hub'], raw_data['group'], raw_data['project']):
-            backend = raw_data['backend']
+        hub = raw_data['hub']
+        group = raw_data['group']
+        project = raw_data['project']
+        if self._provider.credentials.unique_id().to_tuple() != (hub, group, project):
+            # Try to find the right backend
+            try:
+                original_provider = self._provider._factory.get_provider(hub, group, project)
+                backend = original_provider.get_backend(raw_data['backend'])
+            except (IBMQProviderError, QiskitBackendNotFoundError):
+                backend = IBMQRetiredBackend.from_name(
+                    backend_name=raw_data['backend'],
+                    provider=None,
+                    credentials=Credentials(token="", url="",
+                                            hub=hub, group=group, project=project),
+                    api=None
+                )
         else:
             backend = self._provider.get_backend(raw_data['backend'])
 

--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -12,7 +12,7 @@
 
 """Qiskit runtime job."""
 
-from typing import Any, Optional, Callable, Dict, Type, Union
+from typing import Any, Optional, Callable, Dict, Type
 import time
 import logging
 import asyncio
@@ -24,7 +24,6 @@ from datetime import datetime
 from qiskit.providers.exceptions import JobTimeoutError
 from qiskit.providers.backend import Backend
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
-from qiskit.providers.ibmq import ibmqbackend  # pylint: disable=unused-import
 
 from .constants import API_TO_JOB_STATUS
 from .exceptions import RuntimeJobFailureError, RuntimeInvalidStateError, QiskitRuntimeError
@@ -77,7 +76,7 @@ class RuntimeJob:
 
     def __init__(
             self,
-            backend: Union['ibmqbackend.IBMQBackend', str],
+            backend: Backend,
             api_client: RuntimeClient,
             ws_client: RuntimeWebsocketClient,
             job_id: str,
@@ -90,7 +89,7 @@ class RuntimeJob:
         """RuntimeJob constructor.
 
         Args:
-            backend: The backend instance used to run this job or the backend name.
+            backend: The backend instance used to run this job.
             api_client: Object for connecting to the server.
             ws_client: Object for connecting to the server via websocket.
             job_id: Job ID.
@@ -323,12 +322,11 @@ class RuntimeJob:
         """
         return self._job_id
 
-    def backend(self) -> Union[Backend, str]:
+    def backend(self) -> Backend:
         """Return the backend where this job was executed.
 
         Returns:
-            Backend used for the job or the backend name if the job belongs to
-                a different provider.
+            Backend used for the job.
         """
         return self._backend
 

--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -12,7 +12,7 @@
 
 """Qiskit runtime job."""
 
-from typing import Any, Optional, Callable, Dict, Type
+from typing import Any, Optional, Callable, Dict, Type, Union
 import time
 import logging
 import asyncio
@@ -77,7 +77,7 @@ class RuntimeJob:
 
     def __init__(
             self,
-            backend: 'ibmqbackend.IBMQBackend',
+            backend: Union['ibmqbackend.IBMQBackend', str],
             api_client: RuntimeClient,
             ws_client: RuntimeWebsocketClient,
             job_id: str,
@@ -90,7 +90,7 @@ class RuntimeJob:
         """RuntimeJob constructor.
 
         Args:
-            backend: The backend instance used to run this job.
+            backend: The backend instance used to run this job or the backend name.
             api_client: Object for connecting to the server.
             ws_client: Object for connecting to the server via websocket.
             job_id: Job ID.
@@ -323,11 +323,12 @@ class RuntimeJob:
         """
         return self._job_id
 
-    def backend(self) -> Backend:
+    def backend(self) -> Union[Backend, str]:
         """Return the backend where this job was executed.
 
         Returns:
-            Backend used for the job.
+            Backend used for the job or the backend name if the job belongs to
+                a different provider.
         """
         return self._backend
 

--- a/releasenotes/notes/runtime-jobs-backend-09b48e23e319f039.yaml
+++ b/releasenotes/notes/runtime-jobs-backend-09b48e23e319f039.yaml
@@ -1,11 +1,4 @@
 ---
-upgrade:
-  - |
-    Method :meth:`qiskit.providers.ibmq.runtime.RuntimeJob.backend` can now
-    return a string if the provider used to retrive the job is different
-    from the provider used to submit the runtime job. The method continues to
-    return a :class:`~qiskit.providers.ibmq.IBMQBackend` instance if the
-    providers are the same.
 fixes:
   - |
     Fixes the issue wherein a ``QiskitBackendNotFoundError`` exception is raised

--- a/releasenotes/notes/runtime-jobs-backend-09b48e23e319f039.yaml
+++ b/releasenotes/notes/runtime-jobs-backend-09b48e23e319f039.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    Method :meth:`qiskit.providers.ibmq.runtime.RuntimeJob.backend` can now
+    return a string if the provider used to retrive the job is different
+    from the provider used to submit the runtime job. The method continues to
+    return a :class:`~qiskit.providers.ibmq.IBMQBackend` instance if the
+    providers are the same.
+fixes:
+  - |
+    Fixes the issue wherein a ``QiskitBackendNotFoundError`` exception is raised
+    when retrieving a runtime job that was submitted using a different provider
+    than the one used for retrival.

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -24,13 +24,13 @@ import random
 import numpy as np
 from qiskit.result import Result
 from qiskit.providers.jobstatus import JobStatus
-from qiskit.providers.ibmq.runtime.utils import RuntimeEncoder, RuntimeDecoder
 from qiskit.providers.ibmq.accountprovider import AccountProvider
+from qiskit.providers.ibmq.credentials import Credentials
+from qiskit.providers.ibmq.runtime.utils import RuntimeEncoder, RuntimeDecoder
 from qiskit.providers.ibmq.runtime import IBMRuntimeService, RuntimeJob
 from qiskit.providers.ibmq.runtime.exceptions import (RuntimeProgramNotFound,
                                                       RuntimeJobFailureError)
 from qiskit.providers.ibmq.runtime.runtime_program import ProgramParameter, ProgramResult
-
 
 from ...ibmqtestcase import IBMQTestCase
 from .fake_runtime_client import (BaseFakeRuntimeClient, FailedRuntimeJob, CancelableRuntimeJob,
@@ -308,6 +308,16 @@ class TestRuntime(IBMQTestCase):
         program = self.runtime.program(program_id)
         self.assertEqual(update_metadata['max_execution_time'], program.max_execution_time)
         self.assertEqual(update_metadata["version"], program.version)
+
+    def test_different_providers(self):
+        """Test retrieving job submitted with different provider."""
+        # self.runtime = IBMRuntimeService(mock.MagicMock(sepc=AccountProvider))
+        program_id = self._upload_program()
+        job = self._run_program(program_id)
+        cred = Credentials(token="", url="", hub="hub2", group="group2", project="project2")
+        self.runtime._provider.credentials = cred
+        rjob = self.runtime.job(job.job_id())
+        self.assertIsNotNone(rjob.backend())
 
     def _upload_program(self, name=None, max_execution_time=300):
         """Upload a new program."""

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -311,7 +311,6 @@ class TestRuntime(IBMQTestCase):
 
     def test_different_providers(self):
         """Test retrieving job submitted with different provider."""
-        # self.runtime = IBMRuntimeService(mock.MagicMock(sepc=AccountProvider))
         program_id = self._upload_program()
         job = self._run_program(program_id)
         cred = Credentials(token="", url="", hub="hub2", group="group2", project="project2")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the issues wherein if one tries to retrieve runtime jobs using a provider that's different from the provider used to submit the jobs, it'd raise an `QiskitBackendNotFoundError`.


### Details and comments
`RuntimeJob.backend()` currently returns a `Backend` instance, in order to match the behavior of `Job.backend()`. However, unlike circuit jobs, runtime jobs submitted by one provider can be retrieved by another, as long as both providers belong to the same user account. This PR tries to find the `Backend` that belongs to the original provider and uses a `IBMQRetiredBackend` if the backend or provider cannot be found.
