### PR TITLE
add pending parameter to filter jobs

### DIFF
--- a/qiskit/providers/ibmq/api/clients/runtime.py
+++ b/qiskit/providers/ibmq/api/clients/runtime.py
@@ -149,17 +149,19 @@ class RuntimeClient:
         logger.debug("Runtime job get response: %s", response)
         return response
 
-    def jobs_get(self, limit: int = None, skip: int = None) -> Dict:
+    def jobs_get(self, limit: int = None, skip: int = None, pending: bool = None) -> Dict:
         """Get job data for all jobs.
 
         Args:
             limit: Number of results to return.
             skip: Number of results to skip.
+            pending: Returns 'QUEUED' and 'RUNNING' jobs if True,
+                returns 'DONE', 'CANCELLED' and 'ERROR' jobs if False.
 
         Returns:
             JSON response.
         """
-        return self.api.jobs_get(limit=limit, skip=skip)
+        return self.api.jobs_get(limit=limit, skip=skip, pending=pending)
 
     def job_results(self, job_id: str) -> str:
         """Get the results of a program job.

--- a/qiskit/providers/ibmq/api/rest/runtime.py
+++ b/qiskit/providers/ibmq/api/rest/runtime.py
@@ -150,22 +150,26 @@ class Runtime(RestAdapterBase):
         data = json.dumps(payload)
         return self.session.post(url, data=data).json()
 
-    def jobs_get(self, limit: int = None, skip: int = None) -> Dict:
+    def jobs_get(self, limit: int = None, skip: int = None, pending: bool = None) -> Dict:
         """Get a list of job data.
 
         Args:
             limit: Number of results to return.
             skip: Number of results to skip.
+            pending: Returns 'QUEUED' and 'RUNNING' jobs if True,
+                returns 'DONE', 'CANCELLED' and 'ERROR' jobs if False.
 
         Returns:
             JSON response.
         """
         url = self.get_url('jobs')
-        payload = {}
+        payload: Dict[str, Union[int, str]] = {}
         if limit:
             payload['limit'] = limit
         if skip:
             payload['offset'] = skip
+        if pending is not None:
+            payload['pending'] = 'true' if pending else 'false'
         return self.session.get(url, params=payload).json()
 
     def logout(self) -> None:

--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -418,13 +418,14 @@ class IBMRuntimeService:
         return self._decode_job(response)
 
     def jobs(self, limit: int = 10, skip: int = 0, pending: bool = None) -> List[RuntimeJob]:
-        """Retrieve all runtime jobs.
+        """Retrieve all runtime jobs, subject to optional filtering.
 
         Args:
             limit: Number of jobs to retrieve.
             skip: Starting index for the job retrieval.
-            pending: Returns 'QUEUED' and 'RUNNING' jobs if True,
-                returns 'DONE', 'CANCELLED' and 'ERROR' jobs if False.
+            pending: Filter by job pending state. If ``True``, 'QUEUED' and 'RUNNING'
+                jobs are included. If ``False``, 'DONE', 'CANCELLED' and 'ERROR' jobs
+                are included.
 
         Returns:
             A list of runtime jobs.

--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -417,12 +417,14 @@ class IBMRuntimeService:
             raise QiskitRuntimeError(f"Failed to delete job: {ex}") from None
         return self._decode_job(response)
 
-    def jobs(self, limit: int = 10, skip: int = 0) -> List[RuntimeJob]:
+    def jobs(self, limit: int = 10, skip: int = 0, pending: bool = None) -> List[RuntimeJob]:
         """Retrieve all runtime jobs.
 
         Args:
             limit: Number of jobs to retrieve.
             skip: Starting index for the job retrieval.
+            pending: Returns 'QUEUED' and 'RUNNING' jobs if True,
+                returns 'DONE', 'CANCELLED' and 'ERROR' jobs if False.
 
         Returns:
             A list of runtime jobs.
@@ -431,7 +433,10 @@ class IBMRuntimeService:
         current_page_limit = limit or 20
 
         while True:
-            job_page = self._api_client.jobs_get(limit=current_page_limit, skip=skip)["jobs"]
+            job_page = self._api_client.jobs_get(
+                limit=current_page_limit,
+                skip=skip,
+                pending=pending)["jobs"]
             if not job_page:
                 # Stop if there are no more jobs returned by the server.
                 break
@@ -522,7 +527,7 @@ class IBMRuntimeService:
         to clear its cache.
 
         Note:
-            Invoking this method ONLY when your access level to the runtime
+            Invoke this method ONLY when your access level to the runtime
             service has changed - for example, the first time your account is
             given the authority to upload a program.
         """

--- a/releasenotes/notes/get-jobs-filter-by-pending-f93b3adce159a34d.yaml
+++ b/releasenotes/notes/get-jobs-filter-by-pending-f93b3adce159a34d.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    An optional boolean parameter `pending` has been added to
+    :meth:`qiskit.providers.ibmq.runtime.IBMRuntimeService.jobs`
+    and it allows filtering jobs by their status.
+    If `pending` is not specified all jobs are returned.
+    If `pending` is set to True, 'QUEUED' and 'RUNNING' jobs are returned.
+    If `pending` is set to False, 'DONE', 'ERROR' and 'CANCELLED' jobs are returned.

--- a/test/ibmq/runtime/fake_runtime_client.py
+++ b/test/ibmq/runtime/fake_runtime_client.py
@@ -72,18 +72,23 @@ class BaseFakeRuntimeJob:
 
     _executor = ThreadPoolExecutor()
 
-    def __init__(self, job_id, program_id, hub, group, project, backend_name, params):
+    def __init__(self, job_id, program_id, hub, group, project, backend_name, final_status,
+                 params):
         """Initialize a fake job."""
         self._job_id = job_id
-        self._status = "QUEUED"
+        self._status = final_status or "QUEUED"
         self._program_id = program_id
         self._hub = hub
         self._group = group
         self._project = project
         self._backend_name = backend_name
         self._params = params
-        self._future = self._executor.submit(self._auto_progress)
-        self._result = None
+        if final_status is None:
+            self._future = self._executor.submit(self._auto_progress)
+            self._result = None
+        elif final_status == "COMPLETED":
+            self._result = json.dumps("foo")
+        self._final_status = final_status
 
     def _auto_progress(self):
         """Automatically update job status."""
@@ -185,11 +190,12 @@ class TimedRuntimeJob(BaseFakeRuntimeJob):
 class BaseFakeRuntimeClient:
     """Base class for faking the runtime client."""
 
-    def __init__(self, job_classes=None, job_kwargs=None):
+    def __init__(self, job_classes=None, final_status=None, job_kwargs=None):
         """Initialize a fake runtime client."""
         self._programs = {}
         self._jobs = {}
         self._job_classes = job_classes or []
+        self._final_status = final_status
         self._job_kwargs = job_kwargs or {}
 
     def set_job_classes(self, classes):
@@ -197,6 +203,10 @@ class BaseFakeRuntimeClient:
         if not isinstance(classes, list):
             classes = [classes]
         self._job_classes = classes
+
+    def set_final_status(self, final_status):
+        """Set job status to passed in final status instantly."""
+        self._final_status = final_status
 
     def list_programs(self):
         """List all progrmas."""
@@ -244,7 +254,7 @@ class BaseFakeRuntimeClient:
         job = job_cls(job_id=job_id, program_id=program_id,
                       hub=credentials.hub, group=credentials.group,
                       project=credentials.project, backend_name=backend_name,
-                      params=params, **self._job_kwargs)
+                      params=params, final_status=self._final_status, **self._job_kwargs)
         self._jobs[job_id] = job
         return {'id': job_id}
 
@@ -258,11 +268,17 @@ class BaseFakeRuntimeClient:
         """Get the specific job."""
         return self._get_job(job_id).to_dict()
 
-    def jobs_get(self, limit=None, skip=None):
+    def jobs_get(self, limit=None, skip=None, pending=None):
         """Get all jobs."""
+        pending_statuses = ['QUEUED', 'RUNNING']
+        returned_statuses = ['COMPLETED', 'FAILED', 'CANCELLED']
         limit = limit or len(self._jobs)
         skip = skip or 0
-        jobs = list(self._jobs.values())[skip:limit+skip]
+        jobs = list(self._jobs.values())
+        if pending is not None:
+            job_status_list = pending_statuses if pending else returned_statuses
+            jobs = [job for job in jobs if job._status in job_status_list]
+        jobs = jobs[skip:limit+skip]
         return {"jobs": [job.to_dict() for job in jobs],
                 "count": len(self._jobs)}
 

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -239,6 +239,82 @@ class TestRuntime(IBMQTestCase):
         rjobs = self.runtime.jobs(skip=4, limit=2)
         self.assertEqual(2, len(rjobs))
 
+    def test_jobs_pending(self):
+        """Test retrieving pending jobs (QUEUED, RUNNING)."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, pending_jobs_count, _) = self._populate_jobs_with_all_statuses(
+            jobs=jobs, program_id=program_id)
+        rjobs = self.runtime.jobs(pending=True)
+        self.assertEqual(pending_jobs_count, len(rjobs))
+
+    def test_jobs_limit_pending(self):
+        """Test retrieving pending jobs (QUEUED, RUNNING) with limit."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, *_) = self._populate_jobs_with_all_statuses(jobs=jobs, program_id=program_id)
+        limit = 4
+        rjobs = self.runtime.jobs(limit=limit, pending=True)
+        self.assertEqual(limit, len(rjobs))
+
+    def test_jobs_skip_pending(self):
+        """Test retrieving pending jobs (QUEUED, RUNNING) with skip."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, pending_jobs_count, _) = self._populate_jobs_with_all_statuses(
+            jobs=jobs, program_id=program_id)
+        skip = 4
+        rjobs = self.runtime.jobs(skip=skip, pending=True)
+        self.assertEqual(pending_jobs_count - skip, len(rjobs))
+
+    def test_jobs_limit_skip_pending(self):
+        """Test retrieving pending jobs (QUEUED, RUNNING) with limit and skip."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, *_) = self._populate_jobs_with_all_statuses(jobs=jobs, program_id=program_id)
+        limit = 2
+        skip = 3
+        rjobs = self.runtime.jobs(limit=limit, skip=skip, pending=True)
+        self.assertEqual(limit, len(rjobs))
+
+    def test_jobs_returned(self):
+        """Test retrieving returned jobs (COMPLETED, FAILED, CANCELLED)."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, _, returned_jobs_count) = self._populate_jobs_with_all_statuses(
+            jobs=jobs, program_id=program_id)
+        rjobs = self.runtime.jobs(pending=False)
+        self.assertEqual(returned_jobs_count, len(rjobs))
+
+    def test_jobs_limit_returned(self):
+        """Test retrieving returned jobs (COMPLETED, FAILED, CANCELLED) with limit."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, *_) = self._populate_jobs_with_all_statuses(jobs=jobs, program_id=program_id)
+        limit = 6
+        rjobs = self.runtime.jobs(limit=limit, pending=False)
+        self.assertEqual(limit, len(rjobs))
+
+    def test_jobs_skip_returned(self):
+        """Test retrieving returned jobs (COMPLETED, FAILED, CANCELLED) with skip."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, _, returned_jobs_count) = self._populate_jobs_with_all_statuses(
+            jobs=jobs, program_id=program_id)
+        skip = 4
+        rjobs = self.runtime.jobs(skip=skip, pending=False)
+        self.assertEqual(returned_jobs_count - skip, len(rjobs))
+
+    def test_jobs_limit_skip_returned(self):
+        """Test retrieving returned jobs (COMPLETED, FAILED, CANCELLED) with limit and skip."""
+        jobs = []
+        program_id = self._upload_program()
+        (jobs, *_) = self._populate_jobs_with_all_statuses(jobs=jobs, program_id=program_id)
+        limit = 6
+        skip = 2
+        rjobs = self.runtime.jobs(limit=limit, skip=skip, pending=False)
+        self.assertEqual(limit, len(rjobs))
+
     def test_cancel_job(self):
         """Test canceling a job."""
         job = self._run_program(job_classes=CancelableRuntimeJob)
@@ -353,13 +429,36 @@ class TestRuntime(IBMQTestCase):
             description="A test program")
         return program_id
 
-    def _run_program(self, program_id=None, inputs=None, job_classes=None, decoder=None):
+    def _run_program(self, program_id=None, inputs=None, job_classes=None, final_status=None,
+                     decoder=None):
         """Run a program."""
         options = {'backend_name': "some_backend"}
-        if job_classes:
+        if final_status is not None:
+            self.runtime._api_client.set_final_status(final_status)
+        elif job_classes:
             self.runtime._api_client.set_job_classes(job_classes)
         if program_id is None:
             program_id = self._upload_program()
         job = self.runtime.run(program_id=program_id, inputs=inputs,
                                options=options, result_decoder=decoder)
         return job
+
+    def _populate_jobs_with_all_statuses(self, jobs, program_id):
+        pending_jobs_count = 0
+        returned_jobs_count = 0
+        for _ in range(3):
+            jobs.append(self._run_program(program_id, final_status='RUNNING'))
+            pending_jobs_count += 1
+        for _ in range(4):
+            jobs.append(self._run_program(program_id, final_status='COMPLETED'))
+            returned_jobs_count += 1
+        for _ in range(2):
+            jobs.append(self._run_program(program_id, final_status='QUEUED'))
+            pending_jobs_count += 1
+        for _ in range(3):
+            jobs.append(self._run_program(program_id, final_status='FAILED'))
+            returned_jobs_count += 1
+        for _ in range(2):
+            jobs.append(self._run_program(program_id, final_status='CANCELLED'))
+            returned_jobs_count += 1
+        return (jobs, pending_jobs_count, returned_jobs_count)

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -239,6 +239,34 @@ def main(backend, user_messenger, **kwargs):
         rjob_ids = {rjob.job_id() for rjob in rjobs}
         self.assertTrue(rjob_ids.issubset(job_ids))
 
+    def test_retrieve_pending_jobs(self):
+        """Test retrieving pending jobs (QUEUED, RUNNING)."""
+        job = self._run_program(iterations=10)
+        self._wait_for_status(job, JobStatus.RUNNING)
+        rjobs = self.provider.runtime.jobs(pending=True)
+        found = False
+        for rjob in rjobs:
+            if rjob.job_id() == job.job_id():
+                self.assertEqual(job.program_id, rjob.program_id)
+                self.assertEqual(job.inputs, rjob.inputs)
+                found = True
+                break
+        self.assertTrue(found, f"Pending job {job.job_id()} not retrieved.")
+
+    def test_retrieve_returned_jobs(self):
+        """Test retrieving returned jobs (COMPLETED, FAILED, CANCELLED)."""
+        job = self._run_program()
+        job.wait_for_final_state()
+        rjobs = self.provider.runtime.jobs(pending=False)
+        found = False
+        for rjob in rjobs:
+            if rjob.job_id() == job.job_id():
+                self.assertEqual(job.program_id, rjob.program_id)
+                self.assertEqual(job.inputs, rjob.inputs)
+                found = True
+                break
+        self.assertTrue(found, f"Returned job {job.job_id()} not retrieved.")
+
     def test_cancel_job_queued(self):
         """Test canceling a queued job."""
         _ = self._run_program(iterations=10)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
add pending parameter in runtime.jobs():
* if `pending` is not specified all jobs are returned.
* if `pending` is set to True, 'QUEUED' and 'RUNNING' jobs are returned.
* if `pending` is set to False, 'DONE', 'ERROR' and 'CANCELLED' jobs are returned.

### Details and comments
Fixes #971 

