### PR TITLE
Add estimator to provider

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -337,19 +337,19 @@ class AccountProvider(Provider):
         """Estimate the expectation value.
 
         Args:
-            state: Quantum circuit that represents a quantum state.
+            state: A (parameterized) circuit that prepares a quantum state from the zero state.
 
             observable: The Hamiltonian to be evaluated.
 
-            parameters: The parameters to be bound.
+            parameters: The parameters to be bound in the circuit.
 
-            evaluator: The name of the evaluator class.
+            evaluator: The name of the evaluator class. Defaults to 'PauliExpectationValue'.
 
             backend: Backend to execute circuits on.
                 Transpiler options are automatically grabbed from backend configuration
                 and properties unless otherwise specified.
 
-            transpile_options: Additional transpiler options.
+            transpile_options: Additional transpiler options. If not specified, default Qiskit transpilation to the backend is used.
 
             shots: Number of repetitions of each circuit, for sampling. If not specified,
                 the backend default is used.

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -328,7 +328,7 @@ class AccountProvider(Provider):
             state: Union[QuantumCircuit, Statevector],
             observable: Union[BaseOperator, PauliSumOp, List[Tuple[str, float]]],
             parameters: Union[List[Union[float, List[float]]]] = None,
-            evaluator: Union[str] = None,
+            evaluator: Optional[str] = None,
             transpile_options: Optional[dict] = None,
             shots: Optional[int] = None,
             backend: Optional[Union[Backend, BaseBackend, str]] = None,

--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -327,11 +327,11 @@ class AccountProvider(Provider):
             self,
             state: Union[QuantumCircuit, Statevector],
             observable: Union[BaseOperator, PauliSumOp, List[Tuple[str, float]]],
-            parameters: Union[List[Union[float, List[float]]]] = None,
-            evaluator: Optional[str] = None,
+            parameters: Union[List[Union[float, List[float]]]],
+            backend: Union[Backend, BaseBackend, str],
+            evaluator: str = "PauliExpectationValue",
             transpile_options: Optional[dict] = None,
             shots: Optional[int] = None,
-            backend: Optional[Union[Backend, BaseBackend, str]] = None,
             **run_config: Dict
     ) -> 'runtime_job.RuntimeJob':
         """Estimate the expectation value.
@@ -343,13 +343,14 @@ class AccountProvider(Provider):
 
             parameters: The parameters to be bound in the circuit.
 
-            evaluator: The name of the evaluator class. Defaults to 'PauliExpectationValue'.
-
             backend: Backend to execute circuits on.
                 Transpiler options are automatically grabbed from backend configuration
                 and properties unless otherwise specified.
 
-            transpile_options: Additional transpiler options. If not specified, default Qiskit transpilation to the backend is used.
+            evaluator: The name of the evaluator class. Defaults to 'PauliExpectationValue'.
+
+            transpile_options: Additional transpiler options.
+                If not specified, default Qiskit transpilation to the backend is used.
 
             shots: Number of repetitions of each circuit, for sampling. If not specified,
                 the backend default is used.
@@ -359,20 +360,12 @@ class AccountProvider(Provider):
         Returns:
             Runtime job.
         """
-        if backend is None:
-            # We can't put a required parameter before an optional one, but it feels weird to
-            # have backend in between inputs to the estimator. So we make it optional and
-            # check here.
-            raise IBMQInputValueError('"backend" is a required parameter.')
-
         inputs = {
             "state": state,
             "observable": observable,
+            "parameters": parameters,
+            "evaluator": evaluator,
         }
-        if parameters:
-            inputs["parameters"] = parameters
-        if evaluator:
-            inputs["evaluator"] = evaluator
         if transpile_options:
             inputs["transpile_options"] = transpile_options
         run_options = copy.deepcopy(run_config)

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -38,7 +38,7 @@ from ...proxy_server import MockProxyServer, use_proxies
 from .utils import SerializableClass, SerializableClassDecoder, get_complex_types
 
 
-# @unittest.skipIf(not os.environ.get('USE_STAGING_CREDENTIALS', ''), "Only runs on staging")
+@unittest.skipIf(not os.environ.get('USE_STAGING_CREDENTIALS', ''), "Only runs on staging")
 class TestRuntimeIntegration(IBMQTestCase):
     """Integration tests for runtime modules."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a new method `estimate` to the provider that's similar to `run_circuits`. It calls the corresponding runtime program under the cover. 


### Details and comments


