### PR TITLE
Allow retrieving runtime job logs

### DIFF
--- a/qiskit/providers/ibmq/api/clients/runtime.py
+++ b/qiskit/providers/ibmq/api/clients/runtime.py
@@ -188,6 +188,17 @@ class RuntimeClient:
         """
         self.api.program_job(job_id).delete()
 
+    def job_logs(self, job_id: str) -> str:
+        """Get the job logs.
+
+        Args:
+            job_id: Program job ID.
+
+        Returns:
+            Job logs.
+        """
+        return self.api.program_job(job_id).logs()
+
     def logout(self) -> None:
         """Clear authorization cache."""
         self.api.logout()

--- a/qiskit/providers/ibmq/api/rest/runtime.py
+++ b/qiskit/providers/ibmq/api/rest/runtime.py
@@ -229,7 +229,8 @@ class ProgramJob(RestAdapterBase):
     URL_MAP = {
         'self': '',
         'results': '/results',
-        'cancel': '/cancel'
+        'cancel': '/cancel',
+        'logs': '/logs'
     }
 
     def __init__(
@@ -264,7 +265,7 @@ class ProgramJob(RestAdapterBase):
         """Return program job results.
 
         Returns:
-            JSON response.
+            Job results.
         """
         response = self.session.get(self.get_url('results'))
         return response.text
@@ -272,3 +273,11 @@ class ProgramJob(RestAdapterBase):
     def cancel(self) -> None:
         """Cancel the job."""
         self.session.post(self.get_url('cancel'))
+
+    def logs(self) -> str:
+        """Retrieve job logs.
+
+        Returns:
+            Job logs.
+        """
+        return self.session.get(self.get_url('logs')).text

--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -242,6 +242,27 @@ class RuntimeJob:
             return
         self._ws_client.disconnect(normal=True)
 
+    def logs(self) -> str:
+        """Return job logs.
+
+        Note:
+            Job logs are only available after the job finishes.
+
+        Returns:
+            Job logs, including standard output and error.
+
+        Raises:
+            QiskitRuntimeError: If a network error occurred.
+        """
+        if self.status() not in JOB_FINAL_STATES:
+            logger.warning("Job logs are only available after the job finishes.")
+        try:
+            return self._api_client.job_logs(self.job_id())
+        except RequestsApiError as err:
+            if err.status_code == 404:
+                return ""
+            raise QiskitRuntimeError(f"Failed to get job logs: {err}") from None
+
     def _is_streaming(self) -> bool:
         """Return whether job results are being streamed.
 

--- a/releasenotes/notes/runtime-logs-256c79f2fd071eae.yaml
+++ b/releasenotes/notes/runtime-logs-256c79f2fd071eae.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    You can now use the :meth:`qiskit.providers.ibmq.runtime.RuntimeJob.logs`
+    method to retrieve job logs. Note that logs are only available after the
+    job finishes.

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -40,6 +40,7 @@ class TestRuntimeIntegration(IBMQTestCase):
 
     RUNTIME_PROGRAM = """
 import random
+import warnings
 
 from qiskit import transpile
 from qiskit.circuit.random import random_circuit
@@ -54,11 +55,13 @@ def main(backend, user_messenger, **kwargs):
     interim_results = kwargs.pop('interim_results', {})
     final_result = kwargs.pop("final_result", {})
     for it in range(iterations):
-        qc = prepare_circuits(backend)
+        qc = prepare_circuits(backend)        
         user_messenger.publish({"iteration": it, "interim_results": interim_results})
         backend.run(qc).result()
 
     user_messenger.publish(final_result, final=True)
+    print("this is a stdout message")
+    warnings.warn("this is a stderr message")
     """
 
     RUNTIME_PROGRAM_METADATA = {
@@ -496,6 +499,16 @@ def main(backend, user_messenger, **kwargs):
                 job.wait_for_final_state()
             self.assertIn("WebsocketError", ','.join(log_cm.output))
         self.assertFalse(callback_called)
+
+    def test_job_logs(self):
+        """Test job logs."""
+        job = self._run_program(final_result="foo")
+        with self.assertLogs('qiskit.providers.ibmq', 'WARN'):
+            job.logs()
+        job.wait_for_final_state()
+        job_logs = job.logs()
+        self.assertIn("this is a stdout message", job_logs)
+        self.assertIn("this is a stderr message", job_logs)
 
     def _validate_program(self, program):
         """Validate a program."""

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -55,7 +55,7 @@ def main(backend, user_messenger, **kwargs):
     interim_results = kwargs.pop('interim_results', {})
     final_result = kwargs.pop("final_result", {})
     for it in range(iterations):
-        qc = prepare_circuits(backend)        
+        qc = prepare_circuits(backend)
         user_messenger.publish({"iteration": it, "interim_results": interim_results})
         backend.run(qc).result()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds the `logs()` method to `RuntimeJob` that allows one to retrieve job logs.


### Details and comments


