### PR TITLE
Adjust test polling time based on device

### DIFF
--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -253,7 +253,7 @@ def main(backend, user_messenger, **kwargs):
         self._wait_for_status(job, JobStatus.RUNNING)
         job.cancel()
         self.assertEqual(job.status(), JobStatus.CANCELLED)
-        time.sleep(3)  # Wait a bit for DB to update.
+        time.sleep(10)  # Wait a bit for DB to update.
         rjob = self.provider.runtime.job(job.job_id())
         self.assertEqual(rjob.status(), JobStatus.CANCELLED)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Runtime jobs can now run on a simulator, which is much faster than real device. This PR adjust the test polling time based on whether the backend used is a simulator or real device.


### Details and comments


