### PR TITLE
Convert callable to None in RuntimeEncoder

### DIFF
--- a/qiskit/providers/ibmq/runtime/utils.py
+++ b/qiskit/providers/ibmq/runtime/utils.py
@@ -21,6 +21,7 @@ import io
 import zlib
 import inspect
 import importlib
+import warnings
 
 import numpy as np
 try:
@@ -145,6 +146,9 @@ class RuntimeEncoder(json.JSONEncoder):
                     '__module__': obj.__class__.__module__,
                     '__class__': obj.__class__.__name__,
                     '__value__': obj.settings}
+        if callable(obj):
+            warnings.warn(f"Callable {obj} is not JSON serializable and will be set to None.")
+            return None
         if HAS_SCIPY and isinstance(obj, scipy.sparse.spmatrix):
             value = _serialize_and_encode(obj, scipy.sparse.save_npz, compress=False)
             return {'__type__': 'spmatrix', '__value__': value}

--- a/releasenotes/notes/runtime-callable-2975b737e8fa2542.yaml
+++ b/releasenotes/notes/runtime-callable-2975b737e8fa2542.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    :class:`qiskit.providers.ibmq.runtime.utils.RuntimeEncoder` now convert a
+    callable object to ``None``, since callables are not JSON serializable.

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -22,6 +22,7 @@ import time
 import random
 import subprocess
 import tempfile
+import warnings
 
 import numpy as np
 import scipy.sparse
@@ -206,6 +207,14 @@ class TestRuntime(IBMQTestCase):
                 self.assertTrue(isinstance(decoded, opt_cls))
                 for key, value in settings.items():
                     self.assertEqual(decoded.settings[key], value)
+
+    def test_encoder_callable(self):
+        """Test encoding a callable."""
+        with warnings.catch_warnings(record=True) as warn_cm:
+            encoded = json.dumps({"fidelity": lambda x: x}, cls=RuntimeEncoder)
+            decoded = json.loads(encoded, cls=RuntimeDecoder)
+            self.assertIsNone(decoded["fidelity"])
+            self.assertEqual(len(warn_cm), 1)
 
     def test_decoder_import(self):
         """Test runtime decoder importing modules."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Related to #1014. QNSPSA has a `fidelity` attribute that may be set to a callable. This PR updates `RuntimeEncoder` to convert that to `None`, with a warning, to make it more tolerant. 


### Details and comments


