### PR TITLE
Pin mypy version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mypy
+mypy==0.812
 pycodestyle
 pylint==2.4.4
 vcrpy


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
mypy 0.9 falsely flags missing import, even though the configuration file has `ignore_missing_imports=True`. This PR pins the version to 0.8 until that's fixed.


### Details and comments


