### PR TITLE
Fix runtime parameter namespace issue

### DIFF
--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -229,7 +229,7 @@ class IBMRuntimeService:
         # If using params object, extract as dictionary
         if isinstance(inputs, ParameterNamespace):
             inputs.validate()
-            inputs = dict(inputs)
+            inputs = vars(inputs)
 
         backend_name = options['backend_name']
         params_str = json.dumps(inputs, cls=RuntimeEncoder)

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -320,6 +320,14 @@ if __name__ == '__main__':
             params.validate()
         params.param1 = 'foo'
 
+    def test_program_params_namespace(self):
+        """Test running a program using parameter namespace."""
+        program_id = self.runtime.upload_program(
+            data="foo".encode(), metadata=self.DEFAULT_METADATA)
+        params = self.runtime.program(program_id).parameters()
+        params.param1 = "Hello World"
+        self._run_program(program_id, inputs=params)
+
     def test_run_program_failed(self):
         """Test a failed program execution."""
         job = self._run_program(job_classes=FailedRuntimeJob)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#950 Added `ParameterNamespace` that allows auto-completion of runtime program parameters. However, it used `dict()` to convert `ParameterNamespace` to a dictionary, which would raise a `TypeError`. This PR updates the code to use `vars()` instead. 


### Details and comments


