### PR TITLE
Replace deprecated threading aliases

### DIFF
--- a/qiskit/providers/ibmq/jupyter/dashboard/backend_update.py
+++ b/qiskit/providers/ibmq/jupyter/dashboard/backend_update.py
@@ -30,7 +30,7 @@ def update_backend_info(device_list: wid.VBox,
         device_list: Widget showing the devices.
         interval: How often to refresh the backend information.
     """
-    my_thread = threading.currentThread()
+    my_thread = threading.current_thread()
     current_interval = 0
     started = False
     reservation_interval = 10*60

--- a/qiskit/providers/ibmq/utils/utils.py
+++ b/qiskit/providers/ibmq/utils/utils.py
@@ -245,4 +245,4 @@ class RefreshQueue(Queue):
     def notify_all(self) -> None:
         """Wake up all threads waiting for items on the queued."""
         with self.condition:
-            self.condition.notifyAll()
+            self.condition.notify_all()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Replace deprecated threading aliases.

### Details and comments


`threading.currentThread` and `notifyAll` were deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.current_thread`, `notify_all` added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174


