### PR TITLE
Fix websocket connection drop

### DIFF
--- a/qiskit/providers/ibmq/api/clients/base.py
+++ b/qiskit/providers/ibmq/api/clients/base.py
@@ -91,7 +91,6 @@ class BaseWebsocketClient(BaseClient, ABC):
         """
         logger.debug("Websocket connection established for job %s", self._job_id)
         self.connected = True
-        self._current_retry = 0
         if self._cancelled:
             # Immediately disconnect if pre-cancelled.
             self.disconnect(WebsocketClientCloseCode.CANCEL)

--- a/qiskit/providers/ibmq/api/clients/base.py
+++ b/qiskit/providers/ibmq/api/clients/base.py
@@ -91,6 +91,7 @@ class BaseWebsocketClient(BaseClient, ABC):
         """
         logger.debug("Websocket connection established for job %s", self._job_id)
         self.connected = True
+        self._current_retry = 0
         if self._cancelled:
             # Immediately disconnect if pre-cancelled.
             self.disconnect(WebsocketClientCloseCode.CANCEL)
@@ -175,7 +176,7 @@ class BaseWebsocketClient(BaseClient, ABC):
                 logger.debug('Starting new websocket connection: %s using proxy %s',
                              url, self._proxy_params)
                 self._reset_state()
-                self._ws.run_forever(**self._proxy_params)
+                self._ws.run_forever(ping_interval=60, ping_timeout=10, **self._proxy_params)
                 self.connected = False
 
                 logger.debug("Websocket run_forever finished.")

--- a/releasenotes/notes/fix-websocket-connection-drop-3892e313554e99df.yaml
+++ b/releasenotes/notes/fix-websocket-connection-drop-3892e313554e99df.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed issue where the websocket connection kept timing out when streaming results
+    for a runtime job due to inactivity when the job is in a pending state for a long time.

--- a/test/ibmq/runtime/test_runtime_integration.py
+++ b/test/ibmq/runtime/test_runtime_integration.py
@@ -489,8 +489,6 @@ def main(backend, user_messenger, **kwargs):
         callback_err = []
         iterations = 3
         job = self._run_program(iterations=iterations, interim_results=int_res)
-
-        self._wait_for_status(job, JobStatus.RUNNING)
         job.stream_results(result_callback)
         job.wait_for_final_state()
         self.assertEqual(iterations-1, final_it)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Reset retry counter after every successful connection, ping ws server every minute so connection doesn't drop every few mins.


### Details and comments
Fixes issue where ws connection maxes out after 5 retries.

```
runtime_job._start_websocket_client:WARNING:2021-11-17 02:26:59,893: An error occurred while streaming results from the server for job c6a64nurog3ddsr8gio0:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/qiskit/providers/ibmq/runtime/runtime_job.py", line 328, in _start_websocket_client
    self._ws_client.job_results()
  File "/opt/conda/lib/python3.8/site-packages/qiskit/providers/ibmq/api/clients/runtime_ws.py", line 74, in job_results
    self.stream(url=url, retries=max_retries, backoff_factor=backoff_factor)
  File "/opt/conda/lib/python3.8/site-packages/qiskit/providers/ibmq/api/clients/base.py", line 211, in stream
    raise WebsocketError(error_message)
qiskit.providers.ibmq.api.exceptions.WebsocketError: 'Max retries exceeded: Failed to establish a websocket connection. Error: Traceback (most recent call last):\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_app.py", line 369, in run_forever\n    dispatcher.read(self.sock.sock, read, check)\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_app.py", line 70, in read\n    if not read_callback():\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_app.py", line 335, in read\n    op_code, frame = self.sock.recv_data_frame(True)\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_core.py", line 396, in recv_data_frame\n    frame = self.recv_frame()\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_core.py", line 435, in recv_frame\n    return self.frame_buffer.recv_frame()\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_abnf.py", line 337, in recv_frame\n    self.recv_header()\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_abnf.py", line 293, in recv_header\n    header = self.recv_strict(2)\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_abnf.py", line 372, in recv_strict\n    bytes_ = self.recv(min(16384, shortage))\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_core.py", line 519, in _recv\n    return recv(self.sock, bufsize)\n  File "/opt/conda/lib/python3.8/site-packages/websocket/_socket.py", line 125, in recv\n    raise WebSocketConnectionClosedException(\nwebsocket._exceptions.WebSocketConnectionClosedException: Connection to remote host was lost.\n'
```
