### PR TITLE
Test no longer supported proxy url format only when requests <= 2.26

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,7 @@ autosummary_generate = True
 
 autodoc_default_options = {
     'inherited-members': None,
+    'exclude-members': 'with_traceback'
 }
 
 

--- a/test/ibmq/test_proxies.py
+++ b/test/ibmq/test_proxies.py
@@ -15,6 +15,8 @@
 import urllib
 import subprocess
 
+from unittest import skipIf
+from requests import __version__ as requests_version
 from requests.exceptions import ProxyError
 
 from qiskit.providers.ibmq import IBMQFactory
@@ -139,8 +141,22 @@ class TestProxies(IBMQTestCase):
         test_urls = [
             'http://{}:{}'.format(ADDRESS, PORT),
             '//{}:{}'.format(ADDRESS, PORT),
-            'http:{}:{}'.format(ADDRESS, PORT),
             'http://user:123@{}:{}'.format(ADDRESS, PORT)
+        ]
+        for proxy_url in test_urls:
+            with self.subTest(proxy_url=proxy_url):
+                credentials = Credentials(
+                    qe_token, qe_url, proxies={'urls': {'https': proxy_url}})
+                version_finder = VersionClient(credentials.base_url,
+                                               **credentials.connection_parameters())
+                version_finder.version()
+
+    @skipIf(requests_version > '2.26', "Need requests <= 2.26")
+    @requires_qe_access
+    def test_proxy_urls_2(self, qe_token, qe_url):
+        """Test proxy urls only supported by requests <= 2.26"""
+        test_urls = [
+            'http:{}:{}'.format(ADDRESS, PORT)
         ]
         for proxy_url in test_urls:
             with self.subTest(proxy_url=proxy_url):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
requests 2.27 dropped support for proxy url format `'http:{}:{}'`. Hence running the test separately for this format only when requests is less than 2.27.


### Details and comments
Fixes https://github.com/Qiskit-Partners/qiskit-ibm/issues/226

