### PR TITLE
Only add non-None options in run_circuits

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -209,7 +209,7 @@ class AccountProvider(Provider):
             translation_method: Optional[str] = None,
             seed_transpiler: Optional[int] = None,
             optimization_level: int = 1,
-            init_qubits: Optional[bool] = True,
+            init_qubits: bool = True,
             rep_delay: Optional[float] = None,
             transpiler_options: Optional[dict] = None,
             measurement_error_mitigation: bool = False,

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -228,6 +228,9 @@ class AccountProvider(Provider):
                 Transpiler options are automatically grabbed from backend configuration
                 and properties unless otherwise specified.
 
+            shots: Number of repetitions of each circuit, for sampling. If not specified,
+                the backend default is used.
+
             initial_layout: Initial position of virtual qubits on physical qubits.
 
             layout_method: Name of layout selection pass ('trivial', 'dense',
@@ -246,16 +249,13 @@ class AccountProvider(Provider):
                 transpilation time.
                 If None, level 1 will be chosen as default.
 
-            shots: Number of repetitions of each circuit, for sampling. If not specified,
-                the backend default is used.
+            init_qubits: Whether to reset the qubits to the ground state for each shot.
 
             rep_delay: Delay between programs in seconds. Only supported on certain
                 backends (``backend.configuration().dynamic_reprate_enabled`` ). If supported,
                 ``rep_delay`` will be used instead of ``rep_time`` and must be from the
                 range supplied by the backend (``backend.configuration().rep_delay_range``).
                 Default is given by ``backend.configuration().default_rep_delay``.
-
-            init_qubits: Whether to reset the qubits to the ground state for each shot.
 
             transpiler_options: Additional transpiler options.
 

--- a/releasenotes/notes/run-circuits-shots-47345b708bf4e96b.yaml
+++ b/releasenotes/notes/run-circuits-shots-47345b708bf4e96b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the issue that uses ``shots=1`` instead of the documented default
+    when no ``shots`` is specified for
+    :meth:`~qiskit.providers.ibmq.AccountProvider.run_circuits`.

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -444,7 +444,8 @@ def main(backend, user_messenger, **kwargs):
         """Test run_circuit"""
         job = self.provider.run_circuits(
             ReferenceCircuits.bell(), backend=self.backend, shots=100)
-        job.result()
+        counts = job.result().get_counts()
+        self.assertEqual(100, sum(counts.values()))
 
     def test_job_creation_date(self):
         """Test job creation date."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #943. `run_circuits` was sending `shots=None` to the program, assuming the default would be used in that case. Instead, the simulator just sets `shots=None` in Qobj which translates to a single shot.

This PR sets `shots` and other parameters only if they're not `None`. 


### Details and comments


