### PR TITLE
Add encoder to experiment create/update

### DIFF
--- a/qiskit/providers/ibmq/api/clients/experiment.py
+++ b/qiskit/providers/ibmq/api/clients/experiment.py
@@ -105,7 +105,7 @@ class ExperimentClient(BaseClient):
         """
         return self.base_api.experiment(experiment_id).retrieve()
 
-    def experiment_upload(self, data: Dict) -> Dict:
+    def experiment_upload(self, data: str) -> Dict:
         """Upload an experiment.
 
         Args:
@@ -116,7 +116,7 @@ class ExperimentClient(BaseClient):
         """
         return self.base_api.experiment_upload(data)
 
-    def experiment_update(self, experiment_id: str, new_data: Dict) -> Dict:
+    def experiment_update(self, experiment_id: str, new_data: str) -> Dict:
         """Update an experiment.
 
         Args:
@@ -260,7 +260,7 @@ class ExperimentClient(BaseClient):
         )
         return resp
 
-    def analysis_result_upload(self, result: Dict) -> Dict:
+    def analysis_result_upload(self, result: str) -> Dict:
         """Upload an analysis result.
 
         Args:
@@ -271,7 +271,7 @@ class ExperimentClient(BaseClient):
         """
         return self.base_api.analysis_result_upload(result)
 
-    def analysis_result_update(self, result_id: str, new_data: Dict) -> Dict:
+    def analysis_result_update(self, result_id: str, new_data: str) -> Dict:
         """Update an analysis result.
 
         Args:

--- a/qiskit/providers/ibmq/api/rest/analysis_result.py
+++ b/qiskit/providers/ibmq/api/rest/analysis_result.py
@@ -39,7 +39,7 @@ class AnalysisResult(RestAdapterBase):
         self.url_prefix = '{}/analysis_results/{}'.format(url_prefix, result_uuid)
         super().__init__(session, self.url_prefix)
 
-    def update(self, analysis_result: Dict) -> Dict:
+    def update(self, analysis_result: str) -> Dict:
         """Update the analysis result.
 
         Args:
@@ -49,7 +49,8 @@ class AnalysisResult(RestAdapterBase):
             JSON response.
         """
         url = self.get_url('self')
-        return self.session.put(url, json=analysis_result).json()
+        return self.session.put(url, data=analysis_result,
+                                headers=self._HEADER_JSON_CONTENT).json()
 
     def delete(self) -> Dict:
         """Delete the analysis result.

--- a/qiskit/providers/ibmq/api/rest/base.py
+++ b/qiskit/providers/ibmq/api/rest/base.py
@@ -21,6 +21,8 @@ class RestAdapterBase:
     URL_MAP = {}  # type: ignore[var-annotated]
     """Mapping between the internal name of an endpoint and the actual URL."""
 
+    _HEADER_JSON_CONTENT = {'Content-Type': 'application/json'}
+
     def __init__(self, session: RetrySession, prefix_url: str = '') -> None:
         """RestAdapterBase constructor.
 

--- a/qiskit/providers/ibmq/api/rest/experiment.py
+++ b/qiskit/providers/ibmq/api/rest/experiment.py
@@ -48,7 +48,7 @@ class Experiment(RestAdapterBase):
         url = self.get_url('self')
         return self.session.get(url).text
 
-    def update(self, experiment: Dict) -> Dict:
+    def update(self, experiment: str) -> Dict:
         """Update the experiment.
 
         Args:
@@ -58,7 +58,7 @@ class Experiment(RestAdapterBase):
             JSON response.
         """
         url = self.get_url('self')
-        return self.session.put(url, json=experiment).json()
+        return self.session.put(url, data=experiment, headers=self._HEADER_JSON_CONTENT).json()
 
     def delete(self) -> Dict:
         """Delete the experiment.

--- a/qiskit/providers/ibmq/api/rest/root.py
+++ b/qiskit/providers/ibmq/api/rest/root.py
@@ -231,17 +231,18 @@ class Api(RestAdapterBase):
         raw_data = self.session.get(url).json()
         return raw_data
 
-    def experiment_upload(self, experiment: Dict) -> Dict:
+    def experiment_upload(self, experiment: str) -> Dict:
         """Upload an experiment.
 
         Args:
-            experiment: The experiment to upload.
+            experiment: The experiment data to upload.
 
         Returns:
             JSON response.
         """
         url = self.get_url('experiments')
-        raw_data = self.session.post(url, json=experiment).json()
+        raw_data = self.session.post(url, data=experiment,
+                                     headers=self._HEADER_JSON_CONTENT).json()
         return raw_data
 
     def analysis_results(
@@ -298,7 +299,7 @@ class Api(RestAdapterBase):
             params['sort'] = sort_by
         return self.session.get(url, params=params).text
 
-    def analysis_result_upload(self, result: Dict) -> Dict:
+    def analysis_result_upload(self, result: str) -> Dict:
         """Upload an analysis result.
 
         Args:
@@ -308,7 +309,7 @@ class Api(RestAdapterBase):
             JSON response.
         """
         url = self.get_url('analysis_results')
-        return self.session.post(url, json=result).json()
+        return self.session.post(url, data=result, headers=self._HEADER_JSON_CONTENT).json()
 
     def device_components(self, backend_name: Optional[str] = None) -> Dict:
         """Return a list of device components for the backend.

--- a/qiskit/providers/ibmq/experiment/ibm_experiment_service.py
+++ b/qiskit/providers/ibmq/experiment/ibm_experiment_service.py
@@ -118,6 +118,7 @@ class IBMExperimentService:
             notes: Optional[str] = None,
             share_level: Optional[Union[str, ExperimentShareLevel]] = None,
             start_datetime: Optional[Union[str, datetime]] = None,
+            json_encoder: Type[json.JSONEncoder] = json.JSONEncoder,
             **kwargs: Any
     ) -> str:
         """Create a new experiment in the database.
@@ -141,6 +142,7 @@ class IBMExperimentService:
                 - hub: The experiment is shared within its hub
                 - public: The experiment is shared publicly regardless of provider
             start_datetime: Timestamp when the experiment started, in local time zone.
+            json_encoder: Custom JSON encoder to use to encode the experiment.
             kwargs: Additional experiment attributes that are not supported and will be ignored.
 
         Returns:
@@ -172,7 +174,7 @@ class IBMExperimentService:
                                                  start_dt=start_datetime))
 
         with map_api_error(f"Experiment {experiment_id} already exists."):
-            response_data = self._api_client.experiment_upload(data)
+            response_data = self._api_client.experiment_upload(json.dumps(data, cls=json_encoder))
         return response_data['uuid']
 
     def update_experiment(
@@ -184,6 +186,7 @@ class IBMExperimentService:
             tags: Optional[List[str]] = None,
             share_level: Optional[Union[str, ExperimentShareLevel]] = None,
             end_datetime: Optional[Union[str, datetime]] = None,
+            json_encoder: Type[json.JSONEncoder] = json.JSONEncoder,
             **kwargs: Any,
     ) -> None:
         """Update an existing experiment.
@@ -205,6 +208,7 @@ class IBMExperimentService:
                 - public: The experiment is shared publicly regardless of provider
 
             end_datetime: Timestamp for when the experiment ended, in local time.
+            json_encoder: Custom JSON encoder to use to encode the experiment.
             kwargs: Additional experiment attributes that are not supported and will be ignored.
 
         Raises:
@@ -228,7 +232,7 @@ class IBMExperimentService:
             return
 
         with map_api_error(f"Experiment {experiment_id} not found."):
-            self._api_client.experiment_update(experiment_id, data)
+            self._api_client.experiment_update(experiment_id, json.dumps(data, cls=json_encoder))
 
     def _experiment_data_to_api(
             self,
@@ -572,6 +576,7 @@ class IBMExperimentService:
             verified: bool = False,
             result_id: Optional[str] = None,
             chisq: Optional[float] = None,
+            json_encoder: Type[json.JSONEncoder] = json.JSONEncoder,
             **kwargs: Any,
     ) -> str:
         """Create a new analysis result in the database.
@@ -587,6 +592,7 @@ class IBMExperimentService:
             result_id: Analysis result ID. It must be in the ``uuid4`` format.
                 One will be generated if not supplied.
             chisq: chi^2 decimal value of the fit.
+            json_encoder: Custom JSON encoder to use to encode the analysis result.
             kwargs: Additional analysis result attributes that are not supported
                 and will be ignored.
 
@@ -625,7 +631,8 @@ class IBMExperimentService:
             chisq=chisq
         )
         with map_api_error(f"Analysis result {result_id} already exists."):
-            response = self._api_client.analysis_result_upload(request)
+            response = self._api_client.analysis_result_upload(
+                json.dumps(request, cls=json_encoder))
         return response['uuid']
 
     def update_analysis_result(
@@ -636,6 +643,7 @@ class IBMExperimentService:
             quality: Union[ResultQuality, str] = None,
             verified: bool = None,
             chisq: Optional[float] = None,
+            json_encoder: Type[json.JSONEncoder] = json.JSONEncoder,
             **kwargs: Any,
     ) -> None:
         """Update an existing analysis result.
@@ -647,6 +655,7 @@ class IBMExperimentService:
             verified: Whether the result quality has been verified.
             tags: Tags to be associated with the analysis result.
             chisq: chi^2 decimal value of the fit.
+            json_encoder: Custom JSON encoder to use to encode the analysis result.
             kwargs: Additional analysis result attributes that are not supported
                 and will be ignored.
 
@@ -669,7 +678,8 @@ class IBMExperimentService:
                                                verified=verified,
                                                chisq=chisq)
         with map_api_error(f"Analysis result {result_id} not found."):
-            self._api_client.analysis_result_update(result_id, request)
+            self._api_client.analysis_result_update(
+                result_id, json.dumps(request, cls=json_encoder))
 
     def _analysis_result_to_api(
             self,

--- a/test/ibmq/experiment/test_experiment_data_integration.py
+++ b/test/ibmq/experiment/test_experiment_data_integration.py
@@ -53,7 +53,6 @@ class TestExperimentDataIntegration(IBMQTestCase):
         if not cls.provider.has_service('experiment'):
             raise SkipTest("Not authorized to use experiment service.")
 
-        # cls.backend = cls._setup_backend()  # pylint: disable=no-value-for-parameter
         cls.backend = cls.provider.get_backend('ibmq_qasm_simulator')
         cls.device_components = cls.provider.experiment.device_components(cls.backend.name())
         if not cls.device_components:

--- a/test/ibmq/experiment/test_experiment_server_integration.py
+++ b/test/ibmq/experiment/test_experiment_server_integration.py
@@ -20,6 +20,7 @@ from typing import Optional, Dict, Any
 import re
 
 from dateutil import tz
+import numpy as np
 
 from qiskit.providers.ibmq.experiment.constants import ExperimentShareLevel
 from qiskit.providers.ibmq.exceptions import IBMQNotAuthorizedError
@@ -28,6 +29,7 @@ from qiskit.providers.ibmq.experiment import (ResultQuality,
 
 from ...ibmqtestcase import IBMQTestCase
 from ...decorators import requires_provider
+from .utils import ExperimentEncoder, ExperimentDecoder
 
 
 @skipIf(not os.environ.get('USE_STAGING_CREDENTIALS', ''), "Only runs on staging")
@@ -962,6 +964,43 @@ class TestExperimentServerIntegration(IBMQTestCase):
         self.assertRaises(IBMExperimentEntryNotFound,
                           self.provider.experiment.figure, expr_id, figure_name)
 
+    def test_experiment_coders(self):
+        """Test custom encoder and decoder for an experiment."""
+        metadata = {"complex": 2 + 3j, "numpy": np.zeros(2)}
+        expr_id = self._create_experiment(metadata=metadata, json_encoder=ExperimentEncoder)
+        rexp = self.provider.experiment.experiment(expr_id, json_decoder=ExperimentDecoder)
+        rmetadata = rexp["metadata"]
+        self.assertEqual(metadata["complex"], rmetadata["complex"])
+        self.assertTrue((metadata["numpy"] == rmetadata["numpy"]).all())
+
+        new_metadata = {"complex": 4 + 5j, "numpy": np.ones(3)}
+        self.provider.experiment.update_experiment(
+            expr_id, metadata=new_metadata, json_encoder=ExperimentEncoder)
+        rexp = self.provider.experiment.experiment(expr_id, json_decoder=ExperimentDecoder)
+        rmetadata = rexp["metadata"]
+        self.assertEqual(new_metadata["complex"], rmetadata["complex"])
+        self.assertTrue((new_metadata["numpy"] == rmetadata["numpy"]).all())
+
+    def test_analysis_result_coders(self):
+        """Test custom encoder and decoder for an analysis result."""
+        data = {"complex": 2 + 3j, "numpy": np.zeros(2)}
+        result_id = self._create_analysis_result(
+            result_data=data, json_encoder=ExperimentEncoder)
+        rresult = self.provider.experiment.analysis_result(
+            result_id, json_decoder=ExperimentDecoder)
+        rdata = rresult["result_data"]
+        self.assertEqual(data["complex"], rdata["complex"])
+        self.assertTrue((data["numpy"] == rdata["numpy"]).all())
+
+        new_data = {"complex": 4 + 5j, "numpy": np.ones(3)}
+        self.provider.experiment.update_analysis_result(
+            result_id, result_data=new_data, json_encoder=ExperimentEncoder)
+        rresult = self.provider.experiment.analysis_result(
+            result_id, json_decoder=ExperimentDecoder)
+        rdata = rresult["result_data"]
+        self.assertEqual(new_data["complex"], rdata["complex"])
+        self.assertTrue((new_data["numpy"] == rdata["numpy"]).all())
+
     def _create_experiment(
             self,
             experiment_type: Optional[str] = None,
@@ -983,15 +1022,15 @@ class TestExperimentServerIntegration(IBMQTestCase):
             self,
             exp_id: Optional[str] = None,
             result_type: Optional[str] = None,
-            data: Optional[Dict] = None,
+            result_data: Optional[Dict] = None,
             **kwargs: Any):
         """Create a simple analysis result."""
         experiment_id = exp_id or self._create_experiment()
         result_type = result_type or "qiskit_test"
-        data = data or {}
+        result_data = result_data or {}
         aresult_id = self.provider.experiment.create_analysis_result(
             experiment_id=experiment_id,
-            result_data=data,
+            result_data=result_data,
             result_type=result_type,
             **kwargs
         )

--- a/test/ibmq/experiment/utils.py
+++ b/test/ibmq/experiment/utils.py
@@ -1,0 +1,49 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=method-hidden
+
+"""Utility functions for experiment testing."""
+
+from typing import Any
+import json
+
+import numpy as np
+
+
+class ExperimentEncoder(json.JSONEncoder):
+    """A test json encoder for experiments"""
+
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, complex):
+            return {'__type__': 'complex', '__value__': [obj.real, obj.imag]}
+        if hasattr(obj, 'tolist'):
+            return {'__type__': 'array', '__value__': obj.tolist()}
+
+        return json.JSONEncoder.default(self, obj)
+
+
+class ExperimentDecoder(json.JSONDecoder):
+    """JSON Decoder for Numpy arrays and complex numbers."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, obj):
+        """Object hook."""
+        if "__type__" in obj:
+            if obj["__type__"] == "complex":
+                val = obj["__value__"]
+                return val[0] + 1j * val[1]
+            if obj["__type__"] == "array":
+                return np.array(obj["__value__"])
+        return obj

--- a/test/ibmq/experiment/utils.py
+++ b/test/ibmq/experiment/utils.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 # pylint: disable=method-hidden
+# pylint: disable=arguments-differ
 
 """Utility functions for experiment testing."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds a `json_encoder` parameter to create/update experiment/analysis result. This allows the caller to pass in a custom encoder, instead of having to do something weird like 
```
metadata = json.loads(json.dumps(self._metadata, cls=MyEncoder))
```

### Details and comments


