### PR TITLE
Fix Optimizer Conversion Issue (Integer Keys)

### DIFF
--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -31,6 +31,7 @@ from qiskit.algorithms.optimizers import (
     GSLS,
     IMFIL,
     SPSA,
+    QNSPSA,
     SNOBFIT,
     L_BFGS_B,
     NELDER_MEAD,
@@ -139,6 +140,20 @@ class TestRuntime(IBMQTestCase):
                     decoded = [decoded]
                 self.assertTrue(all(isinstance(item, QuantumCircuit) for item in decoded))
 
+    def test_coder_on_integer_dicts(self):
+        """Test runtime encoder and decoder on integer keys."""
+        subtests = (
+            ({1: 23, 4: 56}, True),
+            ({'1': 23, '4': 56}, False)
+        )
+
+        for obj, use_int_keys in subtests:
+            encoded = json.dumps(obj, cls=RuntimeEncoder)
+            self.assertIsInstance(encoded, str)
+            RuntimeDecoder.USE_INT_KEYS = use_int_keys
+            decoded = json.loads(encoded, cls=RuntimeDecoder)
+            self.assertEqual(decoded, obj)
+
     def test_coder_operators(self):
         """Test runtime encoder and decoder for operators."""
         x = Parameter("x")
@@ -178,6 +193,7 @@ class TestRuntime(IBMQTestCase):
             TensoredOp([(X ^ Y), (Z ^ I)]),
             (Z ^ Z) ^ (I ^ 2),
         )
+        RuntimeDecoder.USE_INT_KEYS = False
         for op in subtests:
             with self.subTest(op=op):
                 encoded = json.dumps(op, cls=RuntimeEncoder)
@@ -187,17 +203,19 @@ class TestRuntime(IBMQTestCase):
 
     @skipIf(os.name == 'nt', 'Test not supported on Windows')
     def test_coder_optimizers(self):
-        """Test runtime encoder and decoder for circuits."""
+        """Test runtime encoder and decoder for optimizers."""
         subtests = (
             (ADAM, {"maxiter": 100, "amsgrad": True}),
             (GSLS, {"maxiter": 50, "min_step_size": 0.01}),
             (IMFIL, {"maxiter": 20}),
             (SPSA, {"maxiter": 10, "learning_rate": 0.01, "perturbation": 0.1}),
             (SNOBFIT, {"maxiter": 200, "maxfail": 20}),
+            (QNSPSA, {"fidelity": lambda: 123, "maxiter": 25, "resamplings": {1: 100, 2: 50}}),
             # some SciPy optimizers only work with default arguments due to Qiskit/qiskit-terra#6682
             (L_BFGS_B, {}),
             (NELDER_MEAD, {}),
         )
+        RuntimeDecoder.USE_INT_KEYS = True
         for opt_cls, settings in subtests:
             with self.subTest(opt_cls=opt_cls):
                 optimizer = opt_cls(**settings)
@@ -205,8 +223,11 @@ class TestRuntime(IBMQTestCase):
                 self.assertIsInstance(encoded, str)
                 decoded = json.loads(encoded, cls=RuntimeDecoder)
                 self.assertTrue(isinstance(decoded, opt_cls))
+                if settings.get('fidelity'):
+                    settings.pop('fidelity')
                 for key, value in settings.items():
                     self.assertEqual(decoded.settings[key], value)
+        RuntimeDecoder.USE_INT_KEYS = False
 
     def test_encoder_callable(self):
         """Test encoding a callable."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There are optimizers (notably `QNSPSA`) that use integer keys in their json. This creates serialization issues because Python's built-in `json` module forces conversion to strings. 

### Fixes #1016 

- Adds `QNSPSA` to optimizer encoding/decoding tests
- Adds toggle-able `USE_INT_KEYS` setting to `RuntimeDecoder` to accommodate integer keys
- Fixes issue with `fidelity` property of `QNSPSA` until [fixed in Terra](https://github.com/Qiskit/qiskit-ibmq-provider/pull/1014#issuecomment-887006511).

### Details and comments

⚠️ It appears all instances of serializing optimizers in this repo exist in `test_runtime.py`. If they are serialized in other repos (i.e Terra) using the `RuntimeDecoder` defined in this repo, those instances must also toggle the `USE_INT_KEYS ` property accordingly.

- A property that must be toggled is not an ideal design decision, but `json.dumps` accepts only a class to handle non-default types, not an object. So, it cannot be parameterized.
- The best solution to this would be to avoid using int keys :) JSON doesn't like them.