### PR TITLE
Fix IBMQJobManager job set retrieval 

### DIFF
--- a/qiskit/providers/ibmq/managed/utils.py
+++ b/qiskit/providers/ibmq/managed/utils.py
@@ -25,7 +25,7 @@ from .managedjob import ManagedJob
 JOB_SET_NAME_FORMATTER = "{}_{}_"
 """Formatter for the name of a job in a job set. The first entry is the job set
 name, whereas the second entry is the job's index in the job set."""
-JOB_SET_NAME_RE = re.compile(r'(.*)_([0-9])+_$')
+JOB_SET_NAME_RE = re.compile(r'(.*)_([0-9]+)_$')
 """Regex used to match the name of a job in a job set. The first captured group is
 the job set name, whereas the second captured group is the job's index in the job set."""
 

--- a/releasenotes/notes/fix-jm-re-5ccd3724f32fe1d3.yaml
+++ b/releasenotes/notes/fix-jm-re-5ccd3724f32fe1d3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the issue where
+    :meth:`qiskit.providers.ibmq.managed.IBMQJobManager.retrieve_job_set` only
+    retrieves the first 10 jobs in a :class:`qiskit.providers.ibmq.managed.ManagedJobSet`.

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -202,8 +202,9 @@ class TestIBMQJobManager(IBMQTestCase):
         """Test retrieving a set of jobs."""
         tags = ['test_retrieve_job_set']
 
-        circs_counts = [3, 4]
-        for count in circs_counts:
+        # circuit count, max expr
+        sub_tests = [(3, 2), (4, 2), (11, 1)]
+        for count, max_expr in sub_tests:
             with self.subTest(count=count):
                 circs = []
                 for i in range(count):
@@ -212,7 +213,7 @@ class TestIBMQJobManager(IBMQTestCase):
                     circs.append(new_qc)
 
                 job_set = self._jm.run(circs, backend=self.sim_backend,
-                                       max_experiments_per_job=2, job_tags=tags)
+                                       max_experiments_per_job=max_expr, job_tags=tags)
                 self.assertEqual(job_set.tags(), tags)
                 # Wait for jobs to be submitted.
                 while JobStatus.INITIALIZING in job_set.statuses():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Ported from Qiskit-Partners/qiskit-ibm#33, this fixes the issue where the regular expression used by Job Manager to find the correct job index was wrong and would only pick up the last digit.


### Details and comments


