### PR TITLE
Update __init__.py

### DIFF
--- a/qiskit/providers/ibmq/visualization/__init__.py
+++ b/qiskit/providers/ibmq/visualization/__init__.py
@@ -33,4 +33,5 @@ Interactive Visualizations
    iplot_error_map
 """
 
-from .interactive import iplot_error_map, iplot_gate_map
+from .interactive.error_map import iplot_error_map
+from .interactive.gate_map import iplot_gate_map


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes the following import issue related to importing iplot_error_map / iplot_gate_map from qiskit.providers.ibmq.visualization.interactive.error_map / gate_map. 

### Details and comments

Related to pull request #1134, which doesn't import the specific functions desired by the original code. 

<h3>Version Information</h3>

Qiskit Software | Version
-- | --
qiskit-terra | 0.21.0
qiskit-aer | 0.10.4
qiskit-ibmq-provider | 0.19.2
qiskit | 0.37.0
qiskit-nature | 0.4.1
qiskit-finance | 0.3.3
qiskit-optimization | 0.4.0
qiskit-machine-learning | 0.4.0



Error output: 

---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 from qiskit.providers.ibmq.visualization.interactive.error_map import iplot_error_map

File ~/.local/lib/python3.10/site-packages/qiskit/providers/ibmq/visualization/__init__.py:36, in <module>
      1 # This code is part of Qiskit.
      2 #
      3 # (C) Copyright IBM 2018, 2020.
   (...)
     10 # copyright notice, and modified files need to carry a notice indicating
     11 # that they have been altered from the originals.
     13 """
     14 ===========================================================
     15 Visualizations (:mod:`qiskit.providers.ibmq.visualization`)
   (...)
     33    iplot_error_map
     34 """
---> 36 from .interactive import iplot_error_map, iplot_gate_map

ImportError: cannot import name 'iplot_error_map' from 'qiskit.providers.ibmq.visualization.interactive' (/home/user/.local/lib/python3.10/site-packages/qiskit/providers/ibmq/visualization/interactive/__init__.py)
