### PR TITLE
Handle error converting complex value to float

### DIFF
--- a/qiskit/providers/ibmq/utils/json_encoder.py
+++ b/qiskit/providers/ibmq/utils/json_encoder.py
@@ -33,7 +33,7 @@ class IQXJsonEncoder(json.JSONEncoder):
         if isinstance(o, ParameterExpression):
             try:
                 return float(o)
-            except TypeError:
+            except (TypeError, RuntimeError):
                 val = complex(o)
                 return val.real, val.imag
         return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Symengine was introduced in qiskit-terra for performance improvements https://github.com/Qiskit/qiskit-terra/commit/514caef5994d8c0a4767f4ec3992eb1ef93a266d and it throws RuntimeError instead of old TypeError when we try to convert a complex ParameterExpression to float.

### Details and comments
This fixes the cron terra-master error https://github.com/Qiskit/qiskit-ibmq-provider/runs/2791018014?check_suite_focus=true

