### PR TITLE
Fix job status race condition in fake runtime client

### DIFF
--- a/test/ibmq/runtime/fake_runtime_client.py
+++ b/test/ibmq/runtime/fake_runtime_client.py
@@ -135,14 +135,21 @@ class CancelableRuntimeJob(BaseFakeRuntimeJob):
         "RUNNING"
     ]
 
+    def __init__(self, *args, **kwargs):
+        """Initialize a cancellable job."""
+        super().__init__(*args, **kwargs)
+        self._cancelled = False
+
     def cancel(self):
         """Cancel the job."""
         self._future.cancel()
+        self._cancelled = True
 
     def to_dict(self):
         """Convert to dictionary format."""
         data = super().to_dict()
-        data['status'] = "CANCELLED"
+        if self._cancelled:
+            data['status'] = "CANCELLED"
         return data
 
 

--- a/test/ibmq/runtime/fake_runtime_client.py
+++ b/test/ibmq/runtime/fake_runtime_client.py
@@ -138,7 +138,12 @@ class CancelableRuntimeJob(BaseFakeRuntimeJob):
     def cancel(self):
         """Cancel the job."""
         self._future.cancel()
-        self._status = "CANCELLED"
+
+    def to_dict(self):
+        """Convert to dictionary format."""
+        data = super().to_dict()
+        data['status'] = "CANCELLED"
+        return data
 
 
 class CustomResultRuntimeJob(BaseFakeRuntimeJob):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`CancelableRuntimeJob` may return a RUNNING status if the thread setting job status overwrites the CANCELLED state before being cancelled.


### Details and comments


