### PR TITLE
Support proxy for runtime result streaming

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -c constraints.txt -e .
       - name: Run lint
         run: make style && make lint
       - name: Run mypy

--- a/qiskit/providers/ibmq/api/clients/runtime_ws.py
+++ b/qiskit/providers/ibmq/api/clients/runtime_ws.py
@@ -176,6 +176,7 @@ class RuntimeWebsocketClient:
             proxy_keys = [
                 self._ws_url,
                 'wss',
+                'https://' + url_parts.hostname,
                 'https',
                 'all://' + url_parts.hostname,
                 'all'
@@ -194,9 +195,6 @@ class RuntimeWebsocketClient:
         if "auth" in conn_data:
             out['http_proxy_auth'] = (credentials.proxies['username_ntlm'],
                                       credentials.proxies['password_ntlm'])
-
-        if out:
-            logger.debug("Using proxy %s", out)
 
         return out
 

--- a/qiskit/providers/ibmq/api/clients/runtime_ws.py
+++ b/qiskit/providers/ibmq/api/clients/runtime_ws.py
@@ -70,6 +70,7 @@ class RuntimeWebsocketClient:
             wsa: WebSocketApp object.
             message: Message received.
         """
+        # First message is an ACK
         if not self._connect_ack:
             self._connect_ack = True
         else:
@@ -149,7 +150,7 @@ class RuntimeWebsocketClient:
                     raise WebsocketError(f"A websocket error occurred while streaming "
                                          f"results for runtime job {self._job_id}")
             finally:
-                self.disconnect()
+                self.disconnect(self._normal_close)
 
             backoff_time = self._backoff_time(backoff_factor, self._current_retry)
             logger.info("Retrying websocket after %s seconds. Attemp %s",

--- a/qiskit/providers/ibmq/api/clients/runtime_ws.py
+++ b/qiskit/providers/ibmq/api/clients/runtime_ws.py
@@ -74,7 +74,7 @@ class RuntimeWebsocketClient:
             self._connect_ack = True
         else:
             self._result_queue.put_nowait(message)
-        self._current_retry = 0
+            self._current_retry = 0
 
     def on_close(self, wsa: WebSocketApp, status_code: int, msg: str) -> None:
         """Called when websocket connection clsed.
@@ -129,6 +129,7 @@ class RuntimeWebsocketClient:
         url = '{}/stream/jobs/{}'.format(self._ws_url, self._job_id)
 
         while self._current_retry <= max_retries:
+            self._connect_ack = False
             self._ws = WebSocketApp(url,
                                     header=self._header,
                                     on_open=self.on_open,

--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -27,7 +27,7 @@ from .exceptions import (QiskitRuntimeError, RuntimeDuplicateProgramError, Runti
                          RuntimeJobNotFound)
 from .program.result_decoder import ResultDecoder
 from ..api.clients.runtime import RuntimeClient
-from ..api.clients.runtime_ws import RuntimeWebsocketClient
+
 from ..api.exceptions import RequestsApiError
 from ..exceptions import IBMQNotAuthorizedError, IBMQInputValueError, IBMQProviderError
 from ..ibmqbackend import IBMQRetiredBackend
@@ -231,7 +231,7 @@ class IBMRuntimeService:
         backend = self._provider.get_backend(backend_name)
         job = RuntimeJob(backend=backend,
                          api_client=self._api_client,
-                         ws_client=RuntimeWebsocketClient(self._ws_url, self._access_token),
+                         credentials=self._provider.credentials,
                          job_id=response['id'], program_id=program_id, params=inputs,
                          user_callback=callback,
                          result_decoder=result_decoder)
@@ -498,7 +498,7 @@ class IBMRuntimeService:
         decoded = json.loads(params, cls=RuntimeDecoder)
         return RuntimeJob(backend=backend,
                           api_client=self._api_client,
-                          ws_client=RuntimeWebsocketClient(self._ws_url, self._access_token),
+                          credentials=self._provider.credentials,
                           job_id=raw_data['id'],
                           program_id=raw_data.get('program', {}).get('id', ""),
                           params=decoded,

--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -15,7 +15,6 @@
 from typing import Any, Optional, Callable, Dict, Type
 import time
 import logging
-import asyncio
 from concurrent import futures
 import traceback
 import queue
@@ -32,6 +31,7 @@ from ..api.clients import RuntimeClient, RuntimeWebsocketClient
 from ..exceptions import IBMQError
 from ..api.exceptions import RequestsApiError
 from ..utils.converters import utc_to_local
+from ..credentials import Credentials
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class RuntimeJob:
             self,
             backend: Backend,
             api_client: RuntimeClient,
-            ws_client: RuntimeWebsocketClient,
+            credentials: Credentials,
             job_id: str,
             program_id: str,
             params: Optional[Dict] = None,
@@ -91,7 +91,7 @@ class RuntimeJob:
         Args:
             backend: The backend instance used to run this job.
             api_client: Object for connecting to the server.
-            ws_client: Object for connecting to the server via websocket.
+            credentials: Account credentials.
             job_id: Job ID.
             program_id: ID of the program this job is for.
             params: Job parameters.
@@ -102,7 +102,7 @@ class RuntimeJob:
         self._job_id = job_id
         self._backend = backend
         self._api_client = api_client
-        self._ws_client = ws_client
+        self._ws_client = RuntimeWebsocketClient(credentials, job_id)
         self._results = None
         self._params = params or {}
         self._creation_date = creation_date
@@ -111,9 +111,7 @@ class RuntimeJob:
         self._result_decoder = result_decoder
 
         # Used for streaming
-        self._streaming = False
-        self._streaming_loop = None
-        self._streaming_task = None
+        self._ws_client_future = None  # type: Optional[futures.Future]
         self._result_queue = queue.Queue()  # type: queue.Queue
 
         if user_callback is not None:
@@ -226,23 +224,23 @@ class RuntimeJob:
             RuntimeInvalidStateError: If a callback function is already streaming results or
                 if the job already finished.
         """
-        if self._streaming:
+        if (self._ws_client_future is not None) and (not self._ws_client_future.done()):
             raise RuntimeInvalidStateError("A callback function is already streaming results.")
 
         if self._status in JOB_FINAL_STATES:
             raise RuntimeInvalidStateError("Job already finished.")
 
-        self._executor.submit(self._start_websocket_client,
-                              result_queue=self._result_queue)
+        self._ws_client_future = self._executor.submit(self._start_websocket_client,
+                                                       result_queue=self._result_queue)
         self._executor.submit(self._stream_results,
                               result_queue=self._result_queue, user_callback=callback,
                               decoder=decoder)
 
     def cancel_result_streaming(self) -> None:
         """Cancel result streaming."""
-        if not self._streaming:
+        if (self._ws_client_future is None) or (self._ws_client_future.done()):
             return
-        self._streaming_loop.call_soon_threadsafe(self._streaming_task.cancel)
+        self._ws_client.disconnect(normal=True)
 
     def _start_websocket_client(
             self,
@@ -254,26 +252,14 @@ class RuntimeJob:
             result_queue: Queue used to pass messages.
         """
         try:
-            # Need new loop for the thread.
-            self._streaming_loop = asyncio.new_event_loop()  # type: ignore[assignment]
-            asyncio.set_event_loop(self._streaming_loop)
-            # TODO - use asyncio.create_task() when 3.6 is dropped.
-            self._streaming_task = self._streaming_loop.create_task(
-                self._ws_client.job_results(self._job_id, result_queue))
-            self._streaming = True
-
             logger.debug("Start websocket client for job %s", self.job_id())
-            self._streaming_loop.run_until_complete(self._streaming_task)
+            self._ws_client.job_results(result_queue)
         except Exception:  # pylint: disable=broad-except
             logger.warning(
                 "An error occurred while streaming results "
                 "from the server for job %s:\n%s", self.job_id(), traceback.format_exc())
         finally:
             self._result_queue.put_nowait(self._POISON_PILL)
-            if self._streaming_loop is not None:
-                self._streaming_loop.run_until_complete(  # type: ignore[unreachable]
-                    self._ws_client.disconnect())
-            self._streaming = False
 
     def _stream_results(
             self,

--- a/releasenotes/notes/runtime-ws-4e81556d1905228f.yaml
+++ b/releasenotes/notes/runtime-ws-4e81556d1905228f.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    ``qiskit-ibmq-provider`` now requires a new package ``websocket-client``. The
+    package has been added to the `requirements.txt` file.
+fixes:
+  - |
+    Streaming runtime program interim results with proxies is now supported.
+    You can specify the proxies to use when enabling the account as usual,
+    for example::
+
+      from qiskit import IBMQ
+
+      proxies = {'urls': {'https://127.0.0.1:8085'}}
+      provider = IBMQ.enable_account(API_TOKEN, proxies=proxies)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy>=1.13
 urllib3>=1.21.1
 python-dateutil>=2.8.0
 dill>=0.3
+websocket-client>=1.0.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ REQUIREMENTS = [
     "numpy>=1.13",
     "urllib3>=1.21.1",
     "python-dateutil>=2.8.0",
-    "dill>=0.3"
+    "dill>=0.3",
+    "websocket-client>=1.0.1"
 ]
 
 # Handle version.

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -63,7 +63,10 @@ class TestRuntime(IBMQTestCase):
     def setUp(self):
         """Initial test setup."""
         super().setUp()
-        self.runtime = IBMRuntimeService(mock.MagicMock(sepc=AccountProvider))
+        provider = mock.MagicMock(spec=AccountProvider)
+        provider.credentials = Credentials(
+            token="", url="", services={"runtime": "https://quantum-computing.ibm.com"})
+        self.runtime = IBMRuntimeService(provider)
         self.runtime._api_client = BaseFakeRuntimeClient()
 
     def test_coder(self):
@@ -313,8 +316,10 @@ class TestRuntime(IBMQTestCase):
         """Test retrieving job submitted with different provider."""
         program_id = self._upload_program()
         job = self._run_program(program_id)
-        cred = Credentials(token="", url="", hub="hub2", group="group2", project="project2")
+        cred = Credentials(token="", url="", hub="hub2", group="group2", project="project2",
+                           services={"runtime": "https://quantum-computing.ibm.com"})
         self.runtime._provider.credentials = cred
+        self.runtime._provider._factory = mock.MagicMock()
         rjob = self.runtime.job(job.job_id())
         self.assertIsNotNone(rjob.backend())
 

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -17,7 +17,8 @@ import os
 import uuid
 import time
 import random
-from contextlib import suppress
+from contextlib import suppress, contextmanager
+import subprocess
 
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.test.reference_circuits import ReferenceCircuits
@@ -64,8 +65,12 @@ def main(backend, user_messenger, **kwargs):
         "max_execution_time": 600,
         "description": "Qiskit test program"
     }
-
     PROGRAM_PREFIX = 'qiskit-test'
+
+    TEST_IP_ADDRESS = '127.0.0.1'
+    VALID_PROXY_PORT = 8085
+    INVALID_PROXY_PORT = 6666
+    VALID_PROXIES = {'https': 'http://{}:{}'.format(TEST_IP_ADDRESS, VALID_PROXY_PORT)}
 
     @classmethod
     @requires_runtime_device
@@ -91,16 +96,15 @@ def main(backend, user_messenger, **kwargs):
     def tearDownClass(cls) -> None:
         """Class level teardown."""
         super().tearDownClass()
-        try:
+        with suppress(Exception):
             cls.provider.runtime.delete_program(cls.program_id)
-        except Exception:  # pylint: disable=broad-except
-            pass
 
     def setUp(self) -> None:
         """Test level setup."""
         super().setUp()
         self.to_delete = []
         self.to_cancel = []
+        self.proxy_process = None
 
     def tearDown(self) -> None:
         """Test level teardown."""
@@ -116,6 +120,11 @@ def main(backend, user_messenger, **kwargs):
                 job.cancel()
             with suppress(Exception):
                 self.provider.runtime.delete_job(job.job_id())
+
+        if self.proxy_process is not None and self.proxy_process.returncode is None:
+            self.proxy_process.stdout.close()  # close the IO buffer
+            self.proxy_process.terminate()  # initiate process termination
+            self.proxy_process.wait()  # wait for the process to terminate
 
     def test_runtime_service(self):
         """Test getting runtime service."""
@@ -389,12 +398,10 @@ def main(backend, user_messenger, **kwargs):
         final_result = get_complex_types()
         job = self._run_program(final_result=final_result)
         result = job.result(decoder=SerializableClassDecoder)
-        # self._assert_complex_types_equal(final_result, result)
         self.assertEqual(final_result, result)
 
         rresults = self.provider.runtime.job(job.job_id()).result(decoder=SerializableClassDecoder)
         self.assertEqual(final_result, rresults)
-        # self._assert_complex_types_equal(final_result, rresults)
 
     def test_job_status(self):
         """Test job status."""
@@ -457,6 +464,38 @@ def main(backend, user_messenger, **kwargs):
         for rjob in rjobs:
             self.assertTrue(rjob.creation_date)
 
+    def test_websocket_proxy(self):
+        """Test connecting to websocket via proxy."""
+        def result_callback(job_id, interim_result):  # pylint: disable=unused-argument
+            nonlocal callback_called
+            callback_called = True
+
+        self._start_proxy_server()
+        callback_called = False
+
+        with use_proxies(self.provider, self.VALID_PROXIES):
+            job = self._run_program(iterations=1, callback=result_callback)
+            job.wait_for_final_state()
+
+        self.assertTrue(callback_called)
+
+    def test_websocket_proxy_invalid_port(self):
+        """Test connecting to websocket via invalid proxy port."""
+        def result_callback(job_id, interim_result):  # pylint: disable=unused-argument
+            nonlocal callback_called
+            callback_called = True
+
+        callback_called = False
+        invalid_proxy = {'https': 'http://{}:{}'.format(self.TEST_IP_ADDRESS,
+                                                        self.INVALID_PROXY_PORT)}
+        with use_proxies(self.provider, invalid_proxy):
+            self.provider.credentials.proxies = {'urls': invalid_proxy}
+            with self.assertLogs('qiskit.providers.ibmq', 'WARNING') as log_cm:
+                job = self._run_program(iterations=1, callback=result_callback)
+                job.wait_for_final_state()
+            self.assertIn("WebsocketError", ','.join(log_cm.output))
+        self.assertFalse(callback_called)
+
     def _validate_program(self, program):
         """Validate a program."""
         self.assertTrue(program)
@@ -512,3 +551,19 @@ def main(backend, user_messenger, **kwargs):
             time.sleep(wait_time)
         if job.status() != status:
             self.skipTest(f"Job {job.job_id()} unable to reach status {status}.")
+
+    def _start_proxy_server(self):
+        """Start a proxy server."""
+        command = ['pproxy', '-v', '-l', 'http://{}:{}'.format(
+            self.TEST_IP_ADDRESS, self.VALID_PROXY_PORT)]
+        self.proxy_process = subprocess.Popen(command, stdout=subprocess.PIPE)
+
+
+@contextmanager
+def use_proxies(provider, proxies):
+    """Context manager to set and restore proxies setting."""
+    try:
+        provider.credentials.proxies = {'urls': proxies}
+        yield
+    finally:
+        provider.credentials.proxies = None

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -253,6 +253,7 @@ def main(backend, user_messenger, **kwargs):
         self._wait_for_status(job, JobStatus.QUEUED)
         job.cancel()
         self.assertEqual(job.status(), JobStatus.CANCELLED)
+        time.sleep(10)  # Wait a bit for DB to update.
         rjob = self.provider.runtime.job(job.job_id())
         self.assertEqual(rjob.status(), JobStatus.CANCELLED)
 

--- a/test/ibmq/runtime/test_runtime_ws.py
+++ b/test/ibmq/runtime/test_runtime_ws.py
@@ -22,9 +22,9 @@ import threading
 
 import websockets
 
-from qiskit.providers.ibmq.api.clients.runtime_ws import RuntimeWebsocketClient
 from qiskit.providers.ibmq.runtime import RuntimeJob
 from qiskit.providers.ibmq.runtime.exceptions import RuntimeInvalidStateError
+from qiskit.providers.ibmq.credentials import Credentials
 from qiskit.test.mock.fake_qasm_simulator import FakeQasmSimulator
 
 from ...ibmqtestcase import IBMQTestCase
@@ -223,10 +223,12 @@ class TestRuntimeWebsocketClient(IBMQTestCase):
 
     def _get_job(self, callback=None, job_id=JOB_ID_PROGRESS_DONE):
         """Get a runtime job."""
-        ws_client = RuntimeWebsocketClient(self.VALID_URL, "my_token")
+        cred = Credentials(token="my_token", url="", services={"runtime": self.VALID_URL})
+        # ws_client = RuntimeWebsocketClient(cred, job_id)
+        # ws_client._ws_url = self.VALID_URL
         job = RuntimeJob(backend=FakeQasmSimulator(),
                          api_client=BaseFakeRuntimeClient(),
-                         ws_client=ws_client,
+                         credentials=cred,
                          job_id=job_id,
                          program_id="my-program",
                          user_callback=callback)

--- a/test/ibmq/runtime/test_runtime_ws.py
+++ b/test/ibmq/runtime/test_runtime_ws.py
@@ -224,8 +224,6 @@ class TestRuntimeWebsocketClient(IBMQTestCase):
     def _get_job(self, callback=None, job_id=JOB_ID_PROGRESS_DONE):
         """Get a runtime job."""
         cred = Credentials(token="my_token", url="", services={"runtime": self.VALID_URL})
-        # ws_client = RuntimeWebsocketClient(cred, job_id)
-        # ws_client._ws_url = self.VALID_URL
         job = RuntimeJob(backend=FakeQasmSimulator(),
                          api_client=BaseFakeRuntimeClient(),
                          credentials=cred,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Related to #869. This PR switch to using the `websocket-client` package for runtime which has proxy support for websocket connections. A follow up PR will switch the job websocket to using the same package. 


### Details and comments


