### PR TITLE
fix incorrect variable name in tutorial

### DIFF
--- a/docs/tutorials/2_jupyter_tools.ipynb
+++ b/docs/tutorials/2_jupyter_tools.ipynb
@@ -202,7 +202,7 @@
     "qc.cx(0, 1)\n",
     "qc.measure([0,1], [0,1])\n",
     "\n",
-    "mapped_circuit = transpile(circuit, backend=backend)\n",
+    "mapped_circuit = transpile(qc, backend=backend)\n",
     "job = backend.run(mapped_circuit, shots=1024)"
    ]
   },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix incorrect variable name in tutorial caused due to a copy paste error in #994.


### Details and comments
Fixes #1003 

