### PR TITLE
Support updating program data

### DIFF
--- a/qiskit/providers/ibmq/api/clients/runtime.py
+++ b/qiskit/providers/ibmq/api/clients/runtime.py
@@ -49,7 +49,7 @@ class RuntimeClient:
 
     def program_create(
             self,
-            program_data: Union[bytes, str],
+            program_data: bytes,
             name: str,
             description: str,
             max_execution_time: int,
@@ -154,6 +154,15 @@ class RuntimeClient:
             program_id: Program ID.
         """
         self.api.program(program_id).delete()
+
+    def program_update(self, program_id: str, program_data: str) -> None:
+        """Update a program.
+
+        Args:
+            program_id: Program ID.
+            program_data: Program data.
+        """
+        self.api.program(program_id).update(program_data)
 
     def job_get(self, job_id: str) -> Dict:
         """Get job data.

--- a/qiskit/providers/ibmq/api/rest/runtime.py
+++ b/qiskit/providers/ibmq/api/rest/runtime.py
@@ -65,7 +65,7 @@ class Runtime(RestAdapterBase):
 
     def create_program(
             self,
-            program_data: Union[bytes, str],
+            program_data: bytes,
             name: str,
             description: str,
             max_execution_time: int,
@@ -110,13 +110,8 @@ class Runtime(RestAdapterBase):
         if interim_results:
             data['interimResults'] = json.dumps(interim_results)
 
-        if isinstance(program_data, str):
-            with open(program_data, 'rb') as file:
-                files = {'program': (name, file)}
-                response = self.session.post(url, data=data, files=files).json()
-        else:
-            files = {'program': (name, program_data)}  # type: ignore[dict-item]
-            response = self.session.post(url, data=data, files=files).json()
+        files = {'program': (name, program_data)}  # type: ignore[dict-item]
+        response = self.session.post(url, data=data, files=files).json()
         return response
 
     def program_run(
@@ -243,6 +238,16 @@ class Program(RestAdapterBase):
         """
         url = self.get_url('self')
         self.session.delete(url)
+
+    def update(self, program_data: str) -> None:
+        """Update a program.
+
+        Args:
+            program_data: Program data.
+        """
+        url = self.get_url("data")
+        self.session.put(url, data=program_data,
+                         headers={'Content-Type': 'text/plain'})
 
 
 class ProgramJob(RestAdapterBase):

--- a/releasenotes/notes/update_runtime_program-5b0dd855973da52b.yaml
+++ b/releasenotes/notes/update_runtime_program-5b0dd855973da52b.yaml
@@ -1,10 +1,10 @@
 ---
 features:
   - |
-    You can now use the :meth:`qiskit_ibm.runtime.IBMRuntimeService.update_program`
+    You can now use the :meth:`qiskit.providers.ibmq.runtime.IBMRuntimeService.update_program`
     method to update the data of an existing runtime program.
 upgrade:
   - |
-    The `data` parameter to :meth:`qiskit_ibm.runtime.IBMRuntimeService.upload_program`
+    The `data` parameter to :meth:`qiskit.providers.ibmq.runtime.IBMRuntimeService.upload_program`
     can now only be of type string. It can be either the program data,
     or path to the file that contains program data.

--- a/releasenotes/notes/update_runtime_program-5b0dd855973da52b.yaml
+++ b/releasenotes/notes/update_runtime_program-5b0dd855973da52b.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    You can now use the :meth:`qiskit_ibm.runtime.IBMRuntimeService.update_program`
+    method to update the data of an existing runtime program.
+upgrade:
+  - |
+    The `data` parameter to :meth:`qiskit_ibm.runtime.IBMRuntimeService.upload_program`
+    can now only be of type string. It can be either the program data,
+    or path to the file that contains program data.

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -342,7 +342,7 @@ if __name__ == '__main__':
     def test_program_params_validation(self):
         """Test program parameters validation process"""
         program_id = self.runtime.upload_program(
-            data="foo".encode(), metadata=self.DEFAULT_METADATA)
+            data="def main() {}", metadata=self.DEFAULT_METADATA)
         program = self.runtime.program(program_id)
         params: ParameterNamespace = program.parameters()
         params.param1 = 'Hello, World'
@@ -360,7 +360,7 @@ if __name__ == '__main__':
     def test_program_params_namespace(self):
         """Test running a program using parameter namespace."""
         program_id = self.runtime.upload_program(
-            data="foo".encode(), metadata=self.DEFAULT_METADATA)
+            data="def main() {}", metadata=self.DEFAULT_METADATA)
         params = self.runtime.program(program_id).parameters()
         params.param1 = "Hello World"
         self._run_program(program_id, inputs=params)
@@ -576,7 +576,7 @@ if __name__ == '__main__':
 
         for metadata in sub_tests:
             with self.subTest(metadata_type=type(metadata)):
-                program_id = self.runtime.upload_program(data="foo".encode(), metadata=metadata)
+                program_id = self.runtime.upload_program(data="def main() {}", metadata=metadata)
                 program = self.runtime.program(program_id)
                 self.runtime.delete_program(program_id)
                 self.assertEqual(self.DEFAULT_METADATA['name'], program.name)
@@ -600,7 +600,7 @@ if __name__ == '__main__':
         """Test combining metadata"""
         update_metadata = {"version": "1.2", "max_execution_time": 600}
         program_id = self.runtime.upload_program(
-            data="foo".encode(), metadata=self.DEFAULT_METADATA, **update_metadata)
+            data="def main() {}", metadata=self.DEFAULT_METADATA, **update_metadata)
         program = self.runtime.program(program_id)
         self.assertEqual(update_metadata['max_execution_time'], program.max_execution_time)
         self.assertEqual(update_metadata["version"], program.version)
@@ -623,7 +623,7 @@ if __name__ == '__main__':
         data = "def main() {}"
         program_id = self.runtime.upload_program(
             name=name,
-            data=data.encode(),
+            data=data,
             is_public=is_public,
             max_execution_time=max_execution_time,
             description="A test program")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR allows the owner to update runtime program data without having to delete it first.

### Details and comments
The program update endpoint expects the program data to be in plain text, even though the upload endpoint expects it to be in binary (I think the latter will be changed soon). As a result, the input data to update_program is of type string. This makes the upload_program quite confusing, since it treated data of type string as the program file path. To make the 2 match, this PR changes the signature of upload_program to only take data in string format, and inspect it to see if it's program data or file path.

Backported from https://github.com/Qiskit-Partners/qiskit-ibm/pull/141

