### PR TITLE
Fix decoding of the `QNSPSA` optimizer

### DIFF
--- a/qiskit/providers/ibmq/runtime/utils.py
+++ b/qiskit/providers/ibmq/runtime/utils.py
@@ -177,6 +177,8 @@ class RuntimeDecoder(json.JSONDecoder):
             if obj_type == 'Instruction':
                 return _decode_and_deserialize(
                     obj_val, qpy_serialization._read_instruction, False)
+            if obj_type == 'settings' and obj['__class__'] == 'QNSPSA':
+                obj_val.update({'fidelity': _placeholder_callable})
             if obj_type == 'settings':
                 return deserialize_from_settings(
                     mod_name=obj['__module__'],
@@ -190,3 +192,8 @@ class RuntimeDecoder(json.JSONDecoder):
             if obj_type == 'to_json':
                 return obj_val
         return obj
+
+
+def _placeholder_callable(self):
+    raise RuntimeError('This is a placeholder callable for deserialization. Please set it to '
+                       'an appropriate value before usage.')

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -29,6 +29,7 @@ from qiskit.algorithms.optimizers import (
     ADAM,
     GSLS,
     IMFIL,
+    QNSPSA,
     SPSA,
     SNOBFIT,
     L_BFGS_B,
@@ -192,6 +193,7 @@ class TestRuntime(IBMQTestCase):
             (GSLS, {"maxiter": 50, "min_step_size": 0.01}),
             (IMFIL, {"maxiter": 20}),
             (SPSA, {"maxiter": 10, "learning_rate": 0.01, "perturbation": 0.1}),
+            (QNSPSA, {"fidelity": lambda: 0, "maxiter": 25, "resamplings": {1: 100, 2: 50}}),
             (SNOBFIT, {"maxiter": 200, "maxfail": 20}),
             # some SciPy optimizers only work with default arguments due to Qiskit/qiskit-terra#6682
             (L_BFGS_B, {}),
@@ -204,6 +206,12 @@ class TestRuntime(IBMQTestCase):
                 self.assertIsInstance(encoded, str)
                 decoded = json.loads(encoded, cls=RuntimeDecoder)
                 self.assertTrue(isinstance(decoded, opt_cls))
+
+                # cannot serialize fidelity for QNSPSA, this is replaced by a placeholder in
+                # deserialization
+                if opt_cls == QNSPSA:
+                    settings.pop("fidelity")
+
                 for key, value in settings.items():
                     self.assertEqual(decoded.settings[key], value)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Decoding the QNSPSA optimizer fails due to the missing non-serializable first argument.
This commits fixes decoding by adding a placeholder for that argument which must be replaced by the user after decoding.

### Details and comments

Currently the tests fail since one of the settings is a dictionary with integer-keys which gets decoded into a string-keys dictionary. The optimizer will not recognize these string keys. Is this transformation on purpose or can we adapt it such that integers remain integers?

