### PR TITLE
Add support for viewing error message if runtime job failed

### DIFF
--- a/qiskit/providers/ibmq/runtime/constants.py
+++ b/qiskit/providers/ibmq/runtime/constants.py
@@ -25,6 +25,6 @@ API_TO_JOB_STATUS = {
 }
 
 API_TO_JOB_ERROR_MESSAGE = {
-    'FAILED': 'Unable to retrieve result for job {}. Job has failed:\n{}',
-    'CANCELLED - RAN TOO LONG': 'Job {} ran longer than maximum execution time. Job has failed:\n{}'
+    'FAILED': 'Job {} has failed:\n{}',
+    'CANCELLED - RAN TOO LONG': 'Job {} ran longer than maximum execution time. Job was cancelled:\n{}'
 }

--- a/qiskit/providers/ibmq/runtime/constants.py
+++ b/qiskit/providers/ibmq/runtime/constants.py
@@ -20,5 +20,11 @@ API_TO_JOB_STATUS = {
     'RUNNING': JobStatus.RUNNING,
     'COMPLETED': JobStatus.DONE,
     'FAILED': JobStatus.ERROR,
-    'CANCELLED': JobStatus.CANCELLED
+    'CANCELLED': JobStatus.CANCELLED,
+    'CANCELLED - RAN TOO LONG': JobStatus.ERROR
+}
+
+API_TO_JOB_ERROR_MESSAGE = {
+    'FAILED': 'Unable to retrieve result for job {}. Job has failed:\n{}',
+    'CANCELLED - RAN TOO LONG': 'Job {} ran longer than maximum execution time. Job has failed:\n{}'
 }

--- a/qiskit/providers/ibmq/runtime/constants.py
+++ b/qiskit/providers/ibmq/runtime/constants.py
@@ -26,5 +26,6 @@ API_TO_JOB_STATUS = {
 
 API_TO_JOB_ERROR_MESSAGE = {
     'FAILED': 'Job {} has failed:\n{}',
-    'CANCELLED - RAN TOO LONG': 'Job {} ran longer than maximum execution time. Job was cancelled:\n{}'
+    'CANCELLED - RAN TOO LONG': 'Job {} ran longer than maximum execution time. '
+                                'Job was cancelled:\n{}'
 }

--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -145,7 +145,7 @@ class RuntimeJob:
         if not self._results or (_decoder != self._result_decoder):  # type: ignore[unreachable]
             self.wait_for_final_state(timeout=timeout, wait=wait)
             if self._status == JobStatus.ERROR:
-                raise RuntimeJobFailureError(self.error_message())
+                raise RuntimeJobFailureError(f"Unable to retrieve job result. {self.error_message()}")
             result_raw = self._api_client.job_results(job_id=self.job_id())
             self._results = _decoder.decode(result_raw)
         return self._results

--- a/qiskit/providers/ibmq/runtime/runtime_job.py
+++ b/qiskit/providers/ibmq/runtime/runtime_job.py
@@ -145,7 +145,8 @@ class RuntimeJob:
         if not self._results or (_decoder != self._result_decoder):  # type: ignore[unreachable]
             self.wait_for_final_state(timeout=timeout, wait=wait)
             if self._status == JobStatus.ERROR:
-                raise RuntimeJobFailureError(f"Unable to retrieve job result. {self.error_message()}")
+                raise RuntimeJobFailureError(f"Unable to retrieve job result. "
+                                             f"{self.error_message()}")
             result_raw = self._api_client.job_results(job_id=self.job_id())
             self._results = _decoder.decode(result_raw)
         return self._results

--- a/releasenotes/notes/added-runtime-job-error-message-95eedc250ba94e4c.yaml
+++ b/releasenotes/notes/added-runtime-job-error-message-95eedc250ba94e4c.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add support for new method :meth:`qiskit.providers.ibmq.runtime.RuntimeJob.error_message`
+    which will return a string representing the reason if the job failed.

--- a/test/ibmq/runtime/fake_runtime_client.py
+++ b/test/ibmq/runtime/fake_runtime_client.py
@@ -134,6 +134,23 @@ class FailedRuntimeJob(BaseFakeRuntimeJob):
             self._result = "Kaboom!"
 
 
+class FailedRanTooLongRuntimeJob(BaseFakeRuntimeJob):
+    """Class for faking a failed runtime job."""
+
+    _job_progress = [
+        "QUEUED",
+        "RUNNING",
+        "CANCELLED - RAN TOO LONG"
+    ]
+
+    def _auto_progress(self):
+        """Automatically update job status."""
+        super()._auto_progress()
+
+        if self._status == "CANCELLED - RAN TOO LONG":
+            self._result = "Kaboom!"
+
+
 class CancelableRuntimeJob(BaseFakeRuntimeJob):
     """Class for faking a cancelable runtime job."""
 

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -21,6 +21,7 @@ from contextlib import suppress
 
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.test.reference_circuits import ReferenceCircuits
+from qiskit.providers.ibmq.runtime.constants import API_TO_JOB_ERROR_MESSAGE
 from qiskit.providers.ibmq.exceptions import IBMQNotAuthorizedError
 from qiskit.providers.ibmq.runtime.runtime_program import RuntimeProgram
 from qiskit.providers.ibmq.runtime.exceptions import (RuntimeDuplicateProgramError,
@@ -41,6 +42,7 @@ class TestRuntimeIntegration(IBMQTestCase):
 
     RUNTIME_PROGRAM = """
 import random
+import time
 import warnings
 
 from qiskit import transpile
@@ -53,9 +55,11 @@ def prepare_circuits(backend):
 
 def main(backend, user_messenger, **kwargs):
     iterations = kwargs['iterations']
+    sleep_per_iteration = kwargs.pop('sleep_per_iteration', 0)
     interim_results = kwargs.pop('interim_results', {})
     final_result = kwargs.pop("final_result", {})
     for it in range(iterations):
+        time.sleep(sleep_per_iteration)
         qc = prepare_circuits(backend)
         user_messenger.publish({"iteration": it, "interim_results": interim_results})
         backend.run(qc).result()
@@ -199,10 +203,33 @@ def main(backend, user_messenger, **kwargs):
         self.log.info("Runtime job %s submitted.", job.job_id())
 
         job.wait_for_final_state()
+        job_result_raw = self.provider.runtime._api_client.job_results(job.job_id())
         self.assertEqual(JobStatus.ERROR, job.status())
+        self.assertIn(API_TO_JOB_ERROR_MESSAGE['FAILED'].format(
+            job.job_id(), job_result_raw), job.error_message())
         with self.assertRaises(RuntimeJobFailureError) as err_cm:
             job.result()
         self.assertIn('KeyError', str(err_cm.exception))
+
+    def test_run_program_failed_ran_too_long(self):
+        """Test a program that failed since it ran longer than maxiumum execution time."""
+        max_execution_time = 60
+        inputs = {
+            'iterations': 1,
+            'sleep_per_iteration': 60
+        }
+        program_id = self._upload_program(max_execution_time=max_execution_time)
+        options = {'backend_name': self.backend.name()}
+        job = self.provider.runtime.run(program_id=program_id, inputs=inputs, options=options)
+        self.log.info("Runtime job %s submitted.", job.job_id())
+
+        job.wait_for_final_state()
+        job_result_raw = self.provider.runtime._api_client.job_results(job.job_id())
+        self.assertEqual(JobStatus.ERROR, job.status())
+        self.assertIn(API_TO_JOB_ERROR_MESSAGE['CANCELLED - RAN TOO LONG'].format(
+            job.job_id(), job_result_raw), job.error_message())
+        with self.assertRaises(RuntimeJobFailureError):
+            job.result()
 
     def test_retrieve_job_queued(self):
         """Test retrieving a queued job."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Interpret runtime's "Cancelled - Ran too long" status as Error and also add new method RuntimeJob.error_message() which returns a string representing the reason for runtime job failure.

### Details and comments
Fixes #972
