### PR TITLE
Fix ManagedJobSet.job() index by name

### DIFF
--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -396,7 +396,7 @@ class ManagedJobSet:
             if isinstance(experiment, (QuantumCircuit, Schedule)):
                 experiment = experiment.name
             for job in self.jobs():
-                for i, exp in enumerate(job.circuits()):
+                for i, exp in enumerate(job._qobj.experiments):
                     if hasattr(exp.header, 'name') and exp.header.name == experiment:
                         return job, i
 

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -396,7 +396,7 @@ class ManagedJobSet:
             if isinstance(experiment, (QuantumCircuit, Schedule)):
                 experiment = experiment.name
             for job in self.jobs():
-                for i, exp in enumerate(job._qobj.experiments):
+                for i, exp in enumerate(job._get_qobj().experiments):
                     if hasattr(exp.header, 'name') and exp.header.name == experiment:
                         return job, i
 

--- a/qiskit/providers/ibmq/managed/managedjobset.py
+++ b/qiskit/providers/ibmq/managed/managedjobset.py
@@ -396,8 +396,8 @@ class ManagedJobSet:
             if isinstance(experiment, (QuantumCircuit, Schedule)):
                 experiment = experiment.name
             for job in self.jobs():
-                for i, exp in enumerate(job._get_qobj().experiments):
-                    if hasattr(exp.header, 'name') and exp.header.name == experiment:
+                for i, exp in enumerate(job.circuits()):
+                    if hasattr(exp, 'name') and exp.name == experiment:
                         return job, i
 
         raise IBMQJobManagerJobNotFound(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When reviewing #1051 I somehow read both lines as `len(job.circuits())`... 

This PR fixes the [CI failure](https://github.com/Qiskit/qiskit-ibmq-provider/runs/3768113276) by using the correct attribute.

### Details and comments


