### PR TITLE
Remove validate_qobj parameter from IBMQBackend.run()

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -201,6 +201,9 @@ class IBMQBackend(Backend):
                 as a filter in the :meth:`jobs()` function call.
             experiment_id: Used to add a job to an "experiment", which is a collection
                 of jobs and additional metadata.
+
+            The following arguments are NOT applicable if a Qobj is passed in.
+
             header: User input that will be attached to the job and will be
                 copied to the corresponding result header. Headers do not affect the run.
                 This replaces the old ``Qobj`` header.

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -24,7 +24,7 @@ from qiskit.circuit import QuantumCircuit, Parameter, Delay
 from qiskit.circuit.duration import duration_in_dt
 from qiskit.pulse import Schedule, LoConfig
 from qiskit.pulse.channels import PulseChannel
-from qiskit.qobj import QasmQobj, PulseQobj, validate_qobj_against_schema
+from qiskit.qobj import QasmQobj, PulseQobj
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.providers.backend import BackendV1 as Backend
 from qiskit.providers.options import Options
@@ -153,7 +153,6 @@ class IBMQBackend(Backend):
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
             experiment_id: Optional[str] = None,
-            validate_qobj: bool = None,
             header: Optional[Dict] = None,
             shots: Optional[int] = None,
             memory: Optional[bool] = None,
@@ -202,11 +201,6 @@ class IBMQBackend(Backend):
                 as a filter in the :meth:`jobs()` function call.
             experiment_id: Used to add a job to an "experiment", which is a collection
                 of jobs and additional metadata.
-            validate_qobj: DEPRECATED. If ``True``, run JSON schema validation against the
-                submitted payload. Only applicable if a Qobj is passed in.
-
-            The following arguments are NOT applicable if a Qobj is passed in.
-
             header: User input that will be attached to the job and will be
                 copied to the corresponding result header. Headers do not affect the run.
                 This replaces the old ``Qobj`` header.
@@ -326,14 +320,6 @@ class IBMQBackend(Backend):
                 run_config_dict['method'] = sim_method
             qobj = assemble(circuits, self, **run_config_dict)
 
-        if validate_qobj is not None:
-            warnings.warn("The `validate_qobj` keyword is deprecated and will "
-                          "be removed in a future release. "
-                          "You can pull the schemas from the Qiskit/ibmq-schemas "
-                          "repo and directly validate your payloads with that.",
-                          DeprecationWarning, stacklevel=3)
-            if validate_qobj:
-                validate_qobj_against_schema(qobj)
         return self._submit_job(qobj, job_name, job_tags, experiment_id)
 
     def _get_run_config(self, **kwargs: Any) -> Dict:
@@ -865,7 +851,6 @@ class IBMQSimulator(IBMQBackend):
             job_share_level: Optional[str] = None,
             job_tags: Optional[List[str]] = None,
             experiment_id: Optional[str] = None,
-            validate_qobj: bool = None,
             backend_options: Optional[Dict] = None,
             noise_model: Any = None,
             **kwargs: Dict
@@ -888,8 +873,6 @@ class IBMQSimulator(IBMQBackend):
                 as a filter in the :meth:`IBMQBackend.jobs()<IBMQBackend.jobs>` method.
             experiment_id: Used to add a job to an "experiment", which is a collection
                 of jobs and additional metadata.
-            validate_qobj: DEPRECATED. If ``True``, run JSON schema validation against the
-                submitted payload.
             backend_options: DEPRECATED dictionary of backend options for the execution.
             noise_model: Noise model.
             kwargs: Additional runtime configuration options. They take
@@ -919,7 +902,6 @@ class IBMQSimulator(IBMQBackend):
         run_config.update(kwargs)
         return super().run(circuits, job_name=job_name,
                            job_tags=job_tags, experiment_id=experiment_id,
-                           validate_qobj=validate_qobj,
                            noise_model=noise_model, **run_config)
 
 

--- a/releasenotes/notes/short-description-string-57a52d3158cb3abd.yaml
+++ b/releasenotes/notes/short-description-string-57a52d3158cb3abd.yaml
@@ -1,5 +1,5 @@
 ---
 upgrade:
   - |
-    :meth:`qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run` no longer
+    :meth:`qiskit.providers.ibmq.IBMQBackend.run` no longer
     accepts `validate_qobj` as a parameter.

--- a/releasenotes/notes/short-description-string-57a52d3158cb3abd.yaml
+++ b/releasenotes/notes/short-description-string-57a52d3158cb3abd.yaml
@@ -3,3 +3,6 @@ upgrade:
   - |
     :meth:`qiskit.providers.ibmq.IBMQBackend.run` no longer
     accepts `validate_qobj` as a parameter.
+    If you were relying on this schema validation you should pull the schemas
+    from the `Qiskit/ibm-quantum-schemas <https://github.com/Qiskit/ibm-quantum-schemas>`_
+    and directly validate your payloads with that.

--- a/releasenotes/notes/short-description-string-57a52d3158cb3abd.yaml
+++ b/releasenotes/notes/short-description-string-57a52d3158cb3abd.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    :meth:`qiskit.providers.ibmq.ibmqbackend.IBMQBackend.run` no longer
+    accepts `validate_qobj` as a parameter.

--- a/test/ibmq/test_ibmq_job.py
+++ b/test/ibmq/test_ibmq_job.py
@@ -55,7 +55,7 @@ class TestIBMQJob(IBMQTestCase):
         cls.provider = provider
         cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
         cls.bell = transpile(ReferenceCircuits.bell(), cls.sim_backend)
-        cls.sim_job = cls.sim_backend.run(cls.bell, validate_qobj=True)
+        cls.sim_job = cls.sim_backend.run(cls.bell)
         cls.last_month = datetime.now() - timedelta(days=30)
 
     @slow_test
@@ -64,7 +64,7 @@ class TestIBMQJob(IBMQTestCase):
         """Test running in a real device."""
         shots = 8192
         job = backend.run(transpile(ReferenceCircuits.bell(), backend=backend),
-                          validate_qobj=True, shots=shots)
+                          shots=shots)
 
         job.wait_for_final_state(wait=300, callback=self.simple_job_callback)
         result = job.result()
@@ -86,7 +86,7 @@ class TestIBMQJob(IBMQTestCase):
             qc.cx(qr[i], qr[i + 1])
         qc.measure(qr, cr)
         num_jobs = 5
-        job_array = [self.sim_backend.run(transpile([qc] * 20), validate_qobj=True, shots=2048)
+        job_array = [self.sim_backend.run(transpile([qc] * 20), shots=2048)
                      for _ in range(num_jobs)]
         timeout = 30
         start_time = time.time()
@@ -133,7 +133,7 @@ class TestIBMQJob(IBMQTestCase):
             qc.cx(qr[i], qr[i + 1])
         qc.measure(qr, cr)
         num_jobs = 3
-        job_array = [backend.run(transpile(qc, backend=backend), validate_qobj=True)
+        job_array = [backend.run(transpile(qc, backend=backend))
                      for _ in range(num_jobs)]
         time.sleep(3)  # give time for jobs to start (better way?)
         job_status = [job.status() for job in job_array]
@@ -205,8 +205,8 @@ class TestIBMQJob(IBMQTestCase):
         if not backend_2:
             raise SkipTest('Skipping test that requires multiple backends')
 
-        job_1 = backend_1.run(transpile(ReferenceCircuits.bell(), backend_1), validate_qobj=True)
-        job_2 = backend_2.run(transpile(ReferenceCircuits.bell(), backend_2), validate_qobj=True)
+        job_1 = backend_1.run(transpile(ReferenceCircuits.bell(), backend_1))
+        job_2 = backend_2.run(transpile(ReferenceCircuits.bell(), backend_2))
 
         # test a retrieved job's backend is the same as the queried backend
         self.assertEqual(backend_1.retrieve_job(job_1.job_id()).backend().name(),
@@ -583,8 +583,7 @@ class TestIBMQJob(IBMQTestCase):
     def test_wait_for_final_state_timeout(self):
         """Test waiting for job to reach final state times out."""
         backend = most_busy_backend(self.provider)
-        job = backend.run(transpile(ReferenceCircuits.bell(), backend=backend),
-                          validate_qobj=True)
+        job = backend.run(transpile(ReferenceCircuits.bell(), backend=backend))
         try:
             self.assertRaises(IBMQJobTimeoutError, job.wait_for_final_state, timeout=0.1)
         finally:

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -113,8 +113,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
         # TODO Use circuit metadata for individual header when terra PR-5270 is released.
         # qobj.experiments[0].header.some_field = 'extra info'
 
-        job = backend.run(transpile(self.qc1, backend=backend),
-                          validate_qobj=True, qobj_header=custom_qobj_header)
+        job = backend.run(transpile(self.qc1, backend=backend), qobj_header=custom_qobj_header)
         job.wait_for_final_state(wait=300, callback=self.simple_job_callback)
         result = job.result()
         self.assertTrue(custom_qobj_header.items() <= job.header().items())

--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -113,8 +113,7 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         circuit.measure(qr[0], cr[0])
         circuit.x(qr[0]).c_if(cr, 1)
 
-        result = self.sim_backend.run(transpile(circuit, backend=self.sim_backend),
-                                      validate_qobj=True).result()
+        result = self.sim_backend.run(transpile(circuit, backend=self.sim_backend)).result()
         self.assertEqual(result.get_counts(circuit), {'0001': 1024})
 
     def test_new_sim_method(self):

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -156,7 +156,7 @@ class TestWebsocketIntegration(IBMQTestCase):
         """Test timeout checking status of a job via websockets."""
         backend = most_busy_backend(self.provider)
         job = backend.run(transpile(ReferenceCircuits.bell(), backend),
-                          validate_qobj=True, shots=backend.configuration().max_shots)
+                          shots=backend.configuration().max_shots)
 
         try:
             with self.assertRaises(JobTimeoutError):

--- a/test/ibmq/websocket/test_websocket_integration.py
+++ b/test/ibmq/websocket/test_websocket_integration.py
@@ -72,8 +72,7 @@ class TestWebsocketIntegration(IBMQTestCase):
     @requires_device
     def test_websockets_device(self, backend):
         """Test checking status of a job via websockets for a device."""
-        job = backend.run(transpile(ReferenceCircuits.bell(), backend),
-                          validate_qobj=True, shots=1)
+        job = backend.run(transpile(ReferenceCircuits.bell(), backend), shots=1)
 
         # Manually disable the non-websocket polling.
         job._api_client._job_final_status_polling = self._job_final_status_polling


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Validation is being changed in Qiskit Terra. References in Qiskit Provider need to be removed.

### Details and comments

## Fixes #1004 

- Removes the validation step, coming from `validate_qobj` in `IBMQBackend`
