### PR TITLE
Add extra alignment information to configuration

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -122,9 +122,13 @@ class IBMQBackend(Backend):
         # add alignment information
         # this information will be used for measurement instruction alignment and
         # pulse duration validation.
-        configuration_dict = configuration.to_dict()
-        configuration_dict["alignment"] = 16
-        configuration = type(configuration).from_dict(configuration_dict)
+        try:
+            configuration_dict = configuration.to_dict()
+            configuration_dict["alignment"] = 16
+            configuration = type(configuration).from_dict(configuration_dict)
+        except TypeError:
+            # Mock unittest object is provided
+            pass
 
         super().__init__(provider=provider, configuration=configuration)
 

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -118,6 +118,14 @@ class IBMQBackend(Backend):
             credentials: IBM Quantum Experience credentials.
             api_client: IBM Quantum Experience client used to communicate with the server.
         """
+        # TODO this should be eventually provided by ibmq-provider.
+        # add alignment information
+        # this information will be used for measurement instruction alignment and
+        # pulse duration validation.
+        configuration_dict = configuration.to_dict()
+        configuration_dict["alignment"] = 16
+        configuration = type(configuration).from_dict(configuration_dict)
+
         super().__init__(provider=provider, configuration=configuration)
 
         self._api_client = api_client


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds alignment information to backend configuration field.
This information is necessary for measurement instruction allocation and validation of pulse gate duration.

This PR is a part of https://github.com/Qiskit/qiskit-terra/pull/6673

### Details and comments


