### PR TITLE
Remove usage of deprecated provider.backends property

### DIFF
--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -154,12 +154,12 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
                 else:
                     self.assertEqual(properties, None)
 
-    def test_provider_backends(self):
-        """Test provider_backends have correct attributes."""
-        provider_backends = {back for back in dir(self.provider.backends)
-                             if isinstance(getattr(self.provider.backends, back), IBMQBackend)}
+    def test_provider_backend(self):
+        """Test provider backend has correct attributes."""
+        backend_attributes = {back for back in dir(self.provider.backend)
+                             if isinstance(getattr(self.provider.backend, back), IBMQBackend)}
         backends = {back.name().lower() for back in self.provider._backends.values()}
-        self.assertEqual(provider_backends, backends)
+        self.assertEqual(backend_attributes, backends)
 
     def test_provider_services(self):
         """Test provider services."""

--- a/test/ibmq/test_ibmq_provider.py
+++ b/test/ibmq/test_ibmq_provider.py
@@ -157,7 +157,7 @@ class TestAccountProvider(IBMQTestCase, providers.ProviderTestCase):
     def test_provider_backend(self):
         """Test provider backend has correct attributes."""
         backend_attributes = {back for back in dir(self.provider.backend)
-                             if isinstance(getattr(self.provider.backend, back), IBMQBackend)}
+                              if isinstance(getattr(self.provider.backend, back), IBMQBackend)}
         backends = {back.name().lower() for back in self.provider._backends.values()}
         self.assertEqual(backend_attributes, backends)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove usage of deprecated provider.backends property

### Details and comments
Fixes https://github.com/Qiskit-Partners/qiskit-ibm/issues/218

