### PR TITLE
Deprecation warning in the documentation pages

### DIFF
--- a/docs/apidocs/ibmq-provider.rst
+++ b/docs/apidocs/ibmq-provider.rst
@@ -2,10 +2,6 @@
 Qiskit IBM Quantum Provider API Reference
 *****************************************
 
-.. warning::
-    The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be archived soon.
-    Please transition to the new packages. More information in https://ibm.biz/provider_migration_guide
-
 .. toctree::
    :maxdepth: 1
 

--- a/docs/apidocs/ibmq-provider.rst
+++ b/docs/apidocs/ibmq-provider.rst
@@ -2,6 +2,10 @@
 Qiskit IBM Quantum Provider API Reference
 *****************************************
 
+.. warning::
+    The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be archived soon.
+    Please transition to the new packages. More information in https://ibm.biz/provider_migration_guide
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,4 +150,9 @@ html_theme_options = {
     'style_nav_header_background': '#212121',
 }
 
+rst_prolog = """.. warning::
+   The package ``qiskit-ibmq-provider`` is being deprecated and its repo is going to be archived soon.
+   Please transition to the new packages. More information in https://ibm.biz/provider_migration_guide
+"""
+
 autoclass_content = 'both'


### PR DESCRIPTION
In order to warn documentation readers about the package deprecation, this PR add a warning note in all pages.

Fixes #1155 