### PR TITLE
Remove retired backends from tutorials

### DIFF
--- a/docs/tutorials/1_the_ibmq_account.ipynb
+++ b/docs/tutorials/1_the_ibmq_account.ipynb
@@ -229,13 +229,17 @@
       "text/plain": [
        "[<IBMQSimulator('ibmq_qasm_simulator') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmqx2') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_vigo') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_valencia') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_athens') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>]"
+       " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_bogota') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_lima') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_belem') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_quito') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQSimulator('simulator_statevector') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQSimulator('simulator_mps') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQSimulator('simulator_extended_stabilizer') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQSimulator('simulator_stabilizer') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_manila') from IBMQ(hub='ibm-q', group='open', project='main')>]"
       ]
      },
      "execution_count": 4,
@@ -268,7 +272,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 5,
@@ -277,7 +281,7 @@
     }
    ],
    "source": [
-    "backend = provider.get_backend('ibmq_16_melbourne')\n",
+    "backend = provider.get_backend('ibmq_armonk')\n",
     "backend"
    ]
   },
@@ -306,13 +310,13 @@
      "data": {
       "text/plain": [
        "[<IBMQBackend('ibmqx2') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_vigo') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_valencia') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
        " <IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_athens') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
-       " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>]"
+       " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_bogota') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_lima') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_belem') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_quito') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+       " <IBMQBackend('ibmq_manila') from IBMQ(hub='ibm-q', group='open', project='main')>]"
       ]
      },
      "execution_count": 6,
@@ -344,7 +348,13 @@
     {
      "data": {
       "text/plain": [
-       "[<IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>]"
+        "[<IBMQBackend('ibmqx2') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+        " <IBMQBackend('ibmq_santiago') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+        " <IBMQBackend('ibmq_bogota') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+        " <IBMQBackend('ibmq_lima') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+        " <IBMQBackend('ibmq_belem') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+        " <IBMQBackend('ibmq_quito') from IBMQ(hub='ibm-q', group='open', project='main')>,\n",
+        " <IBMQBackend('ibmq_manila') from IBMQ(hub='ibm-q', group='open', project='main')>]"
       ]
      },
      "execution_count": 7,
@@ -353,7 +363,7 @@
     }
    ],
    "source": [
-    "provider.backends(min_num_qubits=10, simulator=False, operational=True)"
+    "provider.backends(min_num_qubits=5, simulator=False, operational=True)"
    ]
   },
   {
@@ -377,7 +387,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ibmq_ourense\n"
+      "ibmq_belem\n"
      ]
     }
    ],
@@ -508,7 +518,7 @@
     {
      "data": {
       "text/plain": [
-       "'ibmq_ourense'"
+       "'ibmq_belem'"
       ]
      },
      "execution_count": 11,
@@ -533,8 +543,8 @@
     {
      "data": {
       "text/plain": [
-       "{'backend_name': 'ibmq_ourense',\n",
-       " 'backend_version': '1.3.4',\n",
+       "{'backend_name': 'ibmq_belem',\n",
+       " 'backend_version': '1.0.14',\n",
        " 'operational': True,\n",
        " 'pending_jobs': 3,\n",
        " 'status_msg': 'active'}"
@@ -572,79 +582,215 @@
     {
      "data": {
       "text/plain": [
-       "{'backend_name': 'ibmq_ourense',\n",
-       " 'backend_version': '1.3.4',\n",
-       " 'n_qubits': 5,\n",
-       " 'basis_gates': ['id', 'u1', 'u2', 'u3', 'cx'],\n",
-       " 'gates': [{'name': 'id',\n",
-       "   'parameters': [],\n",
-       "   'qasm_def': 'gate id q { U(0,0,0) q; }',\n",
-       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
-       "  {'name': 'u1',\n",
-       "   'parameters': ['lambda'],\n",
-       "   'qasm_def': 'gate u1(lambda) q { U(0,0,lambda) q; }',\n",
-       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
-       "  {'name': 'u2',\n",
-       "   'parameters': ['phi', 'lambda'],\n",
-       "   'qasm_def': 'gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }',\n",
-       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
-       "  {'name': 'u3',\n",
-       "   'parameters': ['theta', 'phi', 'lambda'],\n",
-       "   'qasm_def': 'gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }',\n",
-       "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
-       "  {'name': 'cx',\n",
-       "   'parameters': [],\n",
-       "   'qasm_def': 'gate cx q1,q2 { CX q1,q2; }',\n",
-       "   'coupling_map': [[0, 1],\n",
-       "    [1, 0],\n",
-       "    [1, 2],\n",
-       "    [1, 3],\n",
-       "    [2, 1],\n",
-       "    [3, 1],\n",
-       "    [3, 4],\n",
-       "    [4, 3]]}],\n",
-       " 'local': False,\n",
-       " 'simulator': False,\n",
-       " 'conditional': False,\n",
-       " 'open_pulse': False,\n",
-       " 'memory': True,\n",
-       " 'max_shots': 8192,\n",
-       " 'coupling_map': [[0, 1],\n",
-       "  [1, 0],\n",
-       "  [1, 2],\n",
-       "  [1, 3],\n",
-       "  [2, 1],\n",
-       "  [3, 1],\n",
-       "  [3, 4],\n",
-       "  [4, 3]],\n",
-       " 'dynamic_reprate_enabled': True,\n",
-       " 'supported_instructions': ['cx',\n",
-       "  'id',\n",
-       "  'delay',\n",
-       "  'measure',\n",
-       "  'reset',\n",
-       "  'rz',\n",
-       "  'sx',\n",
-       "  'u1',\n",
-       "  'u2',\n",
-       "  'u3',\n",
-       "  'x'],\n",
-       " 'rep_delay_range': [0.0, 500.0],\n",
-       " 'default_rep_delay': 250.0,\n",
-       " 'max_experiments': 75,\n",
-       " 'sample_name': 'Giraffe',\n",
-       " 'n_registers': 1,\n",
-       " 'credits_required': True,\n",
-       " 'online_date': datetime.datetime(2019, 7, 3, 4, 0, tzinfo=tzutc()),\n",
-       " 'description': '5 qubit device Ourense',\n",
-       " 'allow_q_object': True,\n",
-       " 'dt': 2.222222222222222e-19,\n",
-       " 'dtm': 2.222222222222222e-19,\n",
-       " 'meas_map': [[0, 1, 2, 3, 4]],\n",
-       " 'multi_meas_enabled': False,\n",
-       " 'quantum_volume': 8,\n",
-       " 'url': 'None',\n",
-       " 'allow_object_storage': True}"
+        "{'backend_name': 'ibmq_belem',\n",
+        " 'backend_version': '1.0.14',\n",
+        " 'n_qubits': 5,\n",
+        " 'basis_gates': ['id', 'rz', 'sx', 'x', 'cx', 'reset'],\n",
+        " 'gates': [{'name': 'id',\n",
+        "   'parameters': [],\n",
+        "   'qasm_def': 'gate id q { U(0, 0, 0) q; }',\n",
+        "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+        "  {'name': 'rz',\n",
+        "   'parameters': ['theta'],\n",
+        "   'qasm_def': 'gate rz(theta) q { U(0, 0, theta) q; }',\n",
+        "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+        "  {'name': 'sx',\n",
+        "   'parameters': [],\n",
+        "   'qasm_def': 'gate sx q { U(pi/2, 3*pi/2, pi/2) q; }',\n",
+        "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+        "  {'name': 'x',\n",
+        "   'parameters': [],\n",
+        "   'qasm_def': 'gate x q { U(pi, 0, pi) q; }',\n",
+        "   'coupling_map': [[0], [1], [2], [3], [4]]},\n",
+        "  {'name': 'cx',\n",
+        "   'parameters': [],\n",
+        "   'qasm_def': 'gate cx q0, q1 { CX q0, q1; }',\n",
+        "   'coupling_map': [[0, 1],\n",
+        "    [1, 0],\n",
+        "    [1, 2],\n",
+        "    [1, 3],\n",
+        "    [2, 1],\n",
+        "    [3, 1],\n",
+        "    [3, 4],\n",
+        "    [4, 3]]},\n",
+        "  {'name': 'reset', 'parameters': None, 'qasm_def': None}],\n",
+        " 'local': False,\n",
+        " 'simulator': False,\n",
+        " 'conditional': False,\n",
+        " 'open_pulse': False,\n",
+        " 'memory': True,\n",
+        " 'max_shots': 8192,\n",
+        " 'coupling_map': [[0, 1],\n",
+        "  [1, 0],\n",
+        "  [1, 2],\n",
+        "  [1, 3],\n",
+        "  [2, 1],\n",
+        "  [3, 1],\n",
+        "  [3, 4],\n",
+        "  [4, 3]],\n",
+        " 'dynamic_reprate_enabled': True,\n",
+        " 'supported_instructions': ['id',\n",
+        "  'sx',\n",
+        "  'shiftf',\n",
+        "  'reset',\n",
+        "  'cx',\n",
+        "  'u1',\n",
+        "  'u2',\n",
+        "  'u3',\n",
+        "  'play',\n",
+        "  'delay',\n",
+        "  'x',\n",
+        "  'setf',\n",
+        "  'acquire',\n",
+        "  'measure',\n",
+        "  'rz'],\n",
+        " 'rep_delay_range': [0.0, 500.0],\n",
+        " 'default_rep_delay': 250.0,\n",
+        " 'max_experiments': 75,\n",
+        " 'sample_name': 'family: Falcon, revision: 4, segment: T',\n",
+        " 'n_registers': 1,\n",
+        " 'credits_required': True,\n",
+        " 'online_date': datetime.datetime(2021, 1, 8, 5, 0, tzinfo=tzutc()),\n",
+        " 'description': '5 qubit device Belem',\n",
+        " 'dt': 0.2222222222222222,\n",
+        " 'dtm': 0.2222222222222222,\n",
+        " 'processor_type': {'family': 'Falcon', 'revision': 4, 'segment': 'T'},\n",
+        " 'acquisition_latency': [],\n",
+        " 'allow_q_object': True,\n",
+        " 'channels': {'acquire0': {'operates': {'qubits': [0]},\n",
+        "   'purpose': 'acquire',\n",
+        "   'type': 'acquire'},\n",
+        "  'acquire1': {'operates': {'qubits': [1]},\n",
+        "   'purpose': 'acquire',\n",
+        "   'type': 'acquire'},\n",
+        "  'acquire2': {'operates': {'qubits': [2]},\n",
+        "   'purpose': 'acquire',\n",
+        "   'type': 'acquire'},\n",
+        "  'acquire3': {'operates': {'qubits': [3]},\n",
+        "   'purpose': 'acquire',\n",
+        "   'type': 'acquire'},\n",
+        "  'acquire4': {'operates': {'qubits': [4]},\n",
+        "   'purpose': 'acquire',\n",
+        "   'type': 'acquire'},\n",
+        "  'd0': {'operates': {'qubits': [0]}, 'purpose': 'drive', 'type': 'drive'},\n",
+        "  'd1': {'operates': {'qubits': [1]}, 'purpose': 'drive', 'type': 'drive'},\n",
+        "  'd2': {'operates': {'qubits': [2]}, 'purpose': 'drive', 'type': 'drive'},\n",
+        "  'd3': {'operates': {'qubits': [3]}, 'purpose': 'drive', 'type': 'drive'},\n",
+        "  'd4': {'operates': {'qubits': [4]}, 'purpose': 'drive', 'type': 'drive'},\n",
+        "  'm0': {'operates': {'qubits': [0]}, 'purpose': 'measure', 'type': 'measure'},\n",
+        "  'm1': {'operates': {'qubits': [1]}, 'purpose': 'measure', 'type': 'measure'},\n",
+        "  'm2': {'operates': {'qubits': [2]}, 'purpose': 'measure', 'type': 'measure'},\n",
+        "  'm3': {'operates': {'qubits': [3]}, 'purpose': 'measure', 'type': 'measure'},\n",
+        "  'm4': {'operates': {'qubits': [4]}, 'purpose': 'measure', 'type': 'measure'},\n",
+        "  'u0': {'operates': {'qubits': [0, 1]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u1': {'operates': {'qubits': [1, 0]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u2': {'operates': {'qubits': [1, 2]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u3': {'operates': {'qubits': [1, 3]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u4': {'operates': {'qubits': [2, 1]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u5': {'operates': {'qubits': [3, 1]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u6': {'operates': {'qubits': [3, 4]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'},\n",
+        "  'u7': {'operates': {'qubits': [4, 3]},\n",
+        "   'purpose': 'cross-resonance',\n",
+        "   'type': 'control'}},\n",
+        " 'conditional_latency': [],\n",
+        " 'discriminators': ['linear_discriminator',\n",
+        "  'quadratic_discriminator',\n",
+        "  'hw_centroid'],\n",
+        " 'hamiltonian': {'description': 'Qubits are modeled as Duffing oscillators. In this case, the system includes higher energy states, i.e. not just |0> and |1>. The Pauli operators are generalized via the following set of transformations:\\n\\n$(\\\\mathbb{I}-\\\\sigma_{i}^z)/2 \\\\rightarrow O_i \\\\equiv b^\\\\dagger_{i} b_{i}$,\\n\\n$\\\\sigma_{+} \\\\rightarrow b^\\\\dagger$,\\n\\n$\\\\sigma_{-} \\\\rightarrow b$,\\n\\n$\\\\sigma_{i}^X \\\\rightarrow b^\\\\dagger_{i} + b_{i}$.\\n\\nQubits are coupled through resonator buses. The provided Hamiltonian has been projected into the zero excitation subspace of the resonator buses leading to an effective qubit-qubit flip-flop interaction. The qubit resonance frequencies in the Hamiltonian are the cavity dressed frequencies and not exactly what is returned by the backend defaults, which also includes the dressing due to the qubit-qubit interactions.\\n\\nQuantities are returned in angular frequencies, with units 2*pi*GHz.\\n\\nWARNING: Currently not all system Hamiltonian information is available to the public, missing values have been replaced with 0.\\n',\n",
+        "  'h_latex': '\\\\begin{align} \\\\mathcal{H}/\\\\hbar = & \\\\sum_{i=0}^{4}\\\\left(\\\\frac{\\\\omega_{q,i}}{2}(\\\\mathbb{I}-\\\\sigma_i^{z})+\\\\frac{\\\\Delta_{i}}{2}(O_i^2-O_i)+\\\\Omega_{d,i}D_i(t)\\\\sigma_i^{X}\\\\right) \\\\\\\\ & + J_{0,1}(\\\\sigma_{0}^{+}\\\\sigma_{1}^{-}+\\\\sigma_{0}^{-}\\\\sigma_{1}^{+}) + J_{1,2}(\\\\sigma_{1}^{+}\\\\sigma_{2}^{-}+\\\\sigma_{1}^{-}\\\\sigma_{2}^{+}) + J_{1,3}(\\\\sigma_{1}^{+}\\\\sigma_{3}^{-}+\\\\sigma_{1}^{-}\\\\sigma_{3}^{+}) + J_{3,4}(\\\\sigma_{3}^{+}\\\\sigma_{4}^{-}+\\\\sigma_{3}^{-}\\\\sigma_{4}^{+}) \\\\\\\\ & + \\\\Omega_{d,0}(U_{0}^{(0,1)}(t))\\\\sigma_{0}^{X} + \\\\Omega_{d,1}(U_{1}^{(1,0)}(t)+U_{3}^{(1,3)}(t)+U_{2}^{(1,2)}(t))\\\\sigma_{1}^{X} \\\\\\\\ & + \\\\Omega_{d,2}(U_{4}^{(2,1)}(t))\\\\sigma_{2}^{X} + \\\\Omega_{d,3}(U_{6}^{(3,4)}(t)+U_{5}^{(3,1)}(t))\\\\sigma_{3}^{X} \\\\\\\\ & + \\\\Omega_{d,4}(U_{7}^{(4,3)}(t))\\\\sigma_{4}^{X} \\\\\\\\ \\\\end{align}',\n",
+        "  'h_str': ['_SUM[i,0,4,wq{i}/2*(I{i}-Z{i})]',\n",
+        "   '_SUM[i,0,4,delta{i}/2*O{i}*O{i}]',\n",
+        "   '_SUM[i,0,4,-delta{i}/2*O{i}]',\n",
+        "   '_SUM[i,0,4,omegad{i}*X{i}||D{i}]',\n",
+        "   'jq0q1*Sp0*Sm1',\n",
+        "   'jq0q1*Sm0*Sp1',\n",
+        "   'jq1q2*Sp1*Sm2',\n",
+        "   'jq1q2*Sm1*Sp2',\n",
+        "   'jq1q3*Sp1*Sm3',\n",
+        "   'jq1q3*Sm1*Sp3',\n",
+        "   'jq3q4*Sp3*Sm4',\n",
+        "   'jq3q4*Sm3*Sp4',\n",
+        "   'omegad1*X0||U0',\n",
+        "   'omegad0*X1||U1',\n",
+        "   'omegad3*X1||U3',\n",
+        "   'omegad2*X1||U2',\n",
+        "   'omegad1*X2||U4',\n",
+        "   'omegad4*X3||U6',\n",
+        "   'omegad1*X3||U5',\n",
+        "   'omegad3*X4||U7'],\n",
+        "  'osc': {},\n",
+        "  'qub': {'0': 3, '1': 3, '2': 3, '3': 3, '4': 3},\n",
+        "  'vars': {'delta0': -2.1119231275656283,\n",
+        "   'delta1': -1.989081364755034,\n",
+        "   'delta2': -2.0773937776320905,\n",
+        "   'delta3': -2.096945401946966,\n",
+        "   'delta4': -2.0819029355928373,\n",
+        "   'jq0q1': 0.011772262300160973,\n",
+        "   'jq1q2': 0.012605700949390706,\n",
+        "   'jq1q3': 0.012591488659137172,\n",
+        "   'jq3q4': 0.01051661912410011,\n",
+        "   'omegad0': 0.8027253632102426,\n",
+        "   'omegad1': 0.7994609296532756,\n",
+        "   'omegad2': 1.9688450308371457,\n",
+        "   'omegad3': 0.7721838249505281,\n",
+        "   'omegad4': 0.6185844031359571,\n",
+        "   'wq0': 31.98159911982912,\n",
+        "   'wq1': 32.95737791154753,\n",
+        "   'wq2': 33.68606633828003,\n",
+        "   'wq3': 32.48696041179116,\n",
+        "   'wq4': 33.039435267685114}},\n",
+        " 'meas_kernels': ['hw_boxcar'],\n",
+        " 'meas_levels': [1, 2],\n",
+        " 'meas_lo_range': [[6.801661824e+18, 7.801661824e+18],\n",
+        "  [6.893594461e+18, 7.893594461e+18],\n",
+        "  [6.860214726e+18, 7.860214726e+18],\n",
+        "  [6.803382327e+18, 7.803382327e+18],\n",
+        "  [6.926310916e+18, 7.926310916e+18]],\n",
+        " 'meas_map': [[0, 1, 2, 3, 4]],\n",
+        " 'measure_esp_enabled': False,\n",
+        " 'multi_meas_enabled': True,\n",
+        " 'n_uchannels': 8,\n",
+        " 'parametric_pulses': ['gaussian', 'gaussian_square', 'drag', 'constant'],\n",
+        " 'quantum_volume': 16,\n",
+        " 'qubit_channel_mapping': [['d0', 'm0', 'u1', 'u0'],\n",
+        "  ['u4', 'd1', 'u2', 'u1', 'u3', 'm1', 'u5', 'u0'],\n",
+        "  ['u2', 'd2', 'm2', 'u4'],\n",
+        "  ['m3', 'u3', 'u7', 'd3', 'u5', 'u6'],\n",
+        "  ['m4', 'd4', 'u6', 'u7']],\n",
+        " 'qubit_lo_range': [[4.590029587904213e+18, 5.590029587904213e+18],\n",
+        "  [4.745329605970436e+18, 5.745329605970436e+18],\n",
+        "  [4.861303971058769e+18, 5.861303971058769e+18],\n",
+        "  [4.670460335567279e+18, 5.670460335567279e+18],\n",
+        "  [4.758389439816784e+18, 5.758389439816784e+18]],\n",
+        " 'rep_times': [0.001],\n",
+        " 'u_channel_lo': [[{'q': 1, 'scale': (1+0j)}],\n",
+        "  [{'q': 0, 'scale': (1+0j)}],\n",
+        "  [{'q': 2, 'scale': (1+0j)}],\n",
+        "  [{'q': 3, 'scale': (1+0j)}],\n",
+        "  [{'q': 1, 'scale': (1+0j)}],\n",
+        "  [{'q': 1, 'scale': (1+0j)}],\n",
+        "  [{'q': 4, 'scale': (1+0j)}],\n",
+        "  [{'q': 3, 'scale': (1+0j)}]],\n",
+        " 'uchannels_enabled': True,\n",
+        " 'url': 'None',\n",
+        " 'input_allowed': ['job'],\n",
+        " 'allow_object_storage': True,\n",
+        " 'pulse_num_channels': 9,\n",
+        " 'pulse_num_qubits': 3}"
       ]
      },
      "execution_count": 13,
@@ -801,7 +947,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_16_melbourne') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_armonk') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 17,
@@ -810,7 +956,7 @@
     }
    ],
    "source": [
-    "provider.backend.ibmq_16_melbourne"
+    "provider.backend.ibmq_armonk"
    ]
   },
   {
@@ -1014,7 +1160,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_belem') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 25,
@@ -1394,8 +1540,8 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.23.1</td></tr><tr><td>Terra</td><td>0.16.1</td></tr><tr><td>Aer</td><td>0.7.1</td></tr><tr><td>Ignis</td><td>0.5.1</td></tr><tr><td>Aqua</td><td>0.8.1</td></tr><tr><td>IBM Q Provider</td><td>0.12.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.6.5 (default, Jul 15 2020, 16:10:25) \n",
-       "[GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.32.62)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Dec 18 10:31:22 2020 EST</td></tr></table>"
+        "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.27.0</td></tr><tr><td>Terra</td><td>0.17.4</td></tr><tr><td>Aer</td><td>0.8.2</td></tr><tr><td>Ignis</td><td>0.6.0</td></tr><tr><td>Aqua</td><td>0.9.2</td></tr><tr><td>IBM Q Provider</td><td>0.14.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05) \n",
+        "[GCC 9.3.0]</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>31.40896224975586</td></tr><tr><td colspan='2'>Thu Jul 08 16:31:08 2021 UTC</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"

--- a/docs/tutorials/2_jupyter_tools.ipynb
+++ b/docs/tutorials/2_jupyter_tools.ipynb
@@ -284,7 +284,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "Card(children=[Toolbar(children=[ToolbarTitle(children=['ibmq_ourense @ (ibm-q/open/main)'], style_='color:whi…"
+       "Card(children=[Toolbar(children=[ToolbarTitle(children=['ibmq_belem @ (ibm-q/open/main)'], style_='color:whi…"
       ]
      },
      "metadata": {},
@@ -293,7 +293,7 @@
     {
      "data": {
       "text/plain": [
-       "<IBMQBackend('ibmq_ourense') from IBMQ(hub='ibm-q', group='open', project='main')>"
+       "<IBMQBackend('ibmq_belem') from IBMQ(hub='ibm-q', group='open', project='main')>"
       ]
      },
      "execution_count": 8,
@@ -325,8 +325,8 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.20.0</td></tr><tr><td>Terra</td><td>0.15.1</td></tr><tr><td>Aer</td><td>0.6.1</td></tr><tr><td>Ignis</td><td>0.4.0</td></tr><tr><td>Aqua</td><td>0.7.5</td></tr><tr><td>IBM Q Provider</td><td>0.8.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.1 (default, Jul 15 2020, 18:48:27) \n",
-       "[Clang 11.0.3 (clang-1103.0.32.62)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Sep 04 10:29:29 2020 EDT</td></tr></table>"
+        "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.27.0</td></tr><tr><td>Terra</td><td>0.17.4</td></tr><tr><td>Aer</td><td>0.8.2</td></tr><tr><td>Ignis</td><td>0.6.0</td></tr><tr><td>Aqua</td><td>0.9.2</td></tr><tr><td>IBM Q Provider</td><td>0.14.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05) \n",
+        "[GCC 9.3.0]</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>31.40896224975586</td></tr><tr><td colspan='2'>Thu Jul 08 16:31:08 2021 UTC</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove references to retired backends from tutorials. (Rome, Athens, Melbourne, Ourense, etc. have been retired).


### Details and comments
Fixes #987 

