### PR TITLE
Restore integer dictionary keys dumped by RuntimeEncoder

### DIFF
--- a/qiskit/providers/ibmq/runtime/utils.py
+++ b/qiskit/providers/ibmq/runtime/utils.py
@@ -14,26 +14,28 @@
 
 """Utility functions for the runtime service."""
 
-import json
-from typing import Any, Callable, Dict
 import base64
-import io
-import zlib
-import inspect
+import copy
 import importlib
+import inspect
+import io
+import json
 import warnings
+import zlib
+from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
+
 try:
     import scipy.sparse
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
 
-from qiskit.result import Result
-from qiskit.circuit import QuantumCircuit, qpy_serialization
-from qiskit.circuit import ParameterExpression, Instruction
+from qiskit.circuit import (Instruction, ParameterExpression, QuantumCircuit,
+                            qpy_serialization)
 from qiskit.circuit.library import BlueprintCircuit
+from qiskit.result import Result
 
 
 def _serialize_and_encode(
@@ -106,6 +108,50 @@ def deserialize_from_settings(mod_name: str, class_name: str, settings: Dict) ->
     raise ValueError(f"Unable to find class {class_name} in module {mod_name}")
 
 
+def _set_int_keys_flag(obj: Dict) -> Union[Dict, List]:
+    """Recursively sets '__int_keys__' flag if dictionary uses integer keys
+
+    Args:
+        obj: dictionary
+
+    Returns:
+        obj with the '__int_keys__' flag set if dictionary uses integer key
+    """
+    if isinstance(obj, dict):
+        for k, v in list(obj.items()):
+            if isinstance(k, int):
+                obj['__int_keys__'] = True
+            _set_int_keys_flag(v)
+    return obj
+
+
+def _cast_strings_keys_to_int(obj: Dict) -> Dict:
+    """Casts string to int keys in dictionary when '__int_keys__' flag is set
+
+    Args:
+        obj: dictionary
+
+    Returns:
+        obj with string keys cast to int keys and '__int_keys__' flags removed
+    """
+    if isinstance(obj, dict):
+        int_keys: List[int] = []
+        for k, v in list(obj.items()):
+            if '__int_keys__' in obj:
+                try:
+                    int_keys.append(int(k))
+                except ValueError:
+                    pass
+            _cast_strings_keys_to_int(v)
+        while len(int_keys) > 0:
+            key = int_keys.pop()
+            obj[key] = obj[str(key)]
+            obj.pop(str(key))
+        if '__int_keys__' in obj:
+            del obj['__int_keys__']
+    return obj
+
+
 class RuntimeEncoder(json.JSONEncoder):
     """JSON Encoder used by runtime service."""
 
@@ -145,7 +191,7 @@ class RuntimeEncoder(json.JSONEncoder):
             return {'__type__': 'settings',
                     '__module__': obj.__class__.__module__,
                     '__class__': obj.__class__.__name__,
-                    '__value__': obj.settings}
+                    '__value__': _set_int_keys_flag(copy.deepcopy(obj.settings))}
         if callable(obj):
             warnings.warn(f"Callable {obj} is not JSON serializable and will be set to None.")
             return None
@@ -185,7 +231,7 @@ class RuntimeDecoder(json.JSONDecoder):
                 return deserialize_from_settings(
                     mod_name=obj['__module__'],
                     class_name=obj['__class__'],
-                    settings=obj_val
+                    settings=_cast_strings_keys_to_int(obj_val)
                 )
             if obj_type == 'Result':
                 return Result.from_dict(obj_val)

--- a/releasenotes/notes/fix-restore-dict-int-keys-b0d49dc13a54c1dd.yaml
+++ b/releasenotes/notes/fix-restore-dict-int-keys-b0d49dc13a54c1dd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`qiskit.providers.ibmq.runtime.RuntimeDecoder` can now restore dictionary integer keys
+    in optimizer settings from a JSON string representation dumped by the
+    :class:`qiskit.providers.ibmq.runtime.RuntimeEncoder`.

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -31,6 +31,7 @@ from qiskit.algorithms.optimizers import (
     GSLS,
     IMFIL,
     SPSA,
+    QNSPSA,
     SNOBFIT,
     L_BFGS_B,
     NELDER_MEAD,
@@ -187,13 +188,14 @@ class TestRuntime(IBMQTestCase):
 
     @skipIf(os.name == 'nt', 'Test not supported on Windows')
     def test_coder_optimizers(self):
-        """Test runtime encoder and decoder for circuits."""
+        """Test runtime encoder and decoder for optimizers."""
         subtests = (
             (ADAM, {"maxiter": 100, "amsgrad": True}),
             (GSLS, {"maxiter": 50, "min_step_size": 0.01}),
             (IMFIL, {"maxiter": 20}),
             (SPSA, {"maxiter": 10, "learning_rate": 0.01, "perturbation": 0.1}),
             (SNOBFIT, {"maxiter": 200, "maxfail": 20}),
+            (QNSPSA, {"fidelity": 123, "maxiter": 25, "resamplings": {1: 100, 2: 50}}),
             # some SciPy optimizers only work with default arguments due to Qiskit/qiskit-terra#6682
             (L_BFGS_B, {}),
             (NELDER_MEAD, {}),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
By default json.dumps converts any integer dictionary keys to strings. json.loads, however, does not convert them back (since JSON doesn't really support integer keys). This PR adds support for restoring dictionary integer keys.

### Details and comments
Backported from https://github.com/Qiskit-Partners/qiskit-ibm/pull/50

