### PR TITLE
Fix experiment-integration run command

### DIFF
--- a/.github/workflows/cron-staging.yml
+++ b/.github/workflows/cron-staging.yml
@@ -62,4 +62,4 @@ jobs:
           pip install -U -c constraints.txt -r requirements-dev.txt
           pip install -c constraints.txt -e .
       - name: Run Tests
-        run: make runtime_integration
+        run: make experiment_integration


### PR DESCRIPTION

### Summary

The experiment integration job is using the wrong make entry,
probably due to a copy/paste error.

### Details and comments

Follow up to #945

