### PR TITLE
Always try using PulseBackendConfiguration first

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -199,9 +199,9 @@ class AccountProvider(Provider):
 
             try:
                 decode_backend_configuration(raw_config)
-                if raw_config.get('open_pulse', False):
+                try:
                     config = PulseBackendConfiguration.from_dict(raw_config)
-                else:
+                except (KeyError, TypeError):
                     config = QasmBackendConfiguration.from_dict(raw_config)
                 backend_cls = IBMQSimulator if config.simulator else IBMQBackend
                 ret[config.backend_name] = backend_cls(

--- a/releasenotes/notes/pulse-config-3368ff94333e7278.yaml
+++ b/releasenotes/notes/pulse-config-3368ff94333e7278.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The ``open_pulse`` flag in backend configuration no longer indicates
+    whether a backend supports pulse-level control. As a result,
+    :meth:`qiskit.providers.ibmq.IBMQBackend.configuration` may return a
+    :class:`~qiskit.providers.models.PulseBackendConfiguration` instance even
+    if its ``open_pulse`` flag is ``False``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The backend configuration flag `open_pulse` no longer indicates whether a backend supports pulse-level control. It now merely indicates whether a provider supports Pulse Qobj. This means a user can still send circuits with pulse-gates to a backend with `open_pulse=False`. 

As a result, this PR no longer relies on the `open_pulse` flag to see whether `QasmBackendConfiguration` or `PulseBackendConfiguration` should be used. It will always try to use `PulseBackendConfiguration` first and fall back to `QasmBackendConfiguration` if that doesn't work.


### Details and comments


