### PR TITLE
Use orjson for qobj submission

### DIFF
--- a/releasenotes/notes/orjson-qobj-submission-a39e3f66e0fece0c.yaml
+++ b/releasenotes/notes/orjson-qobj-submission-a39e3f66e0fece0c.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    `orjson <https://github.com/ijl/orjson>`__ is now a dependency for
+    installing ``qiskit-ibmq-provider`` on x86_64 and arm64/aarch64 systems;
+    on other platforms its an optional dependency. Using orjson enables
+    significantly faster JSON serialization which improves the performance
+    of the provider.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ websocket-client>=1.0.1
 websockets>=10.0; python_version >= '3.7'
 websockets>=9.1; python_version < '3.7'
 dataclasses>=0.8; python_version < '3.7'
+orjson>=3.6 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ REQUIREMENTS = [
     "websocket-client>=1.0.1",
     "websockets>=10.0 ; python_version>='3.7'",
     "websockets>=9.1 ; python_version<'3.7'",
-    "dataclasses>=0.8 ; python_version<'3.7'"
+    "dataclasses>=0.8 ; python_version<'3.7'",
+    "orjson>=3.6 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64'",
 ]
 
 # Handle version.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the default JSON serialization library we use for
QOBJ submission to orjson. [1] orjson being written in Rust is
significantly faster than the json module in the standard library. In
practice it eliminates the serialization overhead of generating the JSON
payload from a QOBJ dictionary. However, because orjson is written in
rust and doesn't package precompiled wheels for all the platforms we
support in tiers 1 and 2 [2] we can't add a hard requirement as it would
require users on 32bit platforms to have a Rust compiler to install the
provider package. This commit adds it to the requirements list with
environment markers to limit it to supported hardware platforms and in
the code orjson is treated as an optional dependency. This way by
default users on supported platforms get the performance benefits of
using orjson.

### Details and comments

[1] https://github.com/ijl/orjson
[2] https://qiskit.org/documentation/getting_started.html#platform-support