### PR TITLE
Remove invalid type hint from least_busy method

### DIFF
--- a/qiskit/providers/ibmq/__init__.py
+++ b/qiskit/providers/ibmq/__init__.py
@@ -83,7 +83,7 @@ import logging
 from typing import List, Optional, Union
 from datetime import datetime, timedelta
 
-from qiskit.providers import BaseBackend, Backend  # type: ignore[attr-defined]
+from qiskit.providers import Backend  # type: ignore[attr-defined]
 
 from .ibmqfactory import IBMQFactory
 from .ibmqbackend import IBMQBackend
@@ -114,9 +114,9 @@ QISKIT_IBMQ_PROVIDER_LOG_FILE = 'QISKIT_IBMQ_PROVIDER_LOG_FILE'
 
 
 def least_busy(
-        backends: List[Union[Backend, BaseBackend]],
+        backends: List[Backend],
         reservation_lookahead: Optional[int] = 60
-) -> Union[Backend, BaseBackend]:
+) -> Backend:
     """Return the least busy backend from a list.
 
     Return the least busy available backend for those that


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes an invalid type hint from the least_busy method.
This method was incorrectly listing the BaseBackend class as a valid
input and output type from the method. This has not been a supported
type since #817. Additionally, the class has been deprecated in
qiskit-terra for ~1 year now and was recently removed from the main
development branch. The ibmq provider should not be importing using
this legacy type, especially for a type hint as it is not used
anywhere.

### Details and comments