### PR TITLE
Revert "fix python requirement versions (#1159)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-qiskit-terra~=0.23.0
-requests~=2.28.0
-requests_ntlm~=1.1.0
+qiskit-terra>=0.18.0
+requests>=2.19
+requests_ntlm>=1.1.0
 numpy<1.24
-urllib3~=1.26.0
-python-dateutil~=2.8.0
-websocket-client~=1.5.1
-websockets~=10.0; python_version >= '3.7'
-websockets~=9.1; python_version < '3.7'
-dataclasses~=0.8; python_version < '3.7'
+urllib3>=1.21.1
+python-dateutil>=2.8.0
+websocket-client<=1.3.3
+websockets>=10.0; python_version >= '3.7'
+websockets>=9.1; python_version < '3.7'
+dataclasses>=0.8; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 qiskit-terra>=0.18.0
 requests>=2.19
-requests_ntlm>=1.1.0
+requests_ntlm<=1.1.0
 numpy<1.24
 urllib3>=1.21.1
 python-dateutil>=2.8.0
-websocket-client<=1.3.3
+websocket-client>=1.5.1
 websockets>=10.0; python_version >= '3.7'
 websockets>=9.1; python_version < '3.7'
 dataclasses>=0.8; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,16 @@ import os
 from setuptools import setup
 
 REQUIREMENTS = [
-    "qiskit-terra~=0.23.0",
-    "requests~=2.28.0",
-    "requests-ntlm~=1.1.0",
+    "qiskit-terra>=0.18.0",
+    "requests>=2.19",
+    "requests-ntlm>=1.1.0",
     "numpy<1.24",
-    "urllib3~=1.26.0",
-    "python-dateutil~=2.8.0",
-    "websocket-client~=1.5.1",
-    "websockets~=10.0 ; python_version>='3.7'",
-    "websockets~=9.1 ; python_version<'3.7'",
-    "dataclasses~=0.8 ; python_version<'3.7'"
+    "urllib3>=1.21.1",
+    "python-dateutil>=2.8.0",
+    "websocket-client<=1.3.3",
+    "websockets>=10.0 ; python_version>='3.7'",
+    "websockets>=9.1 ; python_version<'3.7'",
+    "dataclasses>=0.8 ; python_version<'3.7'"
 ]
 
 # Handle version.

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ from setuptools import setup
 REQUIREMENTS = [
     "qiskit-terra>=0.18.0",
     "requests>=2.19",
-    "requests-ntlm>=1.1.0",
+    "requests-ntlm<=1.1.0",
     "numpy<1.24",
     "urllib3>=1.21.1",
     "python-dateutil>=2.8.0",
-    "websocket-client<=1.3.3",
+    "websocket-client>=1.5.1",
     "websockets>=10.0 ; python_version>='3.7'",
     "websockets>=9.1 ; python_version<'3.7'",
     "dataclasses>=0.8 ; python_version<'3.7'"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This reverts commit 2ad2352fbba0962f33017339965e93c86e3b84b3. The changes made to the requirements list in that commit were not valid and actively prevent users from installing the qiskit-ibmq-provider with any version of qiskit-terra other than the 0.23.x release series. Similarly the caps set on every dependency are overly restrictive and will cause compatibility issues with other packages, especially if there are shared dependencies between multiple packages. This commit reverts these changes to prevent issues and this needs to be released as part as 0.20.2 to unblock a future qiskit metapackage release.

### Details and comments