### PR TITLE
Fix submit_job_bad_shots

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -145,7 +145,8 @@ def submit_job_bad_shots(backend: IBMQBackend) -> IBMQJob:
         Submitted job.
     """
     qobj = bell_in_qobj(backend=backend)
-    qobj.config.shots = 10000  # Modify the number of shots to be an invalid amount.
+    # Modify the number of shots to be an invalid amount.
+    qobj.config.shots = backend.configuration().max_shots + 10000
     job_to_fail = backend.run(qobj)
     return job_to_fail
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
A number of tests failed because they rely on `submit_job_bad_shots()` to create a failed job. `submit_job_bad_shots()`, however, used a hard coded 10000 shots. IBM Quantum devices can now support that many shots 😄 hence the jobs never failed. 

Closes https://github.com/Qiskit-Partners/qiskit-ibm/issues/208 and https://github.com/Qiskit-Partners/qiskit-ibm/issues/207 . 

Note that this PR is open in this repo instead of `qiskit-ibm` because a downstream user reported this issue, and I'd like to unblock them asap.


### Details and comments


