### PR TITLE
Nightly cron job on prod for runtime integration tests against simulator

### DIFF
--- a/.github/workflows/cron-prod.yml
+++ b/.github/workflows/cron-prod.yml
@@ -1,0 +1,28 @@
+name: Cron-prod
+on:
+  schedule:
+    - cron: '0 4 * * *'
+jobs:
+  runtime-integration:
+    name: runtime-integration
+    runs-on: macOS-latest
+    env:
+      QE_TOKEN: ${{ secrets.QE_TOKEN }}
+      QE_URL: ${{ secrets.QE_URL }}
+      QE_RUNTIME_DEVICE: ${{ secrets.QE_RUNTIME_DEVICE }}
+      LOG_LEVEL: DEBUG
+      STREAM_LOG: True
+      QISKIT_IN_PARALLEL: True
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -c constraints.txt -e .
+          pip install -U -c constraints.txt -r requirements-dev.txt
+      - name: Run Tests
+        run: make runtime_integration

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -37,7 +37,6 @@ from ...proxy_server import MockProxyServer, use_proxies
 from .utils import SerializableClass, SerializableClassDecoder, get_complex_types
 
 
-@unittest.skipIf(not os.environ.get('USE_STAGING_CREDENTIALS', ''), "Only runs on staging")
 class TestRuntimeIntegration(IBMQTestCase):
     """Integration tests for runtime modules."""
 
@@ -148,14 +147,11 @@ def main(backend, user_messenger, **kwargs):
     def test_upload_program(self):
         """Test uploading a program."""
         max_execution_time = 3000
-        is_public = True
-        program_id = self._upload_program(max_execution_time=max_execution_time,
-                                          is_public=is_public)
+        program_id = self._upload_program(max_execution_time=max_execution_time)
         self.assertTrue(program_id)
         program = self.provider.runtime.program(program_id)
         self.assertTrue(program)
         self.assertEqual(max_execution_time, program.max_execution_time)
-        self.assertEqual(program.is_public, is_public)
 
     def test_upload_program_file(self):
         """Test uploading a program using a file."""
@@ -169,6 +165,26 @@ def main(backend, user_messenger, **kwargs):
         program = self.provider.runtime.program(program_id)
         self.assertTrue(program)
 
+    @unittest.skipIf(
+        not os.environ.get('USE_STAGING_CREDENTIALS', ''),
+        "Only runs on staging"
+    )
+    def test_upload_public_program(self):
+        """Test uploading a public program."""
+        max_execution_time = 3000
+        is_public = True
+        program_id = self._upload_program(max_execution_time=max_execution_time,
+                                          is_public=is_public)
+        self.assertTrue(program_id)
+        program = self.provider.runtime.program(program_id)
+        self.assertTrue(program)
+        self.assertEqual(max_execution_time, program.max_execution_time)
+        self.assertEqual(program.is_public, is_public)
+
+    @unittest.skipIf(
+        not os.environ.get('USE_STAGING_CREDENTIALS', ''),
+        "Only runs on staging"
+    )
     def test_set_visibility(self):
         """Test setting the visibility of a program."""
         program_id = self._upload_program()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Nightly cron job on prod for runtime integration tests against simulator.
Skipped program visibility related test.
I've also set QE_RUNTIME_DEVICE and QE_STAGING_RUNTIME_DEVICE to ibmq_qasm_simulator.

I want to keep running these integration tests on staging as well for 3 reasons:

To be able to run tests on staging that we cannot run on prod
To keep an eye on changes to staging so we can open issues with ntc
Also be prepared for upcoming changes just like we do with terra master


### Details and comments
Backported from https://github.com/Qiskit-Partners/qiskit-ibm/pull/153

