### PR TITLE
Fixed type hint for parameter binds in IBMQBackend

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -240,8 +240,8 @@ class IBMQBackend(Backend):
                 Default: ``True``.
             parameter_binds: List of Parameter bindings over which the set of experiments will be
                 executed. Each list element (bind) should be of the form
-                {Parameter1: value1, Parameter2: value2, ...}. All binds will be
-                executed across all experiments; e.g., if parameter_binds is a
+                {Parameter1: [value1_1, value1_2, ...], Parameter2: [value2_1, value2_2, ...], ...}. 
+                All binds will be executed across all experiments; e.g., if parameter_binds is a
                 length-n list, and there are m experiments, a total of m x n
                 experiments will be run (one for each experiment/bind pair).
             use_measure_esp: Whether to use excited state promoted (ESP) readout for measurements

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2020.
+# (C) Copyright IBM 2017, 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -168,7 +168,7 @@ class IBMQBackend(Backend):
             rep_time: Optional[int] = None,
             rep_delay: Optional[float] = None,
             init_qubits: Optional[bool] = None,
-            parameter_binds: Optional[List[Dict[Parameter, float]]] = None,
+            parameter_binds: Optional[List[Dict[Parameter, List[float]]]] = None,
             use_measure_esp: Optional[bool] = None,
             live_data_enabled: Optional[bool] = None,
             **run_config: Dict


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The type hint for the `parameter_binds` argument in `IBMQBackend.run()` was wrong. The values of each dictionary should be an array of floats, as shown in the example below.


### Details and comments
The issue was discovered by running the following code.
``` python
import numpy as np
from qiskit import Aer
from qiskit.circuit.library import EfficientSU2

backend = Aer.get_backend('qasm_simulator')
circ = EfficientSU2(num_qubits=2, reps=1).decompose()
circ.measure_all()

values = np.random.random(circ.num_parameters)
values_dict = {param : values[i] for i, param in enumerate(circ.parameters)}
backend.run(circuits=[circ], parameter_binds=[values_dict])
```
This raises the error
```
Simulation failed and returned the following error message:
ERROR: Failed to load qobj: [json.exception.type_error.302] type must be array, but is number

<qiskit.providers.aer.jobs.aerjob.AerJob at 0x7f7bf011df10>
```

If one changes the definition of `values_dict` to
``` python
values_dict = {param : [values[i]] for i, param in enumerate(circ.parameters)}
```
the code runs as expected. Therefore I suggest changing the type hint.

