### PR TITLE
make job share level optional to fix failing tests

### DIFF
--- a/qiskit/providers/ibmq/managed/managedjob.py
+++ b/qiskit/providers/ibmq/managed/managedjob.py
@@ -65,7 +65,7 @@ class ManagedJob:
             backend: IBMQBackend,
             executor: ThreadPoolExecutor,
             submit_lock: Lock,
-            job_share_level: ApiJobShareLevel,
+            job_share_level: Optional[ApiJobShareLevel] = None,
             job_tags: Optional[List[str]] = None,
             **run_config: Dict
     ) -> None:

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -84,7 +84,7 @@ class ManagedJobSet:
             experiment_list: Union[List[List[QuantumCircuit]], List[List[Schedule]]],
             backend: IBMQBackend,
             executor: ThreadPoolExecutor,
-            job_share_level: ApiJobShareLevel,
+            job_share_level: Optional[ApiJobShareLevel] = None,
             job_tags: Optional[List[str]] = None,
             **run_config: Any
     ) -> None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Some tests are failing since in #970 we removed passing job_share_level to a method which had job_share_level as mandatory. Make job_share_level optional to fix failing tests.

### Details and comments
Fixes #973

