### PR TITLE
Use qpy to serialize quantum circuits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.17.3
+qiskit-terra>=0.18.0
 requests>=2.19
 requests_ntlm>=1.1.0
 numpy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import os
 from setuptools import setup
 
 REQUIREMENTS = [
-    "qiskit-terra>=0.17.3",
+    "qiskit-terra>=0.18.0",
     "requests>=2.19",
     "requests-ntlm>=1.1.0",
     "numpy>=1.13",

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -16,7 +16,7 @@ import json
 import os
 from io import StringIO
 from unittest.mock import patch
-from unittest import mock, skipIf
+from unittest import mock
 import uuid
 import time
 import random
@@ -24,7 +24,6 @@ import random
 import numpy as np
 from qiskit.result import Result
 from qiskit import QuantumCircuit
-from qiskit.version import VERSION as terra_version
 from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.circuit.library import EfficientSU2
 from qiskit.providers.jobstatus import JobStatus
@@ -105,7 +104,6 @@ class TestRuntime(IBMQTestCase):
         self.assertIsInstance(decoded_result, Result)
         self.assertTrue((decoded_array == orig_array).all())
 
-    @skipIf(terra_version < '0.18', "Need Terra >= 0.18")
     def test_encoder_qc(self):
         """Test runtime encoder and decoder for circuits."""
         bell = ReferenceCircuits.bell()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR switches to using `qpy` to serialize `QuantumCircuit` for runtime instead of pickle, since pickle was only meant to be a stopgap until `qpy` was merged.

Note that this requires the next release of Qiskit Terra and hence is now on hold.


### Details and comments


