### PR TITLE
Check backend status in test_filter_least_busy_reservation

### DIFF
--- a/test/ibmq/test_filter_backends.py
+++ b/test/ibmq/test_filter_backends.py
@@ -83,7 +83,8 @@ class TestBackendFilters(IBMQTestCase):
     def test_filter_least_busy_reservation(self):
         """Test filtering by least busy function, with reservations."""
         backend = reservations = None
-        for backend in self.provider.backends(simulator=False, operational=True):
+        for backend in self.provider.backends(simulator=False, operational=True,
+                                              status_msg='active'):
             reservations = backend.reservations()
             if reservations:
                 break
@@ -101,7 +102,8 @@ class TestBackendFilters(IBMQTestCase):
         self.assertEqual(least_busy([backend], None), backend)
 
         backs = [backend]
-        for back in self.provider.backends(simulator=False, operational=True):
+        for back in self.provider.backends(simulator=False, operational=True,
+                                           status_msg='active'):
             if back.name() != backend.name():
                 backs.append(back)
                 break


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`test_filter_least_busy_reservation` was failing because the backend it selected for the test was in "paused" mode, which is now being bypassed by `least_busy`.


### Details and comments


