### PR TITLE
Remove scikit-quant test usage and unpin numpy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,4 +27,3 @@ qiskit_rng
 qiskit-aer
 websockets>=8
 scikit-learn>=0.20.0
-scikit-quant;platform_system != 'Windows'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit-terra>=0.18.0
 requests>=2.19
 requests_ntlm<=1.1.0
-numpy<1.24
+numpy>=1.13
 urllib3>=1.21.1
 python-dateutil>=2.8.0
 websocket-client>=1.5.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = [
     "qiskit-terra>=0.18.0",
     "requests>=2.19",
     "requests-ntlm<=1.1.0",
-    "numpy<1.24",
+    "numpy>=1.13",
     "urllib3>=1.21.1",
     "python-dateutil>=2.8.0",
     "websocket-client>=1.5.1",

--- a/test/ibmq/runtime/test_runtime.py
+++ b/test/ibmq/runtime/test_runtime.py
@@ -17,7 +17,7 @@ import json
 import os
 from io import StringIO
 from unittest.mock import patch
-from unittest import mock, skipIf
+from unittest import mock
 import uuid
 import time
 import random
@@ -30,10 +30,8 @@ import scipy.sparse
 from qiskit.algorithms.optimizers import (
     ADAM,
     GSLS,
-    IMFIL,
     SPSA,
     QNSPSA,
-    SNOBFIT,
     L_BFGS_B,
     NELDER_MEAD,
 )
@@ -217,19 +215,19 @@ class TestRuntime(IBMQTestCase):
                 decoded = json.loads(encoded, cls=RuntimeDecoder)
                 self.assertEqual(op, decoded)
 
-    @skipIf(os.name == 'nt', 'Test not supported on Windows')
     def test_coder_optimizers(self):
         """Test runtime encoder and decoder for optimizers."""
         subtests = (
             (ADAM, {"maxiter": 100, "amsgrad": True}),
             (GSLS, {"maxiter": 50, "min_step_size": 0.01}),
-            (IMFIL, {"maxiter": 20}),
             (SPSA, {"maxiter": 10, "learning_rate": 0.01, "perturbation": 0.1}),
-            (SNOBFIT, {"maxiter": 200, "maxfail": 20}),
             (QNSPSA, {"fidelity": 123, "maxiter": 25, "resamplings": {1: 100, 2: 50}}),
             # some SciPy optimizers only work with default arguments due to Qiskit/qiskit-terra#6682
             (L_BFGS_B, {}),
             (NELDER_MEAD, {}),
+            # Enable when https://github.com/scikit-quant/scikit-quant/issues/24 is fixed
+            # (IMFIL, {"maxiter": 20}),
+            # (SNOBFIT, {"maxiter": 200, "maxfail": 20}),
         )
         for opt_cls, settings in subtests:
             with self.subTest(opt_cls=opt_cls):


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The numpy requirement was pinned to avoid a CI issue caused by an incompatibility with the scikit-quant package (see: https://github.com/scikit-quant/scikit-quant/issues/24). However, the requirements.txt file has wider reach than just the test environment and it is actively causing conflicts with projects using numpy and qiskit-ibmq-provider as dependencies. The normal path to fix this is to pin the numpy version in the environments that are using both scikit-quant and numpy. Since the testing with scikit-quant isn't critical instead of pinning numpy in CI environments this commit opts to just remove the scikit-quant usage instead.

See Qiskit/qiskit-ibm-runtime#845 for a similar change made there.

### Details and comments


