### PR TITLE
Fix test failures due to accessing deprecated backend.properties

### DIFF
--- a/test/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/ibmq/test_ibmq_qasm_simulator.py
@@ -124,7 +124,8 @@ class TestIbmqQasmSimulator(IBMQTestCase):
                              f"qobj header={qobj.header}")
             return mock.MagicMock()
 
-        backend = copy.deepcopy(self.sim_backend)
+        original_submit_job = copy.copy(self.sim_backend._submit_job)
+        backend = self.sim_backend
         backend._configuration._data['simulation_method'] = 'extended_stabilizer'
         backend._submit_job = _new_submit
 
@@ -133,6 +134,9 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         qobj = assemble(circ, backend=backend, header={'test': 'qobj'})
         backend.run(qobj)
 
+        backend._configuration._data.pop('simulation_method', None)
+        backend._submit_job = original_submit_job
+
     def test_new_sim_method_no_overwrite(self):
         """Test custom method option is not overwritten."""
         def _new_submit(qobj, *args, **kwargs):
@@ -140,7 +144,8 @@ class TestIbmqQasmSimulator(IBMQTestCase):
             self.assertEqual(qobj.config.method, 'my_method', f"qobj header={qobj.header}")
             return mock.MagicMock()
 
-        backend = copy.deepcopy(self.sim_backend)
+        original_submit_job = copy.copy(self.sim_backend._submit_job)
+        backend = self.sim_backend
         backend._configuration._data['simulation_method'] = 'extended_stabilizer'
         backend._submit_job = _new_submit
 
@@ -148,6 +153,9 @@ class TestIbmqQasmSimulator(IBMQTestCase):
         backend.run(circ, method='my_method', header={'test': 'circuits'})
         qobj = assemble(circ, backend=backend, method='my_method', header={'test': 'qobj'})
         backend.run(qobj)
+
+        backend._configuration._data.pop('simulation_method', None)
+        backend._submit_job = original_submit_job
 
     @requires_device
     def test_simulator_with_noise_model(self, backend):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Modify to shallow copy which seems to be enough for this test. deepcopy accesses deprecated backend.properties and makes the test fail due to deprecation warning.

### Details and comments
Temporary fix until we stop extending qiskit base test case.

