### PR TITLE
ImportError: cannot import name 'iplot_error_map'

### DIFF
--- a/qiskit/providers/ibmq/visualization/__init__.py
+++ b/qiskit/providers/ibmq/visualization/__init__.py
@@ -33,4 +33,4 @@ Interactive Visualizations
    iplot_error_map
 """
 
-from .interactive import iplot_error_map, iplot_gate_map
+from .interactive import error_map, gate_map


### PR DESCRIPTION
from .interactive import iplot_error_map, iplot_gate_map --> from .interactive import error_map, gate_map
~\lib\site-packages\qiskit\providers\ibmq\visualization\__init__.py in <module>
36 from .interactive import iplot_error_map, iplot_gate_map
ImportError: cannot import name 'iplot_error_map' from 'qiskit.providers.ibmq.visualization.interactive' (~\lib\site-packages\qiskit\providers\ibmq\visualization\interactive\__init__.py)

But it was also used in 2 more files (1. providers\ibmq\jupyter\config_widget.py 
2. providers\ibmq\jupyter\dashboard\backend_widget.py)
(Either a general edit will be made or the names of 2 files will be changed.)

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


