### PR TITLE
Description fix for maximum_jobs 

### DIFF
--- a/qiskit/providers/ibmq/backendjoblimit.py
+++ b/qiskit/providers/ibmq/backendjoblimit.py
@@ -23,8 +23,8 @@ class BackendJobLimit:
     method.
 
     Attributes:
-        maximum_jobs: The current number of active jobs on this backend, with
-            this provider.
+        maximum_jobs: The maximum number of concurrent jobs this account is 
+            allowed to submit to this backend, with this provider.
         running_jobs: The current number of active jobs on this backend, with
             this provider.
     """

--- a/qiskit/providers/ibmq/backendjoblimit.py
+++ b/qiskit/providers/ibmq/backendjoblimit.py
@@ -23,7 +23,7 @@ class BackendJobLimit:
     method.
 
     Attributes:
-        maximum_jobs: The maximum number of concurrent jobs this account is 
+        maximum_jobs: The maximum number of concurrent jobs this account is
             allowed to submit to this backend, with this provider.
         running_jobs: The current number of active jobs on this backend, with
             this provider.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The BackendJobLimit documentation currently has the same description as running_jobs. This PR replaces the description with the correct description. 


### Details and comments
The new description for maximum_jobs is now "The maximum number of concurrent jobs this account is allowed to submit to this backend, with this provider."

