### PR TITLE
Deprecate `'id'` instructions on IBM Quantum hardware backends.

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -793,7 +793,7 @@ class IBMQBackend(Backend):
             return
 
         if not self.id_warning_issued:
-            if id_support:
+            if id_support and delay_support:
                 warnings.warn("Support for the 'id' instruction has been deprecated "
                               "from IBM hardware backends. Any 'id' instructions "
                               "will be replaced with their equivalent 'delay' instruction. "

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -288,7 +288,7 @@ class IBMQBackend(Backend):
                 "'use_measure_esp' is unset or set to 'False'."
             )
 
-        if sim_method is None:
+        if not self.configuration().simulator:
             self._deprecate_id_instruction(circuits)
 
         if isinstance(circuits, (QasmQobj, PulseQobj)):

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -776,6 +776,9 @@ class IBMQBackend(Backend):
         id_support = 'id' in getattr(self.configuration(), 'basis_gates', [])
         delay_support = 'delay' in getattr(self.configuration(), 'supported_instructions', [])
 
+        if not delay_support:
+            return
+
         if isinstance(circuits, QasmQobj):
             circuit_has_id = any(instr.name == 'id'
                                  for experiment in circuits.experiments
@@ -799,22 +802,14 @@ class IBMQBackend(Backend):
                               "will be replaced with their equivalent 'delay' instruction. "
                               "Please use the 'delay' instruction instead.", DeprecationWarning,
                               stacklevel=4)
-            elif delay_support:
+            else:
                 warnings.warn("Support for the 'id' instruction has been removed "
                               "from IBM hardware backends. Any 'id' instructions "
                               "will be replaced with their equivalent 'delay' instruction. "
                               "Please use the 'delay' instruction instead.", DeprecationWarning,
                               stacklevel=4)
-            else:
-                warnings.warn("Support for the 'id' instruction has been removed "
-                              "from IBM hardware backends. Please use the 'delay' "
-                              "instruction instead.", DeprecationWarning,
-                              stacklevel=4)
 
             self.id_warning_issued = True
-
-        if not delay_support:
-            return
 
         dt_in_s = self.configuration().dt
 

--- a/releasenotes/notes/deprecate-hardware-id-instructions-5166323103eefdc4.yaml
+++ b/releasenotes/notes/deprecate-hardware-id-instructions-5166323103eefdc4.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    The `id` instruction has been deprecated on IBM hardware
+    backends. Instead, please use the `delay` instruction which
+    implements variable-length delays, specified in units of
+    `dt`. When running a circuit containing an `id` instruction,
+    a warning will be raised on job submission and any `id`
+    instructions in the job will be automatically replaced with their
+    equivalent `delay` instruction.
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates `IBMBackend.run` to inspect submitted circuits for instructions containing `'id'`.

- If `'id'` is still reported in the device's `basis_gates`, only a `DeprecationWarning` is raised. 
- If neither `'id'` nor `'delay'` are reported as supported by the device, a `DeprecationWarning` is raised.
- If `'id'` is no longer reported in the device's `basis_gates` and `'delay'` is reported in the device's `supported_instruction`, a `DeprecationWarning` is raised and any `'id'` instructions are replaced with their equivalent (`'sx'`-length) `'delay'` instructions.

### Details and comments

As an example, run a `'id'`-based T1 experiment on `ibmq_16_melbourne` (the only device active device different length `'sx'` gates on different qubits) from `main` and PR branch (forcing `'id'`->`'delay'` conversion):

```
>>> id_qcs = []
>>> for n in range(200):
...    qc = qk.QuantumCircuit(7,4)
...    qc.x([0,1,5,6])
...    for _ in range(n):
...        for __ in range(20):
...            qc.id([0,1,5,6])
...    qc.measure([0,1,5,6],[0,1,2,3])
...    id_qcs.append(qc)
...
>>> melbourne = provider.get_backend('ibmq_16_melbourne')
>>> id_tqcs = qk.transpile(id_qcs, melbourne, optimization_level=0)
>>> id_qobj = qk.assemble(id_tqcs)
>>>
>>>job_qobj = melbourne.run(id_qobj)
>>>job_circ = melbourne.run(id_tqcs)
```

![image](https://user-images.githubusercontent.com/2241698/122856927-ac00a800-d2e5-11eb-8762-a514960960ad.png)

For reference, compare PR and main branch performance of `backend.run(...)` for `id_qobj`, `id_tqcs` (up to 15,920 `'id'` gates) and `x_qobj`, `x_tqcs` (as above, but replace all `'id'` gates with `'x'` gates to isolate worst-case performance of 'scan-for-`'id'`). N.B. These are single-shot runtime readings.

Runtime comparison of `backend.run(...)`:

|        | Main `backend.run(qc)` | PR Branch `backend.run(qc)` | Main `backend.run(Qobj)` | PR `backend.run(Qobj)` |
---|---|---|---|---|
`'id'` | 3m55s | 3m57s | 2m23s | 2m33s |
`'x'` | 4m15s | 3m59s | 2m16 | 2m45s |

Isolate overhead of `backend._deprecate_id_instructions(...)`:

| Function call | Runtime |
--- | --- |
| `backend._deprecate_id_instructions(id_tqcs)` | 2.09s |
| `backend._deprecate_id_instructions(x_tqcs)` | 1.64s |
| `backend._deprecate_id_instructions(id_qobj)` | 812ms |
| `backend._deprecate_id_instructions(x_qobj)` | 440ms |
