### PR TITLE
Fix Failing Terra Cron Jobs (Remove usage of `IBMQDeprecatedBackendService`)

### DIFF
--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -52,36 +52,36 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
 
     def test_remote_backends_exist_real_device(self):
         """Test if there are remote backends that are devices."""
-        remotes = self.provider.backends(simulator=False)
+        remotes = self.provider.backend.backends(simulator=False)
         self.assertTrue(remotes)
 
     def test_remote_backends_exist_simulator(self):
         """Test if there are remote backends that are simulators."""
-        remotes = self.provider.backends(simulator=True)
+        remotes = self.provider.backend.backends(simulator=True)
         self.assertTrue(remotes)
 
     def test_remote_backends_instantiate_simulators(self):
         """Test if remote backends that are simulators are an ``IBMQSimulator`` instance."""
-        remotes = self.provider.backends(simulator=True)
+        remotes = self.provider.backend.backends(simulator=True)
         for backend in remotes:
             with self.subTest(backend=backend):
                 self.assertIsInstance(backend, IBMQSimulator)
 
     def test_remote_backend_status(self):
         """Test backend_status."""
-        remotes = self.provider.backends()
+        remotes = self.provider.backend.backends()
         for backend in remotes:
             _ = backend.status()
 
     def test_remote_backend_configuration(self):
         """Test backend configuration."""
-        remotes = self.provider.backends()
+        remotes = self.provider.backend.backends()
         for backend in remotes:
             _ = backend.configuration()
 
     def test_remote_backend_properties(self):
         """Test backend properties."""
-        remotes = self.provider.backends(simulator=False)
+        remotes = self.provider.backend.backends(simulator=False)
         for backend in remotes:
             properties = backend.properties()
             if backend.configuration().simulator:
@@ -142,7 +142,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
 
     def test_remote_backend_properties_filter_date(self):
         """Test backend properties filtered by date."""
-        backends = self.provider.backends(simulator=False)
+        backends = self.provider.backend.backends(simulator=False)
 
         datetime_filter = datetime(2019, 2, 1).replace(tzinfo=None)
         for backend in backends:
@@ -156,8 +156,8 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
 
     def test_provider_backends(self):
         """Test provider_backends have correct attributes."""
-        provider_backends = {back for back in dir(self.provider.backends)
-                             if isinstance(getattr(self.provider.backends, back), IBMQBackend)}
+        provider_backends = {back for back in dir(self.provider.backend)
+                             if isinstance(getattr(self.provider.backend, back), IBMQBackend)}
         backends = {back.name().lower() for back in self.provider._backends.values()}
         self.assertEqual(provider_backends, backends)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The Terra [cron job tests](https://github.com/Qiskit/qiskit-ibmq-provider/runs/3238753756?check_suite_focus=true) are failing due to using the deprecated `IBMQDeprecatedBackendService` in the `TestAccountProvider` test suite. 

### Fixes #1040 

- Replaces usage of `provider.backends` property with `provider.backend`
- Replaces `provider.backends()` with `provider.backend.backends()` (not necessary, but for consistency)

### Testing

Running the test suite prior to this change, you will see:
```
DeprecationWarning: The `backends` provider attribute is deprecated. Please use `provider.backend` (singular) instead. You can continue to use `provider.backends()` to retrieve all backends.
```
Running this change, that message will not be there.