### PR TITLE
Only print program summary in runtime `pprint_programs()`

### DIFF
--- a/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
+++ b/qiskit/providers/ibmq/runtime/ibm_runtime_service.py
@@ -107,17 +107,22 @@ class IBMRuntimeService:
         self._ws_url = provider.credentials.runtime_url.replace('https', 'wss')
         self._programs = {}  # type: Dict
 
-    def pprint_programs(self, refresh: bool = False) -> None:
+    def pprint_programs(self, refresh: bool = False, detailed: bool = False) -> None:
         """Pretty print information about available runtime programs.
 
         Args:
             refresh: If ``True``, re-query the server for the programs. Otherwise
                 return the cached value.
+            detailed: If ``True`` print all details about available runtime programs.
         """
         programs = self.programs(refresh)
         for prog in programs:
             print("="*50)
-            print(str(prog))
+            if detailed:
+                print(str(prog))
+            else:
+                print(f"Name: {prog.name}")
+                print(f"Description: {prog.description}")
 
     def programs(self, refresh: bool = False) -> List[RuntimeProgram]:
         """Return available runtime programs.

--- a/releasenotes/notes/runtime-pprint-programs-update-8d5d79aceeb49106.yaml
+++ b/releasenotes/notes/runtime-pprint-programs-update-8d5d79aceeb49106.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    By default, :meth:`qiskit.providers.ibmq.runtime.IBMRuntimeService.pprint_programs()`
+    now only prints the summary of each runtime program instead of all of the details.
+    There is a new parameter ``detailed`` that can be set to ``True`` to print all details.

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -286,6 +286,13 @@ if __name__ == '__main__':
             for prog in programs:
                 self.assertIn(prog.program_id, stdout)
                 self.assertIn(prog.name, stdout)
+                self.assertNotIn(prog.version, stdout)
+            self.runtime.pprint_programs(detailed=True)
+            stdout_detailed = mock_stdout.getvalue()
+            for prog in programs:
+                self.assertIn(prog.program_id, stdout_detailed)
+                self.assertIn(prog.name, stdout_detailed)
+                self.assertIn(prog.version, stdout_detailed)
 
     def test_upload_program(self):
         """Test uploading a program."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Only print program summary in runtime `pprint_programs()` and show all details when `detailed` parameter is set to `True`.


### Details and comments
Backported from https://github.com/Qiskit-Partners/qiskit-ibm/pull/120

