### PR TITLE
Add an error for dynamic circuit usage

### DIFF
--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -289,6 +289,14 @@ class IBMQBackend(Backend):
                 "'use_measure_esp' is unset or set to 'False'."
             )
 
+        if run_config.get("dynamic", None):
+            raise IBMQBackendValueError(
+                "The IBMQ provider is being deprecated and does not support dynamic circuits. "
+                "Please use the qiskit-ibm-provider instead. "
+                "See the documentation for more information on usage - "
+                "https://qiskit.org/documentation/partners/qiskit_ibm_provider/#qiskit-ibm-quantum-provider-documentation. "
+            )
+
         if not self.configuration().simulator:
             self._deprecate_id_instruction(circuits)
 
@@ -910,6 +918,7 @@ class IBMQSimulator(IBMQBackend):
             except AttributeError:
                 pass
         run_config.update(kwargs)
+
         return super().run(circuits, job_name=job_name,
                            job_tags=job_tags, experiment_id=experiment_id,
                            noise_model=noise_model, **run_config)

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -289,7 +289,7 @@ class IBMQBackend(Backend):
                 "'use_measure_esp' is unset or set to 'False'."
             )
 
-        if run_config.get("dynamic", None):
+        if run_config.get("dynamic", None) is not None:
             raise IBMQBackendValueError(
                 "The IBMQ provider is being deprecated and does not support dynamic circuits. "
                 "Please use the qiskit-ibm-provider instead. "

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -294,7 +294,7 @@ class IBMQBackend(Backend):
                 "The IBMQ provider is being deprecated and does not support dynamic circuits. "
                 "Please use the qiskit-ibm-provider instead. "
                 "See the documentation for more information on usage - "
-                "https://qiskit.org/documentation/partners/qiskit_ibm_provider/#qiskit-ibm-quantum-provider-documentation. "
+                "https://qiskit.org/documentation/partners/qiskit_ibm_provider/#qiskit-ibm-quantum-provider-documentation. " # noqa: E501
             )
 
         if not self.configuration().simulator:

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -294,7 +294,7 @@ class IBMQBackend(Backend):
                 "The IBMQ provider is being deprecated and does not support dynamic circuits. "
                 "Please use the qiskit-ibm-provider instead. "
                 "See the documentation for more information on usage - "
-                "https://qiskit.org/documentation/partners/qiskit_ibm_provider/#qiskit-ibm-quantum-provider-documentation. " # noqa: E501
+                "https://qiskit.org/documentation/partners/qiskit_ibm_provider/. "
             )
 
         if not self.configuration().simulator:

--- a/releasenotes/notes/add-dynamic-circuits-warning-7e17eac231aed88d.yaml
+++ b/releasenotes/notes/add-dynamic-circuits-warning-7e17eac231aed88d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Calls to run a quantum circuit with ``dynamic=True`` now raise an error
+    that asks the user to install the new ``qiskit-ibm-provider``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds an error if a user tries to use `dynamic=True` with the old provider


### Details and comments


