### PR TITLE
`provider.run_circuits` now takes a backend_name instead of Backend object

### DIFF
--- a/qiskit/providers/ibmq/accountprovider.py
+++ b/qiskit/providers/ibmq/accountprovider.py
@@ -22,8 +22,6 @@ from qiskit.providers import ProviderV1 as Provider  # type: ignore[attr-defined
 from qiskit.providers.models import (QasmBackendConfiguration,
                                      PulseBackendConfiguration)
 from qiskit.circuit import QuantumCircuit
-from qiskit.providers.backend import BackendV1 as Backend
-from qiskit.providers.basebackend import BaseBackend
 from qiskit.transpiler import Layout
 from qiskit.providers.ibmq.runtime import runtime_job  # pylint: disable=unused-import
 from qiskit.providers.ibmq import ibmqfactory  # pylint: disable=unused-import
@@ -221,7 +219,7 @@ class AccountProvider(Provider):
     def run_circuits(
             self,
             circuits: Union[QuantumCircuit, List[QuantumCircuit]],
-            backend: Union[Backend, BaseBackend],
+            backend_name: str,
             shots: Optional[int] = None,
             initial_layout: Optional[Union[Layout, Dict, List]] = None,
             layout_method: Optional[str] = None,
@@ -245,7 +243,7 @@ class AccountProvider(Provider):
         Args:
             circuits: Circuit(s) to execute.
 
-            backend: Backend to execute circuits on.
+            backend_name: Name of the backend to execute circuits on.
                 Transpiler options are automatically grabbed from backend configuration
                 and properties unless otherwise specified.
 
@@ -316,7 +314,7 @@ class AccountProvider(Provider):
         if use_measure_esp is not None:
             inputs['use_measure_esp'] = use_measure_esp
 
-        options = {'backend_name': backend.name()}
+        options = {'backend_name': backend_name}
         return self.runtime.run('circuit-runner', options=options, inputs=inputs,
                                 result_decoder=RunnerResult)
 

--- a/releasenotes/notes/upgrade-run-circuits-backend-name-0dfce7eb558f224f.yaml
+++ b/releasenotes/notes/upgrade-run-circuits-backend-name-0dfce7eb558f224f.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    :meth:`qiskit.providers.ibmq.AccountProvider.run_circuits` method now takes a `backend_name`
+    parameter, which is a string, instead of `backend`, which is a ``Backend`` object.

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -560,9 +560,9 @@ def main(backend, user_messenger, **kwargs):
         _ = self._run_program()
 
     def test_run_circuit(self):
-        """Test run_circuit"""
+        """Test run_circuits"""
         job = self.provider.run_circuits(
-            ReferenceCircuits.bell(), backend=self.backend, shots=100)
+            ReferenceCircuits.bell(), backend_name=self.backend.name(), shots=100)
         counts = job.result().get_counts()
         self.assertEqual(100, sum(counts.values()))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`provider.run_circuits` now takes a backend_name instead of Backend object


### Details and comments
Backported from https://github.com/Qiskit-Partners/qiskit-ibm/pull/173

