### PR TITLE
Fix test deserializing a QASM job result

### DIFF
--- a/test/ibmq/test_serialization.py
+++ b/test/ibmq/test_serialization.py
@@ -117,7 +117,10 @@ class TestSerialization(IBMQTestCase):
         """Test deserializing a QASM job result."""
         result = self.sim_backend.run(self.bell).result()
 
-        self._verify_data(result.to_dict(), ())
+        # Known keys that look like a serialized complex number.
+        good_keys = ('results.metadata.input_qubit_map', 'results.metadata.active_input_qubits')
+
+        self._verify_data(result.to_dict(), good_keys=good_keys)
 
     @slow_test
     def test_pulse_job_result(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add input_qubit_map and active_input_qubits to known good keys to fix test deserializing a QASM job result.

### Details and comments
Backported from https://github.com/Qiskit-Partners/qiskit-ibm/pull/127

