### PR TITLE
Remove extra decompose in RuntimeEncoder

### DIFF
--- a/qiskit/providers/ibmq/runtime/utils.py
+++ b/qiskit/providers/ibmq/runtime/utils.py
@@ -36,7 +36,6 @@ except ImportError:
 
 from qiskit.circuit import (Instruction, ParameterExpression, QuantumCircuit,
                             qpy_serialization)
-from qiskit.circuit.library import BlueprintCircuit
 from qiskit.result import Result
 
 

--- a/qiskit/providers/ibmq/runtime/utils.py
+++ b/qiskit/providers/ibmq/runtime/utils.py
@@ -184,9 +184,6 @@ class RuntimeEncoder(json.JSONEncoder):
         if hasattr(obj, 'to_json'):
             return {'__type__': 'to_json', '__value__': obj.to_json()}
         if isinstance(obj, QuantumCircuit):
-            # TODO Remove the decompose when terra 6713 is released.
-            if isinstance(obj, BlueprintCircuit):
-                obj = obj.decompose()
             value = _serialize_and_encode(
                 data=obj,
                 serializer=lambda buff, data: qpy_serialization.dump(data, buff)

--- a/releasenotes/notes/runtime-decompose-c6f719f99ae6f7c3.yaml
+++ b/releasenotes/notes/runtime-decompose-c6f719f99ae6f7c3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the issue wherein :class:`qiskit.providers.ibmq.runtime.RuntimeEncoder`
+    does an extra `decompose()` if the circuit being serialized is a ``BlueprintCircuit``.

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -143,7 +143,7 @@ class TestIBMQJobManager(IBMQTestCase):
         job_set.results()
         for i, qobj in enumerate(job_set.qobjs()):
             rjob = self.fake_api_provider.backend.retrieve_job(jobs[i].job_id())
-            self.maxDiff = None  # pylint: disable=invalid-name
+            self.maxDiff = None  # pylint: disable=attribute-defined-outside-init
             self.assertDictEqual(qobj.to_dict(), rjob.qobj().to_dict())
 
     def test_error_message(self):

--- a/test/ibmq/test_ibmq_jobmanager.py
+++ b/test/ibmq/test_ibmq_jobmanager.py
@@ -143,7 +143,7 @@ class TestIBMQJobManager(IBMQTestCase):
         job_set.results()
         for i, qobj in enumerate(job_set.qobjs()):
             rjob = self.fake_api_provider.backend.retrieve_job(jobs[i].job_id())
-            self.maxDiff = None  # pylint: disable=attribute-defined-outside-init
+            self.maxDiff = None  # pylint: disable=attribute-defined-outside-init,invalid-name
             self.assertDictEqual(qobj.to_dict(), rjob.qobj().to_dict())
 
     def test_error_message(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`RuntimeEncoder` does an extra `decompose()` if the circuit is a `BlueprintCircuit`, to address a QPY issue. The issue has since been merged and deployed, and this extra decompose is causing QAOA runtime program to fail. 

### Details and comments


