### PR TITLE
Remove qiskit-experiments from requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,5 +26,3 @@ qiskit-aer
 websockets>=8
 scikit-learn>=0.20.0
 scikit-quant;platform_system != 'Windows'
-# TODO: Use released qiskit-experiments when it's released
-git+https://github.com/Qiskit/qiskit-experiments.git ; python_version > '3.6'


### PR DESCRIPTION

### Summary

With PR #1111 there are no more imports of qiskit-experiments
so we can remove it from the requirements-dev file.

### Details and comments

n/a